### PR TITLE
Updates to detecting dodgy timestamps

### DIFF
--- a/include/Converter.hh
+++ b/include/Converter.hh
@@ -43,6 +43,7 @@ public:
 	~MiniballConverter() {};
 
 	void MakeHists();
+	void NewBuffer();
 	void ResetHists();
 	void MakeTree();
 	void StartFile();
@@ -163,7 +164,7 @@ protected:
 	std::vector<std::vector<unsigned long int>> ctr_febex_pause;   	// pause acq for module
 	std::vector<std::vector<unsigned long int>> ctr_febex_resume;  	// resume acq for module
 	unsigned long int ctr_febex_ext;								// pulser timestamps
-	unsigned long int jump_ctr, warp_ctr;							// count timestamp jumps and warps
+	unsigned long int jump_ctr, warp_ctr, mash_ctr;					// count timestamp jumps and warps
 	unsigned long int data_ctr;										// total number of data counted
 	unsigned long int reject_ctr;									// total number of reject buffers
 
@@ -182,8 +183,11 @@ protected:
 	TH1F *hhit_time;
 	
 	// Timestamp tracking
+	std::vector<bool> first_data;
+	std::vector<long long int> tm_stp_read;
 	std::vector<std::vector<long long int>> tm_stp_febex;
 	std::vector<std::vector<std::vector<long long int>>> tm_stp_febex_ch;
+
 
 	// 	Settings file
 	std::shared_ptr<MiniballSettings> set;

--- a/scripts/show_miniball_positions.cc
+++ b/scripts/show_miniball_positions.cc
@@ -2,6 +2,11 @@
 // in the x-y and theta-phi planes. It does not consider segment swaps.
 //
 // Written by Liam Gaffney (liam.gaffney@liverpool.ac.uk) - 20/02/2024
+//
+// To run you need to do the following in ROOT:
+// root [0]: .L show_miniball_positions.cc
+// root [1]: show_miniball_positions( "reaction.dat", "settings.dat" )
+// where the settings and reaction files match those from your experiment
 
 R__LOAD_LIBRARY(libmb_sort.so)
 

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -13,6 +13,9 @@ MiniballConverter::MiniballConverter( std::shared_ptr<MiniballSettings> myset ) 
 	ctr_febex_pause.resize( set->GetNumberOfFebexSfps() );
 	ctr_febex_resume.resize( set->GetNumberOfFebexSfps() );
 
+	first_data.resize( set->GetNumberOfFebexSfps(), true );
+
+	tm_stp_read.resize( set->GetNumberOfFebexSfps(), 0 );
 	tm_stp_febex.resize( set->GetNumberOfFebexSfps() );
 	tm_stp_febex_ch.resize( set->GetNumberOfFebexSfps() );
 
@@ -40,6 +43,17 @@ MiniballConverter::MiniballConverter( std::shared_ptr<MiniballSettings> myset ) 
 	
 }
 
+void MiniballConverter::NewBuffer(){
+
+	// Reset check on first data item per SFP
+	for( unsigned int i = 0; i < set->GetNumberOfFebexSfps(); ++i ) {
+
+		first_data[i] = true;
+		
+	}
+	
+}
+
 void MiniballConverter::StartFile(){
 	
 	// Start counters at zero
@@ -58,8 +72,9 @@ void MiniballConverter::StartFile(){
 
 	ctr_febex_ext = 0;	// pulser trigger
 	
-	jump_ctr = 0;	// timestamp jumps
-	warp_ctr = 0;	// timestamp warps
+	jump_ctr = 0;	// timestamp jumps (jumps more than 300s in same board)
+	warp_ctr = 0;	// timestamp warps (goes back in time, wrong board ID)
+	mash_ctr = 0;	// timestamp mashes (mangled bits, with 16-bit shift)
 	data_ctr = 0;	// total data items
 	reject_ctr = 0;	// rejected buffers
 	

--- a/src/MiniballAngleFitter.cc
+++ b/src/MiniballAngleFitter.cc
@@ -341,6 +341,10 @@ double MiniballAngleFunction::operator() ( const double *p ) {
 				double theta = myreact->GetGammaTheta( clu, cry, seg );
 				double phi = myreact->GetGammaPhi( clu, cry, seg );
 				
+				// Phi should be compared to user input, which will be 0˚-360˚
+				phi *= TMath::RadToDeg();
+				if( phi < 0 ) phi += 360.;
+				
 				// Zeroth parameter is beta
 				double beta = p[0];
 				


### PR DESCRIPTION
This update assumes that the first timestamp in a read is a good one, and it checks that all other timestamps from that SFP, in the same buffer, are within 30 seconds of that one.

This seems to get over some of the previous issues with bad timestamps, but I am still seeing time warps in the Hg data, which I thought wasn't possible. Will be interesting to test it on the plunger data to see if the buffer rejection is working.