### PR TITLE
add option for making a T1 cut

### DIFF
--- a/include/Histogrammer.hh
+++ b/include/Histogrammer.hh
@@ -215,6 +215,11 @@ public:
 			(double)s->GetTime() - (double)read_evts->GetEBIS() < react->GetEBISOffTime() ) return true;
 		else return false;
 	};
+	inline bool T1Cut(){
+		if( (double)read_evts->GetEBIS() - (double)read_evts->GetT1() >= react->GetT1MinTime() &&
+		    (double)read_evts->GetEBIS() - (double)read_evts->GetT1() < react->GetT1MaxTime() ) return true;
+		else return false;
+	}
 
 	// Particle energy vs angle cuts
 	inline bool TransferCut( std::shared_ptr<ParticleEvt> p ){

--- a/include/Reaction.hh
+++ b/include/Reaction.hh
@@ -367,6 +367,12 @@ public:
 	inline double GetEBISOffTime(){ return EBIS_Off; };
 	inline double GetEBISTimeRatio(){ return EBIS_On / ( EBIS_Off - EBIS_On ); };
 	inline double GetEBISFillRatio(){ return EBIS_ratio; };
+	
+	
+	// Get T1 times
+	inline bool GetT1Cut(){ return t1_cut; };
+	inline double GetT1MinTime(){ return t1_time[0]; };
+	inline double GetT1MaxTime(){ return t1_time[1]; };
 
 	// Get particle gamma coincidence times
 	inline double GetParticleGammaPromptTime( unsigned char i ){
@@ -551,6 +557,10 @@ private:
 	double EBIS_On;		///< beam on max time in ns
 	double EBIS_Off;	///< beam off max time in ns
 	double EBIS_ratio;	///< ratio of ebis on/off as measured
+
+	// T1 cut times
+	bool t1_cut;		///< enable/disable T1 cuts on data
+	double t1_time[2];	///< event time - T1 cut window
 	
 	// Particle and Gamma coincidences windows
 	int pg_prompt[2];	// particle-gamma prompt

--- a/reaction.dat
+++ b/reaction.dat
@@ -79,6 +79,12 @@
 #EBIS.Off: 2.52e7		# Off window is 20 times the On window
 #EBIS.FillRatio: 0.05	# default is equal to the time window ratio
 
+# T1 cut
+#T1.Cut: false			# set to true to enable gating on the T1 time
+#T1.Min: 0.0			# [ns] lower limit of event time with respect to T1 time for cut
+#T1.Max: 1.2e9			# [ns] upper limit of event time with respect to T1 time for cut
+
+
 # Particle and Gamma coincidence time windows
 #ParticleGamma_PromptTime.Min: -300		# lower limit of particle-gamma prompt window
 #ParticleGamma_PromptTime.Max: 300		# upper limit of particle-gamma prompt window

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -1911,6 +1911,9 @@ unsigned long MiniballHistogrammer::FillHists() {
 		// Test if we want to plot this event or not
 		if( laser_status != laser_mode && laser_mode != 2 ) continue;
 		
+		// Apply the T1 cut if requested by the user
+		if( react->GetT1Cut() && !T1Cut() ) continue;
+		
 		// Check if it we are restricting to particle-gamma events
 		int g_e_mult = read_evts->GetGammaRayMultiplicity() + read_evts->GetSpedeMultiplicity();
 		if( ( read_evts->GetParticleMultiplicity() == 0 || g_e_mult == 0 )

--- a/src/Reaction.cc
+++ b/src/Reaction.cc
@@ -258,6 +258,11 @@ void MiniballReaction::ReadReaction() {
 	EBIS_Off = config->GetValue( "EBIS.Off", 2.52e7 );	// this allows a off window 20 times bigger than on
 	EBIS_ratio = config->GetValue( "EBIS.FillRatio", GetEBISTimeRatio() );	// this is the measured ratio of EBIS On/off. Default is just the time window ratio
 	
+	// T1 cuts
+	t1_cut = config->GetValue( "T1.Cut", false );		// enable or disable the T1 cuts
+	t1_time[0] = config->GetValue( "T1.Min", 0.0 );		// minimum T1 time for cut (ns), default 0
+	t1_time[1] = config->GetValue( "T1.Max", 1.2e9 );	// maximum T1 time for cut (ns), default 1.2 seconds
+	
 	// Events tree options
 	events_particle_gamma = config->GetValue( "Events.ParticleGammaOnly", false );	// only do histogramming for particle-gamma coincidences to speed things up
 


### PR DESCRIPTION
New option in reaction file to apply a T1 cut to the data. 

```
# T1 cut
#T1.Cut: false			# set to true to enable gating on the T1 time
#T1.Min: 0.0			# [ns] lower limit of event time with respect to T1 time for cut
#T1.Max: 1.2e9			# [ns] upper limit of event time with respect to T1 time for cut
```