### PR TITLE
Angle fit merged in to main code with automatic peak fitting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ OBJECTS =  		$(SRC_DIR)/Calibration.o \
 				$(SRC_DIR)/MbsConverter.o \
 				$(SRC_DIR)/MbsFormat.o \
 				$(SRC_DIR)/MidasConverter.o \
+				$(SRC_DIR)/MiniballAngleFitter.o \
 				$(SRC_DIR)/MiniballEvts.o \
 				$(SRC_DIR)/MiniballGeometry.o \
 				$(SRC_DIR)/Reaction.o \
@@ -81,6 +82,7 @@ DEPENDENCIES =  $(INC_DIR)/Calibration.hh \
 				$(INC_DIR)/MbsConverter.hh \
 				$(INC_DIR)/MbsFormat.hh \
 				$(INC_DIR)/MidasConverter.hh \
+				$(INC_DIR)/MiniballAngleFitter.hh \
 				$(INC_DIR)/MiniballEvts.hh \
 				$(INC_DIR)/MiniballGeometry.hh \
 				$(INC_DIR)/Reaction.hh \

--- a/include/Converter.hh
+++ b/include/Converter.hh
@@ -139,7 +139,8 @@ protected:
 	bool mbs_data;
 	
 	// Flag to signify this buffer or the one before is full
-	bool buffer_full;
+	bool buffer_full = false;
+	bool buffer_part = false;
 	
 	// Maximum size of the ADC value
 	unsigned long long qmax_default;

--- a/include/MiniballAngleFitter.hh
+++ b/include/MiniballAngleFitter.hh
@@ -1,0 +1,159 @@
+#ifndef __MINIBALLANGLEFITTER_HH
+#define __MINIBALLANGLEFITTER_HH
+
+// C++ includes
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <sstream>
+#include <vector>
+
+// ROOT includes
+#include "TFile.h"
+#include "TMath.h"
+#include "TCanvas.h"
+#include "TGraph.h"
+#include "TMultiGraph.h"
+#include "TGraphErrors.h"
+#include "TF1.h"
+#include "TH1.h"
+#include "TLegend.h"
+#include "Math/Functor.h"
+#include "Math/Factory.h"
+#include "Math/Minimizer.h"
+#include "Math/MinimizerOptions.h"
+
+// Settings header
+#ifndef __SETTINGS_HH
+# include "Settings.hh"
+#endif
+
+// Reaction header
+#ifndef __REACTION_HH
+# include "Reaction.hh"
+#endif
+
+
+class MiniballAngleFunction {
+
+public:
+	
+	// ctors and dtors
+	MiniballAngleFunction();
+	~MiniballAngleFunction(){};
+	MiniballAngleFunction( std::shared_ptr<MiniballSettings> _myset, std::shared_ptr<MiniballReaction> _myreact );
+
+	// Initial setup, called from constructors
+	void Initialise();
+		
+	// Fit the segment spectra to get the energies
+	void FitPeak( TH1D *h, double &en, double &er );
+	void FitSegmentEnergies( std::shared_ptr<TFile> infile );
+
+	// Load energies
+	void LoadExpEnergies( std::string energy_file );
+	
+	// Check if segment is present
+	inline bool IsPresent( unsigned int clu ){
+		return cluster[clu];
+	};
+	inline bool IsPresent( unsigned int clu, unsigned int cry, unsigned int seg ){
+		return present[clu][cry][seg];
+	};
+
+	// Setter and getter for reference energy
+	inline void SetReferenceEnergy( double e ){ eref = e; };
+	inline double GetReferenceEnergy(){ return eref; };
+	
+	// Getters for the experimental energies
+	inline double GetExpEnergy( unsigned int clu, unsigned int cry, unsigned int seg ){
+		return energy[clu][cry][seg];
+	};
+	inline double GetExpError( unsigned int clu, unsigned int cry, unsigned int seg ){
+		return err[clu][cry][seg];
+	};
+
+	// operator for the fit function
+	double operator() ( const double *p );
+
+private:
+	
+	// Vectors for data, etc
+	std::vector<std::vector<std::vector<bool>>> present;
+	std::vector<std::vector<std::vector<double>>> energy;
+	std::vector<std::vector<std::vector<double>>> err;
+	std::vector<bool> cluster;
+	
+	// Settings files, etc
+	std::shared_ptr<MiniballSettings> myset;
+	std::shared_ptr<MiniballReaction> myreact;
+	
+	double user_z = 0;
+	double eref = 440.2;
+
+};
+
+class MiniballAngleFitter {
+
+public:
+	
+	// ctors and dtors
+	MiniballAngleFitter();
+	~MiniballAngleFitter(){};
+	MiniballAngleFitter( std::string settings_file, std::string reaction_file );
+	MiniballAngleFitter( std::shared_ptr<MiniballSettings> _myset, std::shared_ptr<MiniballReaction> _myreact );
+	
+	// Initialise at the start, called from ctors
+	void Initialise();
+	
+	// Call the actual fitting
+	void DoFit();
+	
+	// Write the results to a reaction file
+	void SaveReactionFile( std::string fname );
+	
+	// Set the input ROOT file
+	bool SetInputROOTFile( std::string fname );
+	
+	// Set the input data file with energies
+	bool SetInputEnergiesFile( std::string fname );
+	
+	// Set the output directory
+	inline void SetOutputDirectory( std::string dir ){
+		datadir = dir;
+	};
+
+private:
+
+	// Settings files, etc
+	std::shared_ptr<MiniballSettings> myset;
+	std::shared_ptr<MiniballReaction> myreact;
+	
+	// Input ROOT file
+	std::shared_ptr<TFile> input_root_file;
+	
+	// Input data file
+	std::string input_data_filename;
+	
+	// This is the main fit function
+	MiniballAngleFunction ff;
+	
+	// Output directory
+	std::string datadir;
+	
+	// Flag if we need to fit the peaks ourselves, or they are given
+	bool flag_fit_peaks = false;
+	
+	// Paramaters and limits
+	unsigned npars = 1;
+	std::vector<double> pars;
+	std::vector<std::string> names;
+	std::vector<double> LL;
+	std::vector<double> UL;
+
+
+};
+
+
+#endif
+

--- a/include/MiniballAngleFitter.hh
+++ b/include/MiniballAngleFitter.hh
@@ -17,6 +17,7 @@
 #include "TGraphErrors.h"
 #include "TF1.h"
 #include "TH1.h"
+#include "TH2.h"
 #include "TLegend.h"
 #include "Math/Functor.h"
 #include "Math/Factory.h"
@@ -39,7 +40,7 @@ class MiniballAngleFunction {
 public:
 	
 	// ctors and dtors
-	MiniballAngleFunction();
+	MiniballAngleFunction(){};
 	~MiniballAngleFunction(){};
 	MiniballAngleFunction( std::shared_ptr<MiniballSettings> _myset, std::shared_ptr<MiniballReaction> _myreact );
 
@@ -47,7 +48,7 @@ public:
 	void Initialise();
 		
 	// Fit the segment spectra to get the energies
-	void FitPeak( TH1D *h, double &en, double &er );
+	bool FitPeak( TH1D *h, double &en, double &er );
 	void FitSegmentEnergies( std::shared_ptr<TFile> infile );
 
 	// Load energies
@@ -150,7 +151,6 @@ private:
 	std::vector<std::string> names;
 	std::vector<double> LL;
 	std::vector<double> UL;
-
 
 };
 

--- a/include/MiniballAngleFitter.hh
+++ b/include/MiniballAngleFitter.hh
@@ -51,8 +51,9 @@ public:
 	bool FitPeak( TH1D *h, double &en, double &er );
 	void FitSegmentEnergies( TFile *infile );
 
-	// Load energies
+	// Load/save energies
 	void LoadExpEnergies( std::string energy_file );
+	void SaveExpEnergies( std::string energy_file );
 	
 	// Check if segment is present
 	inline bool IsPresent( unsigned int clu ){
@@ -112,6 +113,11 @@ public:
 	
 	// Write the results to a reaction file
 	void SaveReactionFile( std::string fname );
+	
+	// Save experimental energies
+	inline void SaveExpEnergies( std::string energy_file ){
+		ff.SaveExpEnergies( energy_file );
+	};
 	
 	// Set the input ROOT file
 	bool SetInputROOTFile( std::string fname );

--- a/include/MiniballAngleFitter.hh
+++ b/include/MiniballAngleFitter.hh
@@ -49,7 +49,7 @@ public:
 		
 	// Fit the segment spectra to get the energies
 	bool FitPeak( TH1D *h, double &en, double &er );
-	void FitSegmentEnergies( std::shared_ptr<TFile> infile );
+	void FitSegmentEnergies( TFile *infile );
 
 	// Load energies
 	void LoadExpEnergies( std::string energy_file );
@@ -115,6 +115,9 @@ public:
 	
 	// Set the input ROOT file
 	bool SetInputROOTFile( std::string fname );
+	inline void CloseROOTFile(){
+		if( input_root_file != nullptr ) input_root_file->Close();
+	};
 	
 	// Set the input data file with energies
 	bool SetInputEnergiesFile( std::string fname );
@@ -131,7 +134,7 @@ private:
 	std::shared_ptr<MiniballReaction> myreact;
 	
 	// Input ROOT file
-	std::shared_ptr<TFile> input_root_file;
+	TFile *input_root_file = nullptr;
 	
 	// Input data file
 	std::string input_data_filename;

--- a/include/MiniballGeometry.hh
+++ b/include/MiniballGeometry.hh
@@ -64,6 +64,12 @@ public:
 	/// \param user_z distance from target to origin in beam direction [mm]
 	inline void SetCluZ( double user_z ) { z = user_z; };
 	
+	/// Getters for the various setters
+	inline double GetCluTheta(){ return theta; };
+	inline double GetCluPhi(){ return phi; };
+	inline double GetCluAlpha(){ return alpha; };
+	inline double GetCluR(){ return r; };
+
 	/// Get the theta angle of the crystal with respect to the beam
 	/// \param cry number of the MB Ge crystal counting from 0 to 2
 	/// \return theta of cry in beam reference (radians)

--- a/include/Reaction.hh
+++ b/include/Reaction.hh
@@ -153,6 +153,9 @@ public:
 	MiniballReaction( std::string filename, std::shared_ptr<MiniballSettings> myset );
 	~MiniballReaction() {};
 	
+	// Print the reaction data to a file
+	void PrintReaction( std::ostream &stream, std::string opt );
+	
 	// Main functions
 	void AddBindingEnergy( short Ai, short Zi, TString ame_be_str );
 	void ReadMassTables();
@@ -171,15 +174,15 @@ public:
 	inline unsigned char GetLaserMode(){ return laser_mode; };
 	
 	// Get values for geometry
-	inline float			GetCDDistance( unsigned char det ){
+	inline double			GetCDDistance( unsigned char det ){
 		if( det < cd_dist.size() ) return cd_dist.at(det);
 		else return 0.0;
 	};
-	inline float			GetCDPhiOffset( unsigned char det ){
+	inline double			GetCDPhiOffset( unsigned char det ){
 		if( det < cd_offset.size() ) return cd_offset.at(det);
 		else return 0.0;
 	};
-	inline float			GetCDDeadLayer( unsigned char det ){
+	inline double			GetCDDeadLayer( unsigned char det ){
 		if( det < dead_layer.size() ) return dead_layer.at(det);
 		else return 0.0;
 	};
@@ -199,19 +202,19 @@ public:
 		return GetCDVector( det, sec, (float)pid, (float)nid );
 	};
 	TVector3		GetParticleVector( unsigned char det, unsigned char sec, unsigned char pid, unsigned char nid );
-	inline float	GetParticleTheta( unsigned char det, unsigned char sec, unsigned char pid, unsigned char nid ){
+	inline double	GetParticleTheta( unsigned char det, unsigned char sec, unsigned char pid, unsigned char nid ){
 		return GetParticleVector( det, sec, pid, nid ).Theta();
 	};
-	inline float	GetParticlePhi( unsigned char det, unsigned char sec, unsigned char pid, unsigned char nid ){
+	inline double	GetParticlePhi( unsigned char det, unsigned char sec, unsigned char pid, unsigned char nid ){
 		return GetParticleVector( det, sec, pid, nid ).Phi();
 	};
-	inline float	GetParticleX( unsigned char det, unsigned char sec, unsigned char pid, unsigned char nid ){
+	inline double	GetParticleX( unsigned char det, unsigned char sec, unsigned char pid, unsigned char nid ){
 		return GetParticleVector( det, sec, pid, nid ).X();
 	};
-	inline float	GetParticleY( unsigned char det, unsigned char sec, unsigned char pid, unsigned char nid ){
+	inline double	GetParticleY( unsigned char det, unsigned char sec, unsigned char pid, unsigned char nid ){
 		return GetParticleVector( det, sec, pid, nid ).Y();
 	};
-	inline float	GetParticleZ( unsigned char det, unsigned char sec, unsigned char pid, unsigned char nid ){
+	inline double	GetParticleZ( unsigned char det, unsigned char sec, unsigned char pid, unsigned char nid ){
 		return GetParticleVector( det, sec, pid, nid ).Z();
 	};
 	inline TVector3	GetCDVector( std::shared_ptr<ParticleEvt> p ){
@@ -220,19 +223,19 @@ public:
 	inline TVector3	GetParticleVector( std::shared_ptr<ParticleEvt> p ){
 		return GetParticleVector( p->GetDetector(), p->GetSector(), p->GetStripP(), p->GetStripN() );
 	};
-	inline float	GetParticleTheta( std::shared_ptr<ParticleEvt> p ){
+	inline double	GetParticleTheta( std::shared_ptr<ParticleEvt> p ){
 		return GetParticleTheta( p->GetDetector(), p->GetSector(), p->GetStripP(), p->GetStripN() );
 	};
-	inline float	GetParticlePhi( std::shared_ptr<ParticleEvt> p ){
+	inline double	GetParticlePhi( std::shared_ptr<ParticleEvt> p ){
 		return GetParticlePhi( p->GetDetector(), p->GetSector(), p->GetStripP(), p->GetStripN() );
 	};
-	inline float	GetParticleX( std::shared_ptr<ParticleEvt> p ){
+	inline double	GetParticleX( std::shared_ptr<ParticleEvt> p ){
 		return GetParticleX( p->GetDetector(), p->GetSector(), p->GetStripP(), p->GetStripN() );
 	};
-	inline float	GetParticleY( std::shared_ptr<ParticleEvt> p ){
+	inline double	GetParticleY( std::shared_ptr<ParticleEvt> p ){
 		return GetParticleY( p->GetDetector(), p->GetSector(), p->GetStripP(), p->GetStripN() );
 	};
-	inline float	GetParticleZ( std::shared_ptr<ParticleEvt> p ){
+	inline double	GetParticleZ( std::shared_ptr<ParticleEvt> p ){
 		return GetParticleZ( p->GetDetector(), p->GetSector(), p->GetStripP(), p->GetStripN() );
 	};
 
@@ -240,52 +243,64 @@ public:
 	inline void   SetupCluster( unsigned char clu, double user_theta, double user_phi, double user_alpha, double user_r, double user_z) {
 		mb_geo[clu].SetupCluster(user_theta, user_phi, user_alpha, user_r, user_z);
 	}
-	inline float	GetGammaTheta( unsigned char clu, unsigned char cry, unsigned char seg ){
+	inline double	GetMiniballTheta( unsigned char clu ){
+		return mb_geo[clu].GetCluTheta();
+	};
+	inline double	GetMiniballPhi( unsigned char clu ){
+		return mb_geo[clu].GetCluPhi();
+	};
+	inline double	GetMiniballAlpha( unsigned char clu ){
+		return mb_geo[clu].GetCluAlpha();
+	};
+	inline double	GetMiniballR( unsigned char clu ){
+		return mb_geo[clu].GetCluR();
+	};
+	inline double	GetGammaTheta( unsigned char clu, unsigned char cry, unsigned char seg ){
 		return mb_geo[clu].GetSegTheta( cry, seg );
 	};
-	inline float	GetGammaPhi( unsigned char clu, unsigned char cry, unsigned char seg ){
+	inline double	GetGammaPhi( unsigned char clu, unsigned char cry, unsigned char seg ){
 		return mb_geo[clu].GetSegPhi( cry, seg );
 	};
-	inline float	GetGammaX( unsigned char clu, unsigned char cry, unsigned char seg ){
+	inline double	GetGammaX( unsigned char clu, unsigned char cry, unsigned char seg ){
 		return mb_geo[clu].GetSegX( cry, seg );
 	};
-	inline float	GetGammaY( unsigned char clu, unsigned char cry, unsigned char seg ){
+	inline double	GetGammaY( unsigned char clu, unsigned char cry, unsigned char seg ){
 		return mb_geo[clu].GetSegY( cry, seg );
 	};
-	inline float	GetGammaZ( unsigned char clu, unsigned char cry, unsigned char seg ){
+	inline double	GetGammaZ( unsigned char clu, unsigned char cry, unsigned char seg ){
 		return mb_geo[clu].GetSegZ( cry, seg );
 	};
-	inline float	GetGammaTheta( std::shared_ptr<GammaRayEvt> g ){
+	inline double	GetGammaTheta( std::shared_ptr<GammaRayEvt> g ){
 		return GetGammaTheta( g->GetCluster(), g->GetCrystal(), g->GetSegment() );
 	};
-	inline float	GetGammaPhi( std::shared_ptr<GammaRayEvt> g ){
+	inline double	GetGammaPhi( std::shared_ptr<GammaRayEvt> g ){
 		return GetGammaPhi( g->GetCluster(), g->GetCrystal(), g->GetSegment() );
 	};
-	inline float	GetGammaX( std::shared_ptr<GammaRayEvt> g ){
+	inline double	GetGammaX( std::shared_ptr<GammaRayEvt> g ){
 		return GetGammaX( g->GetCluster(), g->GetCrystal(), g->GetSegment() );
 	};
-	inline float	GetGammaY( std::shared_ptr<GammaRayEvt> g ){
+	inline double	GetGammaY( std::shared_ptr<GammaRayEvt> g ){
 		return GetGammaY( g->GetCluster(), g->GetCrystal(), g->GetSegment() );
 	};
-	inline float	GetGammaZ( std::shared_ptr<GammaRayEvt> g ){
+	inline double	GetGammaZ( std::shared_ptr<GammaRayEvt> g ){
 		return GetGammaZ( g->GetCluster(), g->GetCrystal(), g->GetSegment() );
 	};
 
 	// SPEDE and electron geometry
-	inline float	GetSpedeDistance(){ return spede_dist; };
-	inline float	GetSpedePhiOffset(){ return spede_offset; };
+	inline double	GetSpedeDistance(){ return spede_dist; };
+	inline double	GetSpedePhiOffset(){ return spede_offset; };
 	TVector3		GetSpedeVector( unsigned char seg, bool random = false );
 	TVector3		GetElectronVector( unsigned char seg );
-	inline float	GetElectronTheta( unsigned char seg ){
+	inline double	GetElectronTheta( unsigned char seg ){
 		return GetElectronVector(seg).Theta();
 	};
-	inline float	GetElectronTheta( SpedeEvt *s ){
+	inline double	GetElectronTheta( SpedeEvt *s ){
 		return GetElectronTheta( s->GetSegment() );
 	};
-	inline float	GetElectronPhi( unsigned char seg ){
+	inline double	GetElectronPhi( unsigned char seg ){
 		return GetElectronVector(seg).Phi();
 	};
-	inline float	GetElectronPhi( SpedeEvt *s ){
+	inline double	GetElectronPhi( SpedeEvt *s ){
 		return GetElectronPhi( s->GetSegment() );
 	};
 
@@ -337,6 +352,7 @@ public:
 
 	
 	// Doppler correction
+	double DopplerShift( double gen, double pbeta, double costheta );
 	double DopplerCorrection( std::shared_ptr<GammaRayEvt> g, double pbeta, double ptheta, double pphi );
 	double DopplerCorrection( std::shared_ptr<GammaRayEvt> g, bool ejectile );
 	double DopplerCorrection( std::shared_ptr<SpedeEvt> s, bool ejectile );
@@ -453,6 +469,11 @@ public:
 	bool ReadStoppingPowers( std::string isotope1, std::string isotope2, std::unique_ptr<TGraph> &g );
 
 	
+	// Getter for target offsets
+	inline double GetOffsetX(){ return x_offset; };
+	inline double GetOffsetY(){ return y_offset; };
+	inline double GetOffsetZ(){ return z_offset; };
+
 	// Get cuts
 	inline TCutG* GetEjectileCut(){ return ejectile_cut; };
 	inline TCutG* GetRecoilCut(){ return recoil_cut; };
@@ -518,27 +539,27 @@ private:
 	int ee_random[2];	// electron-electron random
 	int pe_prompt[2];	// particle-electron prompt
 	int pe_random[2];	// particle-electron random
-	float pg_ratio, gg_ratio, pp_ratio; // fill ratios
-	float pe_ratio, ge_ratio, ee_ratio; // fill ratios
+	double pg_ratio, gg_ratio, pp_ratio; // fill ratios
+	double pe_ratio, ge_ratio, ee_ratio; // fill ratios
 
 	// Target thickness and offsets
-	float target_thickness;	///< target thickness in units of mg/cm^2
-	float x_offset;			///< horizontal offset of the target/beam position, with respect to the CD and Miniball in mm
-	float y_offset;			///< vertical offset of the target/beam position, with respect to the CD and Miniball in mm
-	float z_offset;			///< lateral offset of the target/beam position, with respect to the only Miniball in mm (cd_dist is independent)
+	double target_thickness;	///< target thickness in units of mg/cm^2
+	double x_offset;			///< horizontal offset of the target/beam position, with respect to the CD and Miniball in mm
+	double y_offset;			///< vertical offset of the target/beam position, with respect to the CD and Miniball in mm
+	double z_offset;			///< lateral offset of the target/beam position, with respect to the only Miniball in mm (cd_dist is independent)
 
 	// CD detector things
-	std::vector<float> cd_dist;		///< distance from target to CD detector in mm
-	std::vector<float> cd_offset;	///< phi rotation of the CD in degrees
-	std::vector<float> dead_layer;	///< dead layer thickness in mm
+	std::vector<double> cd_dist;		///< distance from target to CD detector in mm
+	std::vector<double> cd_offset;	///< phi rotation of the CD in degrees
+	std::vector<double> dead_layer;	///< dead layer thickness in mm
 
 	// Miniball detector things
 	std::vector<MiniballGeometry> mb_geo;
-	std::vector<float> mb_theta, mb_phi, mb_alpha, mb_r;
+	std::vector<double> mb_theta, mb_phi, mb_alpha, mb_r;
 
 	// SPEDE things
-	float spede_dist;	///< distance from target to SPEDE detector
-	float spede_offset;	///< phi rotation of the SPEDE detector
+	double spede_dist;	///< distance from target to SPEDE detector
+	double spede_offset;	///< phi rotation of the SPEDE detector
 	
 	// Doppler mode, calculating the velocity for Doppler correction
 	// 0 = use angles and two-body kinematics at centre of the target

--- a/include/RootLinkDef.h
+++ b/include/RootLinkDef.h
@@ -22,6 +22,7 @@
 #pragma link C++ class MBSInfoPackets+;
 #pragma link C++ class MiniballReaction+;
 #pragma link C++ class MiniballParticle+;
+#pragma link C++ class MiniballAngleFitter+;
 #pragma link C++ class MiniballGUI+;
 #pragma link C++ class MyDialog+;
 #endif

--- a/mb_sort.cc
+++ b/mb_sort.cc
@@ -629,18 +629,20 @@ void do_angle_fit(){
 	if( input_names.size() ){
 
 		// Perform the hadd (doesn't work on Windows)
+		gErrorIgnoreLevel = kError;
 		std::string cmd = "hadd -k -T -v 0 -f ";
 		cmd += name_output_file;
 		cmd += hadd_file_list;
 		gSystem->Exec( cmd.data() );
-		
+		gErrorIgnoreLevel = kInfo;
+
 		// Give this file to the angle fitter
 		if( !angle_fit.SetInputROOTFile( name_output_file ) ) return;
 		
 	}
 	
 	// Otherwise we have to take the energies from the file
-	if( !angle_fit.SetInputEnergiesFile( name_angle_file ) ) return;
+	else if( !angle_fit.SetInputEnergiesFile( name_angle_file ) ) return;
 	
 	// Perform the fitting
 	angle_fit.DoFit();

--- a/mb_sort.cc
+++ b/mb_sort.cc
@@ -7,6 +7,7 @@ std::string datadir_name;
 std::string name_set_file;
 std::string name_cal_file;
 std::string name_react_file;
+std::string name_angle_file = "";
 std::vector<std::string> input_names;
 
 // a flag at the input to force the conversion
@@ -28,6 +29,9 @@ bool gui_flag = false;
 
 // Input data type
 bool flag_mbs = false;
+
+// Do we want to fit the 22Ne angle data?
+bool flag_angle_fit = false;
 
 // DataSpy
 bool flag_spy = false;
@@ -571,6 +575,79 @@ void do_hist() {
 	
 }
 
+void do_angle_fit(){
+
+	//------------------------------------------//
+	// Run angle fitting routine with 22Ne data //
+	//------------------------------------------//
+	MiniballAngleFitter angle_fit( myset, myreact );
+	std::cout << "\n +++ Miniball Analysis:: processing MiniballAngleFitter +++" << std::endl;
+
+	TFile *rtest;
+	std::ifstream ftest;
+	std::string name_input_file;
+	std::string name_output_file = "22Ne_angle_fit.root";
+	std::string hadd_file_list = "";
+	std::string name_results_file = "22Ne_angle_fit.cal";
+	
+	// Check each file
+	for( unsigned int i = 0; i < input_names.size(); i++ ){
+	
+		name_input_file = input_names.at(i).substr( input_names.at(i).find_last_of("/")+1,
+												   input_names.at(i).length() - input_names.at(i).find_last_of("/")-1 );
+		name_input_file = name_input_file.substr( 0,
+												 name_input_file.find_last_of(".") );
+		name_input_file = datadir_name + "/" + name_input_file + "_events.root";
+	
+		// Add to list if the converted file exists
+		ftest.open( name_input_file.data() );
+		if( ftest.is_open() ) {
+	
+			ftest.close();
+			rtest = new TFile( name_input_file.data() );
+			if( !rtest->IsZombie() ) {
+				hadd_file_list += " " + name_input_file;
+			}
+			else {
+				std::cout << "Skipping " << name_input_file;
+				std::cout << ", it's broken" << std::endl;
+			}
+			rtest->Close();
+	
+		}
+	
+		else {
+	
+			std::cout << "Skipping " << name_input_file;
+			std::cout << ", file does not exist" << std::endl;
+	
+		}
+	
+	}
+	
+	// If we have some ROOT files, add them and pass to the fitter
+	if( input_names.size() ){
+
+		// Perform the hadd (doesn't work on Windows)
+		std::string cmd = "hadd -k -T -v 0 -f ";
+		cmd += name_output_file;
+		cmd += hadd_file_list;
+		gSystem->Exec( cmd.data() );
+		
+		// Give this file to the angle fitter
+		if( !angle_fit.SetInputROOTFile( name_output_file ) ) return;
+		
+	}
+	
+	// Otherwise we have to take the energies from the file
+	if( !angle_fit.SetInputEnergiesFile( name_angle_file ) ) return;
+	
+	// Perform the fitting
+	angle_fit.DoFit();
+	angle_fit.SaveReactionFile( name_results_file );
+	
+}
+
 int main( int argc, char *argv[] ){
 	
 	// Command line interface, stolen from MiniballCoulexSort
@@ -585,8 +662,10 @@ int main( int argc, char *argv[] ){
 	interface->Add("-e", "Flag to force new event builder (new calibration)", &flag_events );
 	interface->Add("-source", "Flag to define an source only run", &flag_source );
 	interface->Add("-ebis", "Flag to define an EBIS only run, discarding data >4ms after an EBIS event", &flag_ebis );
-    interface->Add("-mbs", "Flag to define input as MBS data type", &flag_mbs );
-    interface->Add("-spy", "Flag to run the DataSpy", &flag_spy );
+	interface->Add("-mbs", "Flag to define input as MBS data type", &flag_mbs );
+	interface->Add("-anglefit", "Flag to run the angle fit", &flag_angle_fit );
+	interface->Add("-angledata", "File containing 22Ne segment energies", &name_angle_file );
+	interface->Add("-spy", "Flag to run the DataSpy", &flag_spy );
 	interface->Add("-m", "Monitor input file every X seconds", &mon_time );
 	interface->Add("-p", "Port number for web server (default 8030)", &port_num );
 	interface->Add("-d", "Directory to put the sorted data default is /path/to/data/sorted", &datadir_name );
@@ -612,17 +691,37 @@ int main( int argc, char *argv[] ){
 
 	}
 
-	// Check we have data files
-	if( !input_names.size() && !flag_spy  ) {
+	// Check if we are doing the angle fit
+	if( flag_angle_fit ) {
+		
+		if( input_names.size() == 0 && name_angle_file.length() > 0 )
+			std::cout << "Angle fitting using energies from a file" << std::endl;
 			
-			std::cout << "You have to provide at least one input file unless you are in DataSpy mode!" << std::endl;
+		else if( input_names.size() > 0 && name_angle_file.length() == 0 )
+			std::cout << "Angle fitting using 22Ne data files, with automatic peak fitting" << std::endl;
+
+		else {
+			
+			std::cout << "When fitting the 22Ne angle data, you must give segments energy file as input" << std::endl;
+			std::cout << "using the -angledata flag. Alternatively, you can give the raw data files using" << std::endl;
+			std::cout << "the -i flag and the peaks will be automatically fitted from the events file." << std::endl;
 			return 1;
+			
+		}
+		
+	}
+	
+	// Check we have data files
+	else if( !input_names.size() && !flag_spy ) {
+			
+		std::cout << "You have to provide at least one input file unless you are in DataSpy mode!" << std::endl;
+		return 1;
 			
 	}
 	
 	// Check if it should be MBS format
-	if( !flag_mbs && !flag_spy ){
-		
+	if( !flag_mbs && !flag_spy && !name_angle_file.length() ){
+
 		std::string extension = input_names.at(0).substr( input_names.at(0).find_last_of(".")+1,
 														 input_names.at(0).length()-input_names.at(0).find_last_of(".")-1 );
 		
@@ -631,9 +730,9 @@ int main( int argc, char *argv[] ){
 			flag_mbs = true;
 			std::cout << "Assuming we have MBS data because of the .lmd extension" << std::endl;
 			std::cout << "Forcing the data block size to 32 kB" << std::endl;
-
-		}
 			
+		}
+		
 	}
 	
 	// Check if we should be monitoring the input
@@ -646,7 +745,7 @@ int main( int argc, char *argv[] ){
 		
 	}
 	
-	else if( mon_time >= 0 && input_names.size() == 1 ) {
+	else if( mon_time >= 0 && input_names.size() == 1 && !flag_angle_fit ) {
 		
 		flag_monitor = true;
 		std::cout << "Running sort in a loop every " << mon_time;
@@ -658,7 +757,7 @@ int main( int argc, char *argv[] ){
 		
 		flag_monitor = false;
 		std::cout << "Cannot monitor multiple input files, switching to normal mode" << std::endl;
-				
+		
 	}
 	
 	// Check the directory we are writing to
@@ -681,7 +780,9 @@ int main( int argc, char *argv[] ){
 			
 		}
 		
-		else datadir_name = "dataspy";
+		else if( flag_spy ) datadir_name = "dataspy";
+		else if( flag_angle_fit ) datadir_name = "positions";
+		else datadir_name = "mb_sort_outputs";
 		
 		// Create the directory if it doesn't exist (not Windows compliant)
 		std::string cmd = "mkdir -p " + datadir_name;
@@ -690,7 +791,7 @@ int main( int argc, char *argv[] ){
 		std::cout << "Sorted data files being saved to " << datadir_name << std::endl;
 		
 	}
-
+	
 	// Check the ouput file name
 	if( output_name.length() == 0 ) {
 
@@ -701,10 +802,19 @@ int main( int argc, char *argv[] ){
 			name_input_file = name_input_file.substr( 0,
 													 name_input_file.find_last_of(".") );
 			
-			if( input_names.size() > 1 ) {
+			if( flag_angle_fit ) {
+				
+				output_name = datadir_name + "/" + name_input_file + "_results.root";
+
+			}
+			
+			else if( input_names.size() > 1 ) {
+				
 				output_name = datadir_name + "/" + name_input_file + "_hists_";
 				output_name += std::to_string(input_names.size()) + "_subruns.root";
+			
 			}
+			
 			else
 				output_name = datadir_name + "/" + name_input_file + "_hists.root";
 				
@@ -807,7 +917,7 @@ int main( int argc, char *argv[] ){
 	if( flag_mbs ) mycal->SetDefaultQint();
 	mycal->ReadCalibration();
 	myreact = std::make_shared<MiniballReaction>( name_react_file, myset );
-
+	
 	// Force data block size for MBS data
 	if( flag_mbs ) myset->SetBlockSize( 0x8000 );
 	
@@ -854,7 +964,11 @@ int main( int argc, char *argv[] ){
 	// Run the analysis //
 	//------------------//
 	do_convert();
-	if( !flag_source ) {
+	if( flag_angle_fit ){
+		do_build();
+		do_angle_fit();
+	}
+	else if( !flag_source ) {
 		if( do_build() )
 			do_hist();
 	}

--- a/mb_sort.cc
+++ b/mb_sort.cc
@@ -647,6 +647,7 @@ void do_angle_fit(){
 	// Perform the fitting
 	angle_fit.DoFit();
 	angle_fit.SaveReactionFile( name_results_file );
+	angle_fit.CloseROOTFile();
 	
 }
 

--- a/mb_sort.cc
+++ b/mb_sort.cc
@@ -646,7 +646,13 @@ void do_angle_fit(){
 	
 	// Perform the fitting
 	angle_fit.DoFit();
+
+	// Save the experimental energies and angles to a file
+	if( input_names.size() )
+		angle_fit.SaveExpEnergies( "22Ne_fitted_energies.dat" );
 	angle_fit.SaveReactionFile( name_results_file );
+	
+	// Close the ROOT file
 	angle_fit.CloseROOTFile();
 	
 }

--- a/mb_sort.hh
+++ b/mb_sort.hh
@@ -60,6 +60,10 @@
 # include "MiniballGUI.hh"
 #endif
 
+// MiniballAngleFit header
+#ifndef __MINIBALLANGLEFITTER_HH
+# include "MiniballAngleFitter.hh"
+#endif
 
 // Command line interface
 #ifndef __COMMAND_LINE_INTERFACE_HH

--- a/src/MiniballAngleFitter.cc
+++ b/src/MiniballAngleFitter.cc
@@ -1,0 +1,672 @@
+#include "MiniballAngleFitter.hh"
+
+MiniballAngleFunction::MiniballAngleFunction() {
+	
+	// Settings and reaction files - dummies
+	myset = std::make_shared<MiniballSettings>( "default" );
+	myreact = std::make_shared<MiniballReaction>( "default", myset );
+	
+	// Now initialise everything
+	Initialise();
+	
+}
+
+MiniballAngleFunction::MiniballAngleFunction( std::shared_ptr<MiniballSettings> _myset, std::shared_ptr<MiniballReaction> _myreact ) {
+
+	// Settings and reaction files
+	myset = _myset;
+	myreact = _myreact;
+
+	// Now initialise everything
+	Initialise();
+
+};
+
+void MiniballAngleFunction::Initialise() {
+	
+	// Loop over clusters
+	present.resize( myset->GetNumberOfMiniballClusters() );
+	energy.resize( myset->GetNumberOfMiniballClusters() );
+	err.resize( myset->GetNumberOfMiniballClusters() );
+	for( unsigned int clu = 0; clu < myset->GetNumberOfMiniballClusters(); ++clu ) {
+		
+		cluster.push_back(false);
+		present[clu].resize( myset->GetNumberOfMiniballCrystals() );
+		energy[clu].resize( myset->GetNumberOfMiniballCrystals() );
+		err[clu].resize( myset->GetNumberOfMiniballCrystals() );
+
+		// Loop over crystals
+		for( unsigned int cry = 0; cry < myset->GetNumberOfMiniballCrystals(); ++cry ) {
+			
+			present[clu][cry].resize( myset->GetNumberOfMiniballSegments() );
+			energy[clu][cry].resize( myset->GetNumberOfMiniballSegments() );
+			err[clu][cry].resize( myset->GetNumberOfMiniballSegments() );
+
+			// Loop over segments
+			for( unsigned int seg = 0; seg < myset->GetNumberOfMiniballSegments(); ++seg ) {
+				
+				present[clu][cry].push_back(false);
+				energy[clu][cry].push_back(0.0);
+				err[clu][cry].push_back(0.0);
+			
+			} // seg
+		
+		} // cry
+	
+	} // clu
+
+	// Set the user z
+	user_z = myreact->GetOffsetZ();
+
+	
+}
+
+void MiniballAngleFunction::FitPeak( TH1D *h, double &en, double &er ){
+	
+	// Make a TF1
+	auto peakfit = std::make_unique<TF1>( "peakfit", "gaus(0)+pol1(3)", en*0.925 - 10., en*1.075 + 10. );
+	
+	// Set initial parameters
+	double sig_est = 1.7; // 1.7 keV guess for sigma = 4.0 keV for FWHM
+	double bg_est = h->GetBinContent( h->FindBin(en+10.) );
+	double amp_est = h->GetBinContent( h->FindBin(en) ) - bg_est;
+	amp_est *= TMath::TwoPi() * sig_est;
+	peakfit->SetParameter( 0, amp_est );	// amplitude
+	peakfit->SetParameter( 1, en );			// centroid
+	peakfit->SetParameter( 2, sig_est );	// sigma width
+	peakfit->SetParameter( 3, bg_est );		// bg const
+	peakfit->SetParameter( 4, 1e-9 );		// bg gradient
+
+	// Make fit
+	h->Fit( peakfit.get(), "LRE" );
+	
+	// Set parameters back
+	en = peakfit->GetParameter(1);
+	er = peakfit->GetParError(1);
+
+}
+
+void MiniballAngleFunction::FitSegmentEnergies( std::shared_ptr<TFile> infile ){
+
+	// Names of the spectra in the events file
+	std::string hname, folder = "/miniball/cluster_", base = "mb_en_core_seg_";
+	
+	// Histogram object
+	TH1D *h;
+	
+	// Loop over all clusters
+	for( unsigned int clu = 0; clu < myset->GetNumberOfMiniballClusters(); ++clu ) {
+		
+		// Loop over crystals
+		for( unsigned int cry = 0; cry < myset->GetNumberOfMiniballCrystals(); ++cry ) {
+			
+			// Loop over segments
+			for( unsigned int seg = 0; seg < myset->GetNumberOfMiniballSegments(); ++seg ) {
+
+				// Build up the histogram name
+				hname  = folder + std::to_string(clu) + "/";
+				hname += base + std::to_string(clu) + "_";
+				hname += std::to_string(cry) + "_";
+				hname += std::to_string(seg) + "_ebis";
+
+				// Get histogram from file
+				h = static_cast<TH1D*>( infile->Get( hname.data() ) );
+				
+				// Check if we have some counts
+				if( h->Integral() > 0 )
+					present[clu][cry][seg] = true;
+				
+				// Predict the centroid from intial guesses
+				double en_init = myreact->DopplerShift( eref, myreact->GetBeta(),
+								TMath::Cos( myreact->GetGammaTheta( clu, cry, seg ) ) );
+				
+				// Fit peak and update the energy and error
+				energy[clu][cry][seg] = en_init;
+				FitPeak( h, energy[clu][cry][seg], err[clu][cry][seg] );
+
+				
+			} // seg
+			
+		} // cry
+		
+	} // clu
+	
+	// Clean up
+	delete h;
+		
+}
+
+void MiniballAngleFunction::LoadExpEnergies( std::string energy_file ){
+	
+	// Open file
+	std::ifstream energyfile( energy_file );
+
+	// Some parameters to read in
+	int cl, cr, sg;
+	double en, er;
+
+	// Loop over the whole file
+	while( energyfile >> cl >> cr >> sg >> en >> er ) {
+
+		if( cl >= (int)myset->GetNumberOfMiniballClusters() || cl < 0 ) {
+			
+			std::cerr << "Bad cluster number = " << cl << std::endl;
+			continue;
+			
+		}
+
+		if( cr >= (int)myset->GetNumberOfMiniballCrystals() || cr < 0 ) {
+			
+			std::cerr << "Bad crystal number = " << cr << std::endl;
+			continue;
+			
+		}
+
+		if( sg >= (int)myset->GetNumberOfMiniballSegments() || sg < 0 ) {
+			
+			std::cerr << "Bad segment number = " << sg << std::endl;
+			continue;
+			
+		}
+
+		present[cl][cr][sg] = true;
+		energy[cl][cr][sg] = en;
+		err[cl][cr][sg] = er;
+		cluster[cl] = true;
+
+	}
+	
+	energyfile.close();
+	
+};
+
+double MiniballAngleFunction::operator() ( const double *p ) {
+
+	// change angles
+	// p[0] = beta
+	// p[1] = theta1, p[2] = phi1, p[3] = alpha1, p[4] = r1,
+	// p[5] = theta2, p[6] = phi2, p[7] = alpha2, p[8] = r2, etc.
+	int indx = 1;
+
+	// Loop over clusters
+	for( unsigned int clu = 0; clu < myset->GetNumberOfMiniballClusters(); ++clu ) {
+
+		myreact->SetupCluster( clu, p[indx], p[indx+1], p[indx+2], p[indx+3], user_z );
+		indx += 4;
+
+	}
+	
+	double chisq = 0;
+	
+	// Loop over clusters
+	for( unsigned int clu = 0; clu < myset->GetNumberOfMiniballClusters(); ++clu ) {
+
+		// Loop over crystals
+		for( unsigned int cry = 0; cry < myset->GetNumberOfMiniballCrystals(); ++cry ) {
+
+			// Loop over segments
+			for( unsigned int seg = 0; seg < myset->GetNumberOfMiniballSegments(); ++seg ) {
+				
+				if( !present[clu][cry][seg] ) continue;
+				double theta = myreact->GetGammaTheta( clu, cry, seg );
+				double beta = p[0];
+				double edop = myreact->DopplerShift( eref, beta, TMath::Cos(theta) );
+				chisq += TMath::Power( ( energy[clu][cry][seg] - edop ) / err[clu][cry][seg], 2.0 );
+
+			}
+
+		}
+
+	}
+	
+	return chisq;
+	
+}
+
+MiniballAngleFitter::MiniballAngleFitter() {
+
+	// Just use dummy files
+	MiniballAngleFitter( "default", "default" );
+	
+}
+
+MiniballAngleFitter::MiniballAngleFitter( std::string settings_file, std::string reaction_file ) {
+
+	// Settings and reaction files
+	myset = std::make_shared<MiniballSettings>( settings_file );
+	myreact = std::make_shared<MiniballReaction>( reaction_file, myset );
+	
+	// Now call main function
+	MiniballAngleFitter( myset, myreact );
+
+}
+
+MiniballAngleFitter::MiniballAngleFitter( std::shared_ptr<MiniballSettings> _myset, std::shared_ptr<MiniballReaction> _myreact ) {
+
+	// Settings and reaction files
+	myset = _myset ;
+	myreact = _myreact;
+	
+	// Now initialise
+	Initialise();
+
+}
+
+// Input ROOT file
+bool MiniballAngleFitter::SetInputROOTFile( std::string fname ){
+	
+	// Open input file.
+	input_root_file = std::make_shared<TFile>( fname.data(), "read" );
+	if( input_root_file->IsZombie() ) {
+		
+		std::cout << "Cannot open " << fname << std::endl;
+		return false;
+		
+	}
+	
+	// Set the flag for fitting the peaks from the ROOT file
+	flag_fit_peaks = true;
+	
+	// Hack at the moment because we can't fit stuff
+	return false;
+
+	// Of course, when it works, we should return true here
+	//return true;
+	
+}
+
+// Input data file
+bool MiniballAngleFitter::SetInputEnergiesFile( std::string fname ){
+	
+	// Open input file.
+	input_data_filename = fname;
+	std::ifstream ftest;
+	ftest.open( input_data_filename );
+	if( !ftest.is_open() ) {
+		
+		std::cout << "Cannot open " << input_data_filename << std::endl;
+		return false;
+		
+	}
+	ftest.close();
+	
+	// Set the flag for taking the data from a list file
+	flag_fit_peaks = false;
+	
+	return true;
+	
+}
+
+void MiniballAngleFitter::Initialise() {
+	
+	// Setup the fit function
+	ff = MiniballAngleFunction( myset, myreact );
+	
+	// Resize the vectors for parameters and limits
+	npars = 1 + 4 * myset->GetNumberOfMiniballClusters();
+	pars.resize( npars );
+	names.resize( npars );
+	LL.resize( npars );
+	UL.resize( npars );
+	
+	// set the initial velocity from the reaction file
+	pars[0] = myreact->GetBeta();
+	names[0] = "beta";
+	LL[0] = 0.01;
+	UL[0] = 0.5;
+	
+	// Set the initial guesses for angles of each cluster from the reaction file
+	for( unsigned int clu = 0; clu < myset->GetNumberOfMiniballClusters(); ++clu ) {
+
+		// work out the parameter numbers
+		int indx = 1 + 4 * clu;
+		
+		// get starting guesses from the reaction file
+		pars[indx+0]	= myreact->GetMiniballTheta(clu);
+		pars[indx+1]	= myreact->GetMiniballPhi(clu);
+		pars[indx+2]	= myreact->GetMiniballAlpha(clu);
+		pars[indx+3]	= myreact->GetMiniballR(clu);
+		
+		// Names of the parameters
+		names[indx+0]	= "theta_" + std::to_string(clu);
+		names[indx+1]	= "phi_"   + std::to_string(clu);
+		names[indx+2]	= "alpha_" + std::to_string(clu);
+		names[indx+3]	= "r_"     + std::to_string(clu);
+
+		// Lower limits
+		// these may cause issue if we need to cross over the 0/360 boundary
+		LL[indx+0]	= 0.0;
+		LL[indx+1]	= 0.0;
+		LL[indx+2]	= 0.0;
+		LL[indx+3]	= 10.0;
+		
+		// Upper limits
+		UL[indx+0]	= 180.0;
+		UL[indx+1]	= 360.0;
+		UL[indx+2]	= 360.0;
+		UL[indx+3]	= 400.0;
+
+	}
+	
+}
+
+void MiniballAngleFitter::DoFit() {
+	
+	// First we need to fit all of the segment energies
+	// or read them in from a file
+	if( flag_fit_peaks ) ff.FitSegmentEnergies( input_root_file );
+	else ff.LoadExpEnergies( input_data_filename );
+		
+	// Create minimizer
+	ROOT::Math::Minimizer *min =
+		ROOT::Math::Factory::CreateMinimizer("Minuit2", "Migrad");
+	
+	// Create function for the fitting
+	ROOT::Math::Functor f_init( ff, npars );
+	
+	// Some fit controls
+	min->SetErrorDef(1.);
+	min->SetMaxFunctionCalls(1000);
+	min->SetMaxIterations(1000);
+	min->SetTolerance(0.001);
+	min->SetPrecision(1e-6);
+	min->SetFunction(f_init);
+
+	// Set limits in fit
+	for( unsigned int i = 0; i < npars; ++i ) {
+		min->SetLimitedVariable( i, names.at(i), pars.at(i), 0.0001, LL.at(i), UL.at(i) );
+		min->SetVariableStepSize( i, 1.0 );
+	}
+	
+	// Set the variable step size for beta
+	min->SetVariableStepSize( 0, 0.001 );
+
+	// Call the minimisation procedure
+	min->Minimize();
+	
+	// Print the results to the terminal
+	min->PrintResults();
+	
+	// Copy results into reaction object
+	double beta = min->X()[0];
+	for( unsigned int clu = 0; clu < myset->GetNumberOfMiniballClusters(); ++clu ) {
+
+		// work out the parameter numbers
+		int indx = 1 + 4 * clu;
+		
+		// Setup the cluster again
+		myreact->SetupCluster(clu, min->X()[indx], min->X()[indx+1], min->X()[indx+2], min->X()[indx+3], 0.0 );
+
+	}
+	
+	// print fit + residuals to pdf
+	TGraphErrors *engraph = new TGraphErrors();
+	engraph->SetName("engraph");
+	engraph->SetTitle("Experimental energies; Channel index; Energy [keV]");
+
+	TGraph *calcgraph = new TGraph();
+	calcgraph->SetName("calcgraph");
+	engraph->SetTitle("Calculated energies; Channel index; Energy [keV]");
+
+	TGraphErrors *resgraph = new TGraphErrors();
+	resgraph->SetName("resgraph");
+	engraph->SetTitle("Residuals; Channel index; Energy [keV]");
+
+	TGraphErrors *corrgraph = new TGraphErrors();
+	corrgraph->SetName("corrgraph");
+	engraph->SetTitle("Doppler-corrected energies; Channel index; Energy [keV]");
+
+	
+	// Loop over clusters
+	for( unsigned int clu = 0; clu < myset->GetNumberOfMiniballClusters(); ++clu ) {
+
+		// Loop over crystals
+		for( unsigned int cry = 0; cry < myset->GetNumberOfMiniballCrystals(); ++cry ) {
+
+			// Loop over segments
+			for( unsigned int seg = 0; seg < myset->GetNumberOfMiniballSegments(); ++seg ) {
+
+				// Check if it's present
+				if( !ff.IsPresent( clu, cry, seg ) ) continue;
+				
+				// Get Doppler shifted energy
+				double theta = myreact->GetGammaTheta( clu, cry, seg );
+				double edop = myreact->DopplerShift( ff.GetReferenceEnergy(),
+													beta, TMath::Cos(theta) );
+				double corr = ff.GetReferenceEnergy() / edop;
+				
+				engraph->AddPoint( engraph->GetN(), ff.GetExpEnergy( clu, cry, seg ) );
+				engraph->SetPointError( engraph->GetN()-1, 0, ff.GetExpError( clu, cry, seg ) );
+				
+				corrgraph->AddPoint( engraph->GetN(), ff.GetExpEnergy( clu, cry, seg ) * corr );
+				corrgraph->SetPointError( engraph->GetN()-1, 0, ff.GetExpError( clu, cry, seg ) );
+				
+				calcgraph->AddPoint( calcgraph->GetN(), edop );
+				
+				resgraph->AddPoint( resgraph->GetN(), edop - ff.GetExpEnergy( clu, cry, seg ) );
+				resgraph->SetPointError( resgraph->GetN()-1, 0, ff.GetExpError( clu, cry, seg ) );
+
+			} // seg
+			
+		} // cry
+		
+	} // clu
+	
+	// Draw the absolute experimental/calculated energies
+	auto c1 = std::make_unique<TCanvas>();
+	engraph->SetMarkerStyle(kFullCircle);
+	engraph->SetMarkerSize(0.5);
+	engraph->SetMarkerColor(kRed);
+	engraph->SetLineColor(kRed);
+	engraph->Draw("AP");
+	engraph->Write();
+	calcgraph->SetMarkerStyle(kFullCircle);
+	calcgraph->SetMarkerSize(0.5);
+	calcgraph->Draw("P");
+	calcgraph->Write();
+
+	// Add a legend
+	auto leg = std::make_unique<TLegend>(0.1,0.75,0.3,0.9);
+	leg->AddEntry(engraph, "Experimental energies");
+	leg->AddEntry(calcgraph, "Calculated energies");
+	leg->Draw();
+	
+	// Save first plot as a PDF
+	c1->Print("position_cal.pdf(");
+	
+	// Draw the residuals
+	resgraph->SetMarkerStyle(kFullCircle);
+	resgraph->SetMarkerSize(0.5);
+	resgraph->Draw("AP");
+	resgraph->Write();
+	auto func = std::make_unique<TF1>("func", "[0]", 0, 168);
+	func->SetParameter( 0, 0.0 );
+	func->Draw("same");
+	
+	// Save second plot as a PDF
+	c1->Print("position_cal.pdf");
+	
+	// Draw the corrected energies compared to reference
+	corrgraph->SetMarkerStyle(kFullCircle);
+	corrgraph->SetMarkerSize(0.5);
+	corrgraph->Draw("AP");
+	corrgraph->Write();
+	func->SetParameter( 0, ff.GetReferenceEnergy() );
+	func->Draw("same");
+	
+	// Save third plot as a PDF
+	c1->Print("position_cal.pdf");
+	
+	// Define a colour scheme for the next bit
+	int colors[8] = {632, 416, 600, 400, 616, 432, 800, 900};
+
+	// A multi-graph showing all the positions in theta-phi, xy, xz, etc
+	auto tp_mg = std::make_unique<TMultiGraph>();
+	auto xy_f_mg = std::make_unique<TMultiGraph>();
+	auto xy_b_mg = std::make_unique<TMultiGraph>();
+	auto xz_r_mg = std::make_unique<TMultiGraph>();
+	auto xz_l_mg = std::make_unique<TMultiGraph>();
+	tp_mg->SetName("theta_phi_map");
+	xy_f_mg->SetName("xy_f_mg");
+	xy_b_mg->SetName("xy_b_mg");
+	xz_r_mg->SetName("xz_r_mg");
+	xz_l_mg->SetName("xz_l_mg");
+	std::vector< std::vector< std::unique_ptr<TGraph> > > theta_phi;
+	std::vector< std::vector< std::unique_ptr<TGraph> > > xy_f;
+	std::vector< std::vector< std::unique_ptr<TGraph> > > xy_b;
+	std::vector< std::vector< std::unique_ptr<TGraph> > > xz_l;
+	std::vector< std::vector< std::unique_ptr<TGraph> > > xz_r;
+	theta_phi.resize( myset->GetNumberOfMiniballClusters() );
+	xy_f.resize( myset->GetNumberOfMiniballClusters() );
+	xy_b.resize( myset->GetNumberOfMiniballClusters() );
+	xz_l.resize( myset->GetNumberOfMiniballClusters() );
+	xz_r.resize( myset->GetNumberOfMiniballClusters() );
+
+	// Loop over clusters
+	for( unsigned int clu = 0; clu < myset->GetNumberOfMiniballClusters(); ++clu ) {
+
+		theta_phi[clu].resize( myset->GetNumberOfMiniballCrystals() );
+		xy_f[clu].resize( myset->GetNumberOfMiniballCrystals() );
+		xy_b[clu].resize( myset->GetNumberOfMiniballCrystals() );
+		xz_l[clu].resize( myset->GetNumberOfMiniballCrystals() );
+		xz_r[clu].resize( myset->GetNumberOfMiniballCrystals() );
+
+		// Loop over crystals
+		for( unsigned int cry = 0; cry < myset->GetNumberOfMiniballCrystals(); ++cry ) {
+
+			// Make the graphs to prevent any issues
+			theta_phi[clu][cry] = std::make_unique<TGraph>();
+			xy_f[clu][cry] = std::make_unique<TGraph>();
+			xy_b[clu][cry] = std::make_unique<TGraph>();
+			xz_l[clu][cry] = std::make_unique<TGraph>();
+			xz_r[clu][cry] = std::make_unique<TGraph>();
+			
+			// But then skip if there's no data
+			if( !ff.IsPresent( clu ) ) continue;
+
+			// Loop over segments
+			for( unsigned int seg = 0; seg < myset->GetNumberOfMiniballSegments(); ++seg ) {
+
+				// Get position
+				double theta = myreact->GetGammaTheta( clu, cry, seg ) * TMath::RadToDeg();
+				double phi = myreact->GetGammaPhi( clu, cry, seg ) * TMath::RadToDeg();
+				double x = myreact->GetGammaX( clu, cry, seg );
+				double y = myreact->GetGammaY( clu, cry, seg );
+				double z = myreact->GetGammaZ( clu, cry, seg );
+
+				// Plot positions
+				theta_phi[clu][cry]->AddPoint( theta, phi );
+				if( z > 0 ) xy_f[clu][cry]->AddPoint( y, x );
+				else xy_b[clu][cry]->AddPoint( y, x );
+				if( y > 0 ) xz_r[clu][cry]->AddPoint( z, x );
+				else xz_l[clu][cry]->AddPoint( z, x );
+				
+			} // seg
+			
+			// Set colours etc
+			theta_phi[clu][cry]->SetMarkerSize(1.0);
+			theta_phi[clu][cry]->SetMarkerStyle(kFullCircle);
+			theta_phi[clu][cry]->SetMarkerColor(colors[clu]+cry);
+			xy_f[clu][cry]->SetMarkerSize(1.0);
+			xy_f[clu][cry]->SetMarkerStyle(kFullCircle);
+			xy_f[clu][cry]->SetMarkerColor(colors[clu]+cry);
+			xy_b[clu][cry]->SetMarkerSize(1.0);
+			xy_b[clu][cry]->SetMarkerStyle(kFullCircle);
+			xy_b[clu][cry]->SetMarkerColor(colors[clu]+cry);
+			xz_r[clu][cry]->SetMarkerSize(1.0);
+			xz_r[clu][cry]->SetMarkerStyle(kFullCircle);
+			xz_r[clu][cry]->SetMarkerColor(colors[clu]+cry);
+			xz_l[clu][cry]->SetMarkerSize(1.0);
+			xz_l[clu][cry]->SetMarkerStyle(kFullCircle);
+			xz_l[clu][cry]->SetMarkerColor(colors[clu]+cry);
+			
+			// Add to multi-graph
+			tp_mg->Add( theta_phi[clu][cry].get() );
+			xy_f_mg->Add( xy_f[clu][cry].get() );
+			xy_b_mg->Add( xy_b[clu][cry].get() );
+			xz_r_mg->Add( xz_r[clu][cry].get() );
+			xz_l_mg->Add( xz_l[clu][cry].get() );
+
+		} // cry
+		
+		// Skip if there's no data
+		if( !ff.IsPresent( clu ) ) continue;
+		
+	} // clu
+	
+	// Draw the multigraph for theta-phi
+	tp_mg->Draw("AP");
+	tp_mg->GetXaxis()->SetLimits(0,180);
+	tp_mg->GetYaxis()->SetLimits(-180,180);
+	tp_mg->GetXaxis()->SetTitle("Reaction Theta [deg]");
+	tp_mg->GetYaxis()->SetTitle("Reaction Phi [deg]");
+	tp_mg->Write();
+	c1->Print("position_cal.pdf");
+	
+	// Draw the multigraph for xy-forward
+	xy_f_mg->Draw("AP");
+	xy_f_mg->GetYaxis()->SetTitle("x [mm]");
+	xy_f_mg->GetXaxis()->SetTitle("y [mm]");
+	xy_f_mg->Write();
+	c1->Print("position_cal.pdf");
+
+	// Draw the multigraph for xy-backwards
+	xy_b_mg->Draw("AP");
+	xy_b_mg->GetYaxis()->SetTitle("x [mm]");
+	xy_b_mg->GetXaxis()->SetTitle("y [mm]");
+	xy_b_mg->Write();
+	c1->Print("position_cal.pdf");
+
+	// Draw the multigraph for xz-right
+	xz_r_mg->Draw("AP");
+	xz_r_mg->GetYaxis()->SetTitle("x [mm]");
+	xz_r_mg->GetXaxis()->SetTitle("z [mm]");
+	xz_r_mg->Write();
+	c1->Print("position_cal.pdf");
+	
+	// Draw the multigraph for xz-left
+	xz_l_mg->Draw("AP");
+	xz_l_mg->GetYaxis()->SetTitle("x [mm]");
+	xz_l_mg->GetXaxis()->SetTitle("z [mm]");
+	xz_l_mg->Write();
+	c1->Print("position_cal.pdf)");
+	
+	// Print final results to terminal
+	std::cout << "fitted beta = " << beta << std::endl;
+	printf("       theta       phi     alpha         R\n");
+	for( unsigned int clu = 0; clu < myset->GetNumberOfMiniballClusters(); ++clu ) {
+
+		if( !ff.IsPresent(clu) ) continue;
+		int indx = 1 + 4*clu;
+		printf("Cl%i   %6.2f    %6.2f    %6.2f    %6.2f\n", clu, min->X()[indx], min->X()[indx+1], min->X()[indx+2], min->X()[indx+3]);
+
+	}
+	std::cout << std::endl << std::endl;
+	
+	// Print the angles in the reaction file format
+	myreact->PrintReaction( std::cout, "a" );
+
+	return;
+	
+}
+
+void MiniballAngleFitter::SaveReactionFile( std::string fname ){
+	
+	// Output
+	std::ofstream react_file;
+	react_file.open( fname );
+	if( react_file.is_open() ) {
+
+		myreact->PrintReaction( react_file, "ae" );
+		react_file.close();
+
+	}
+
+	else {
+
+		std::cerr << "Couldn't open " << fname;
+		std::cerr << std::endl;
+		
+	}
+	
+}

--- a/src/MiniballAngleFitter.cc
+++ b/src/MiniballAngleFitter.cc
@@ -146,7 +146,10 @@ void MiniballAngleFunction::FitSegmentEnergies( TFile *infile ){
 					cluster[clu] = true;
 					present[clu][cry][seg] = true;
 				}
-				else break;
+				else {
+					present[clu][cry][seg] = false;
+					continue;
+				}
 				
 				// Predict the centroid from intial guesses
 				double en_init = myreact->DopplerShift( eref, myreact->GetBeta(),
@@ -158,7 +161,7 @@ void MiniballAngleFunction::FitSegmentEnergies( TFile *infile ){
 					present[clu][cry][seg] = false;
 
 				// Don't include data with big errors, probably a fitting issue
-				if( err[clu][cry][seg] > 1.0 )
+				if( err[clu][cry][seg] > 0.6 )
 					present[clu][cry][seg] = false;
 
 			} // seg
@@ -221,6 +224,37 @@ void MiniballAngleFunction::LoadExpEnergies( std::string energy_file ){
 	energyfile.close();
 	
 };
+
+void MiniballAngleFunction::SaveExpEnergies( std::string energy_file ){
+
+	// Open file
+	std::ofstream energyfile( energy_file, std::ios::out );
+
+	// Loop over all clusters
+	for( unsigned int clu = 0; clu < myset->GetNumberOfMiniballClusters(); ++clu ) {
+		
+		// Loop over crystals
+		for( unsigned int cry = 0; cry < myset->GetNumberOfMiniballCrystals(); ++cry ) {
+			
+			// Loop over segments
+			for( unsigned int seg = 1; seg < myset->GetNumberOfMiniballSegments(); ++seg ) {
+				
+				if( present[clu][cry][seg] ){
+					
+					energyfile << clu << "\t" << cry << "\t" << seg << "\t";
+					energyfile << energy[clu][cry][seg] << "\t" << err[clu][cry][seg] << std::endl;
+				
+				}
+				
+			} // seg
+			
+		} // cry
+		
+	} // clu
+	
+	energyfile.close();
+				
+}
 
 double MiniballAngleFunction::operator() ( const double *p ) {
 

--- a/src/Reaction.cc
+++ b/src/Reaction.cc
@@ -385,9 +385,9 @@ void MiniballReaction::PrintReaction( std::ostream &stream, std::string opt = ""
 	// Loop over clusters
 	for( unsigned int i = 0; i < set->GetNumberOfMiniballClusters(); ++i ) {
 
-		stream << Form( "MiniballCluster_%d.Theta: %f", i, GetMiniballTheta(i) ) << std::endl;
-		stream << Form( "MiniballCluster_%d.Phi: %f", i, GetMiniballPhi(i) ) << std::endl;
-		stream << Form( "MiniballCluster_%d.Alpha: %f", i, GetMiniballAlpha(i) ) << std::endl;
+		stream << Form( "MiniballCluster_%d.Theta: %f", i, GetMiniballTheta(i) * TMath::RadToDeg() ) << std::endl;
+		stream << Form( "MiniballCluster_%d.Phi: %f", i, GetMiniballPhi(i) * TMath::RadToDeg() ) << std::endl;
+		stream << Form( "MiniballCluster_%d.Alpha: %f", i, GetMiniballAlpha(i) * TMath::RadToDeg() ) << std::endl;
 		stream << Form( "MiniballCluster_%d.R: %f", i, GetMiniballR(i) ) << std::endl;
 
 	}

--- a/src/Reaction.cc
+++ b/src/Reaction.cc
@@ -376,6 +376,24 @@ void MiniballReaction::ReadReaction() {
 
 }
 
+void MiniballReaction::PrintReaction( std::ostream &stream, std::string opt = "" ) {
+
+	// Check options (not yet implemented)
+	if( opt.length() > 0 )
+		stream << "# The following print options were used: " << opt << std::endl;
+	
+	// Loop over clusters
+	for( unsigned int i = 0; i < set->GetNumberOfMiniballClusters(); ++i ) {
+
+		stream << Form( "MiniballCluster_%d.Theta: %f", i, GetMiniballTheta(i) ) << std::endl;
+		stream << Form( "MiniballCluster_%d.Phi: %f", i, GetMiniballPhi(i) ) << std::endl;
+		stream << Form( "MiniballCluster_%d.Alpha: %f", i, GetMiniballAlpha(i) ) << std::endl;
+		stream << Form( "MiniballCluster_%d.R: %f", i, GetMiniballR(i) ) << std::endl;
+
+	}
+	
+}
+
 TVector3 MiniballReaction::GetCDVector( unsigned char det, unsigned char sec, float pid, float nid ){
 	
 	// Check that we have a real CD detector
@@ -576,6 +594,17 @@ double MiniballReaction::CosTheta( std::shared_ptr<SpedeEvt> s, bool ejectile ) 
 	
 	return TMath::Cos( evec.Angle( p.GetVector() ) );
 
+}
+
+double MiniballReaction::DopplerShift( double gen, double pbeta, double costheta ) {
+
+	/// Returns Doppler shifted gamma-ray energy
+	double gamma = 1.0 / TMath::Sqrt( 1.0 - TMath::Power( pbeta, 2.0 ) );
+	double corr = 1.0 - pbeta * costheta;
+	corr *= gamma;
+	
+	return gen / corr;
+	
 }
 
 double MiniballReaction::DopplerCorrection( std::shared_ptr<GammaRayEvt> g, double pbeta, double ptheta, double pphi ) {

--- a/utils/mb_angle_fit.cc
+++ b/utils/mb_angle_fit.cc
@@ -129,7 +129,7 @@ int main( int argc, char *argv[] ) {
 	
 	TFile *file = new TFile("MiniballAngleFits.root", "recreate");
 	
-	//set up parameters, bounds
+	// set up parameters, bounds
 	std::vector<double> pars(1+7*4);
 	std::vector<std::string> names(1+7*4);
 	std::vector<double> LL(1+7*4);


### PR DESCRIPTION
Convergence of the position fit still isn't great, but that can be worked out as we go along. The main infrastructure is now in place and tested.

If you give the 22Ne data on CD2 target, with an appropriate settings file, calibration file and reaction file, but also add the `-anglefit` flag, the code will sort the data, fit the Doppler shifted 440 keV peaks in each segment, and build a position fit for all clusters, using the values in the reaction file as the starting values.

Once this is done, the peak centroids are written to a file at `22Ne_fitted_energies.dat`, which can be edited to remove segments with bad fits (fits can be inspected in the pdf file at `peak_fits.pdf`) or add manual points. This file can then be read back in to `mb_sort` using the `-angledata` flag, in place of the data files. This skips the process of fitting the peaks and goes directly to the peak position determination, saving time and using the user provided values.

The next step is to include the phi angle constraints from the 22Ne on 196Pt data, but I first have to make the analysis for this.