### PR TITLE
Feature request for speeding up Histogrammer

### DIFF
--- a/include/Calibration.hh
+++ b/include/Calibration.hh
@@ -11,7 +11,7 @@
 
 #include "TSystem.h"
 #include "TEnv.h"
-#include "TRandom.h"
+#include "TRandom3.h"
 #include "TMath.h"
 #include "TGraph.h"
 
@@ -211,7 +211,7 @@ public:
 private:
 
 	std::string fInputFile;
-	std::unique_ptr<TRandom> fRand;
+	std::unique_ptr<TRandom3> fRand;
 	
 	bool default_qint;
 	

--- a/include/Converter.hh
+++ b/include/Converter.hh
@@ -76,7 +76,7 @@ public:
 		if( ebis_period == 0 ) return false;
 		else {
 			long long test_t = ( t - ebis_tm_stp ) % ebis_period;
-			return ( test_t < 4000000 );
+			return ( test_t < 4000000 && test_t > 0 );
 		}
 	};
 

--- a/include/Reaction.hh
+++ b/include/Reaction.hh
@@ -501,6 +501,8 @@ public:
 	inline bool IsRecoilDetected(){ return recoil_detected; };
 	inline bool IsTransferDetected(){ return transfer_detected; };
 
+	// Events tree options
+	inline bool EventsParticleGammaOnly(){ return events_particle_gamma; };
 	
 	// Histogram options
 	inline bool HistSegmentPhi(){ return hist_segment_phi; };
@@ -595,6 +597,9 @@ private:
 	
 	// Laser status mode: 0 = OFF, 1 = ON, 2 = OFF or ON
 	unsigned char laser_mode;
+	
+	// Events tree options
+	bool events_particle_gamma;
 	
 	// Histogram options
 	bool hist_segment_phi;

--- a/reaction.dat
+++ b/reaction.dat
@@ -77,7 +77,7 @@
 # EBIS time windows
 #EBIS.On: 1.20e6		# slow extraction is about 1.2 ms
 #EBIS.Off: 2.52e7		# Off window is 20 times the On window
-EBIS.FillRatio: 0.05	# default is equal to the time window ratio
+#EBIS.FillRatio: 0.05	# default is equal to the time window ratio
 
 # Particle and Gamma coincidence time windows
 #ParticleGamma_PromptTime.Min: -300		# lower limit of particle-gamma prompt window
@@ -122,6 +122,9 @@ EBIS.FillRatio: 0.05	# default is equal to the time window ratio
 #TransferCut.X: E			# variable along the x axis of the plot that is cut (default E, options: dE, E, theta)
 #TransferCut.Y: dE			# variable along the y axis of the plot that is cut (default dE, options: dE, E, theta)
 
+
+## Read events
+#Events.ParticleGammaOnly: false	# only include events with particle-gamma coincidences when reading from events tree
 
 ## Histogram options
 #Histograms.SegmentPhi: false		# turn on/off the making of segment-by-sgement phi histograms (default false = off)

--- a/src/Calibration.cc
+++ b/src/Calibration.cc
@@ -206,7 +206,7 @@ MiniballCalibration::MiniballCalibration( std::string filename, std::shared_ptr<
 
 	SetFile( filename );
 	set = myset;
-	fRand = std::make_unique<TRandom>();
+	fRand = std::make_unique<TRandom3>();
 	default_qint = false;
 
 }

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -2493,7 +2493,7 @@ unsigned long MiniballHistogrammer::FillHists() {
 				ic_E->Fill( ic_evt->GetEnergyRest() );
 				
 				// 2D plot
-				ic_dE_E->Fill( ic_evt->GetEnergyRest(), ic_evt->GetEnergyLoss() );
+				ic_dE_E->Fill( ic_evt->GetEnergyLoss(), ic_evt->GetEnergyRest() );
 				
 			} // j: ion chamber
 			

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -1962,8 +1962,8 @@ unsigned long MiniballHistogrammer::FillHists() {
 				// Time differences by sector
 				if( react->HistBySector() ) {
 					
-					gamma_particle_td_sec[particle_evt->GetDetector()]->Fill( (double)particle_evt->GetTime() - (double)gamma_evt->GetTime() );
-					gamma_particle_E_vs_td_sec[particle_evt->GetDetector()]->Fill( (double)particle_evt->GetTime() - (double)gamma_evt->GetTime(), gamma_evt->GetEnergy() );
+					gamma_particle_td_sec[particle_evt->GetSector()]->Fill( (double)particle_evt->GetTime() - (double)gamma_evt->GetTime() );
+					gamma_particle_E_vs_td_sec[particle_evt->GetSector()]->Fill( (double)particle_evt->GetTime() - (double)gamma_evt->GetTime(), gamma_evt->GetEnergy() );
 					
 				}
 				

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -1911,6 +1911,10 @@ unsigned long MiniballHistogrammer::FillHists() {
 		// Test if we want to plot this event or not
 		if( laser_status != laser_mode && laser_mode != 2 ) continue;
 		
+		// Check if it we are restricting to particle-gamma events
+		int g_e_mult = read_evts->GetGammaRayMultiplicity() + read_evts->GetSpedeMultiplicity();
+		if( ( read_evts->GetParticleMultiplicity() == 0 || g_e_mult == 0 )
+		   && react->EventsParticleGammaOnly() ) continue;
 		
 		// ------------------------- //
 		// Loop over particle events //

--- a/src/Reaction.cc
+++ b/src/Reaction.cc
@@ -258,6 +258,9 @@ void MiniballReaction::ReadReaction() {
 	EBIS_Off = config->GetValue( "EBIS.Off", 2.52e7 );	// this allows a off window 20 times bigger than on
 	EBIS_ratio = config->GetValue( "EBIS.FillRatio", GetEBISTimeRatio() );	// this is the measured ratio of EBIS On/off. Default is just the time window ratio
 	
+	// Events tree options
+	events_particle_gamma = config->GetValue( "Events.ParticleGammaOnly", false );	// only do histogramming for particle-gamma coincidences to speed things up
+
 	// Histogram options
 	hist_segment_phi = config->GetValue( "Histograms.SegmentPhi", false );	// turn on histograms for segment phi
 	hist_by_crystal = config->GetValue( "Histograms.ByCrystal", false );	// turn on histograms for gamma-gamma


### PR DESCRIPTION
Fillipo was asking about the possibilty of making a copy of the events tree with only particle-gamma coincidences in it to speed up the histogramming step. I made a more primitive way of doing this with a new user option in the reaction file `Events.ParticleGammaOnly`. Default is false, so turned off and all events are histogrammed as before.

Also contains a couple of bug fixes for plotting particle-gamma time differences for each CD sector/quadrant and the ski-slop effect seen in the EBIS-gamma time difference plot when using the -ebis flag.
