### PR TITLE
Avoid warning about unused variable padmax_idx.

### DIFF
--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -795,6 +795,8 @@ void MiniballEventBuilder::ParticleFinder() {
 				}
 
 			} // k: all pad events
+
+			(void) padmax_idx; // Avoid unused warning.
 			
 
 			// Plot multiplcities


### PR DESCRIPTION
Or the variable c/should be removed?