### PR TITLE
Updates to calibration file logic and some histogrammer improvements

### DIFF
--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pages: write
     steps:
       - uses: DenverCoder1/doxygen-github-pages-action@v2.0.0
         with:

--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: write
       pages: write
+      pull-requests: write
     steps:
       - uses: DenverCoder1/doxygen-github-pages-action@v2.0.0
         with:

--- a/calibration.dat
+++ b/calibration.dat
@@ -27,5 +27,10 @@
 # febex_<sfp>_<board>_<ch>.CFD.HoldOff:				# this is equivalent to 'CFD Delay', i.e. the hold-off time of the CFD (from initual LED threshold crossing).
 
 
-# The above can be set to some default parameters, and then overridden on a channel-by-channel basis using
-#febex_default.<parameter>:
+# The above can be set to some default parameters
+#febex.<parameter>: <value>
+
+# Which can be overridden on an SFP, board or channel basis
+#febex_<sfp>.<parameter>: <value>
+#febex_<sfp>_<board>.<parameter>: <value>
+#febex_<sfp>_<board>_<ch>.<parameter>: <value>

--- a/include/Calibration.hh
+++ b/include/Calibration.hh
@@ -253,17 +253,17 @@ private:
 	std::vector< std::vector<std::vector<float>> > fFebexCFD_Fraction;
 
 	// MWD defaults
-	unsigned int default_MWD_Decay;
-	unsigned int default_MWD_Rise;
-	unsigned int default_MWD_Top;
-	unsigned int default_MWD_Baseline;
-	unsigned int default_MWD_Window;
-	float default_CFD_Fraction;
-	unsigned int default_CFD_Delay;
-	unsigned int default_CFD_HoldOff;
-	unsigned int default_CFD_Shaping;
-	unsigned int default_CFD_Integration;
-	int default_CFD_Threshold;
+	unsigned int default_FebexMWD_Decay;
+	unsigned int default_FebexMWD_Rise;
+	unsigned int default_FebexMWD_Top;
+	unsigned int default_FebexMWD_Baseline;
+	unsigned int default_FebexMWD_Window;
+	float default_FebexCFD_Fraction;
+	unsigned int default_FebexCFD_Delay;
+	unsigned int default_FebexCFD_HoldOff;
+	unsigned int default_FebexCFD_Shaping;
+	unsigned int default_FebexCFD_Integration;
+	int default_FebexCFD_Threshold;
 
 	
 	ClassDef( MiniballCalibration, 4 )

--- a/include/Histogrammer.hh
+++ b/include/Histogrammer.hh
@@ -360,36 +360,52 @@ private:
 	TH2F *aE_costheta_ejectile, *aE_costheta_recoil;
 
 	// Doppler-corrected gamma-rays without addback
-	TH1F *gE_ejectile_dc_none, *gE_ejectile_dc_ejectile, *gE_ejectile_dc_recoil;
-	TH1F *gE_recoil_dc_none,   *gE_recoil_dc_ejectile,   *gE_recoil_dc_recoil;
-	TH1F *gE_2p_dc_none,       *gE_2p_dc_ejectile,       *gE_2p_dc_recoil;
-	TH2F *gE_ejectile_dc_ejectile_t1, *gE_ejectile_dc_recoil_t1;
-	TH2F *gE_recoil_dc_ejectile_t1,   *gE_recoil_dc_recoil_t1;
-	TH2F *gE_2p_dc_ejectile_t1,       *gE_2p_dc_recoil_t1;
-	TH2F *gE_vs_theta_ejectile_dc_none, *gE_vs_theta_ejectile_dc_ejectile, *gE_vs_theta_ejectile_dc_recoil;
-	TH2F *gE_vs_theta_recoil_dc_none,   *gE_vs_theta_recoil_dc_ejectile,   *gE_vs_theta_recoil_dc_recoil;
-	TH2F *gE_vs_theta_2p_dc_none,       *gE_vs_theta_2p_dc_ejectile,       *gE_vs_theta_2p_dc_recoil;
-	TH2F *gE_vs_crystal_ejectile_dc_none, *gE_vs_crystal_ejectile_dc_ejectile, *gE_vs_crystal_ejectile_dc_recoil;
-	TH2F *gE_vs_crystal_recoil_dc_none,   *gE_vs_crystal_recoil_dc_ejectile,   *gE_vs_crystal_recoil_dc_recoil;
-	TH2F *gE_vs_crystal_2p_dc_none,       *gE_vs_crystal_2p_dc_ejectile,       *gE_vs_crystal_2p_dc_recoil;
-	TH2F *ggE_ejectile_dc_none, *ggE_ejectile_dc_ejectile, *ggE_ejectile_dc_recoil;
-	TH2F *ggE_recoil_dc_none,   *ggE_recoil_dc_ejectile,   *ggE_recoil_dc_recoil;
+	TH1F *gE_ejectile_dc_none,               *gE_ejectile_dc_ejectile,               *gE_ejectile_dc_recoil;
+	TH1F *gE_recoil_dc_none,                 *gE_recoil_dc_ejectile,                 *gE_recoil_dc_recoil;
+	TH1F *gE_1p_ejectile_dc_none,            *gE_1p_ejectile_dc_ejectile,            *gE_1p_ejectile_dc_recoil;
+	TH1F *gE_1p_recoil_dc_none,              *gE_1p_recoil_dc_ejectile,              *gE_1p_recoil_dc_recoil;
+	TH1F *gE_2p_dc_none,                     *gE_2p_dc_ejectile,                     *gE_2p_dc_recoil;
+	TH2F *gE_ejectile_dc_none_t1,            *gE_ejectile_dc_ejectile_t1,            *gE_ejectile_dc_recoil_t1;
+	TH2F *gE_recoil_dc_none_t1,              *gE_recoil_dc_ejectile_t1,              *gE_recoil_dc_recoil_t1;
+	TH2F *gE_1p_ejectile_dc_none_t1,         *gE_1p_ejectile_dc_ejectile_t1,         *gE_1p_ejectile_dc_recoil_t1;
+	TH2F *gE_1p_recoil_dc_none_t1,           *gE_1p_recoil_dc_ejectile_t1,           *gE_1p_recoil_dc_recoil_t1;
+	TH2F *gE_2p_dc_none_t1,                  *gE_2p_dc_ejectile_t1,                  *gE_2p_dc_recoil_t1;
+	TH2F *gE_vs_theta_ejectile_dc_none,      *gE_vs_theta_ejectile_dc_ejectile,      *gE_vs_theta_ejectile_dc_recoil;
+	TH2F *gE_vs_theta_recoil_dc_none,        *gE_vs_theta_recoil_dc_ejectile,        *gE_vs_theta_recoil_dc_recoil;
+	TH2F *gE_vs_theta_1p_ejectile_dc_none,   *gE_vs_theta_1p_ejectile_dc_ejectile,   *gE_vs_theta_1p_ejectile_dc_recoil;
+	TH2F *gE_vs_theta_1p_recoil_dc_none,     *gE_vs_theta_1p_recoil_dc_ejectile,     *gE_vs_theta_1p_recoil_dc_recoil;
+	TH2F *gE_vs_theta_2p_dc_none,            *gE_vs_theta_2p_dc_ejectile,            *gE_vs_theta_2p_dc_recoil;
+	TH2F *gE_vs_crystal_ejectile_dc_none,    *gE_vs_crystal_ejectile_dc_ejectile,    *gE_vs_crystal_ejectile_dc_recoil;
+	TH2F *gE_vs_crystal_recoil_dc_none,      *gE_vs_crystal_recoil_dc_ejectile,      *gE_vs_crystal_recoil_dc_recoil;
+	TH2F *gE_vs_crystal_1p_ejectile_dc_none, *gE_vs_crystal_1p_ejectile_dc_ejectile, *gE_vs_crystal_1p_ejectile_dc_recoil;
+	TH2F *gE_vs_crystal_1p_recoil_dc_none,   *gE_vs_crystal_1p_recoil_dc_ejectile,   *gE_vs_crystal_1p_recoil_dc_recoil;
+	TH2F *gE_vs_crystal_2p_dc_none,          *gE_vs_crystal_2p_dc_ejectile,          *gE_vs_crystal_2p_dc_recoil;
+	TH2F *ggE_ejectile_dc_none,              *ggE_ejectile_dc_ejectile,              *ggE_ejectile_dc_recoil;
+	TH2F *ggE_recoil_dc_none,                *ggE_recoil_dc_ejectile,                *ggE_recoil_dc_recoil;
 
 	// Doppler-corrected gamma-rays with addback
-	TH1F *aE_ejectile_dc_none, *aE_ejectile_dc_ejectile, *aE_ejectile_dc_recoil;
-	TH1F *aE_recoil_dc_none,   *aE_recoil_dc_ejectile,   *aE_recoil_dc_recoil;
-	TH1F *aE_2p_dc_none,       *aE_2p_dc_ejectile,       *aE_2p_dc_recoil;
-	TH2F *aE_ejectile_dc_ejectile_t1, *aE_ejectile_dc_recoil_t1;
-	TH2F *aE_recoil_dc_ejectile_t1,   *aE_recoil_dc_recoil_t1;
-	TH2F *aE_2p_dc_ejectile_t1,       *aE_2p_dc_recoil_t1;
-	TH2F *aE_vs_theta_ejectile_dc_none, *aE_vs_theta_ejectile_dc_ejectile, *aE_vs_theta_ejectile_dc_recoil;
-	TH2F *aE_vs_theta_recoil_dc_none,   *aE_vs_theta_recoil_dc_ejectile,   *aE_vs_theta_recoil_dc_recoil;
-	TH2F *aE_vs_theta_2p_dc_none,       *aE_vs_theta_2p_dc_ejectile,       *aE_vs_theta_2p_dc_recoil;
-	TH2F *aE_vs_crystal_ejectile_dc_none, *aE_vs_crystal_ejectile_dc_ejectile, *aE_vs_crystal_ejectile_dc_recoil;
-	TH2F *aE_vs_crystal_recoil_dc_none,   *aE_vs_crystal_recoil_dc_ejectile,   *aE_vs_crystal_recoil_dc_recoil;
-	TH2F *aE_vs_crystal_2p_dc_none,       *aE_vs_crystal_2p_dc_ejectile,       *aE_vs_crystal_2p_dc_recoil;
-	TH2F *aaE_ejectile_dc_none, *aaE_ejectile_dc_ejectile, *aaE_ejectile_dc_recoil;
-	TH2F *aaE_recoil_dc_none,   *aaE_recoil_dc_ejectile,   *aaE_recoil_dc_recoil;
+	TH1F *aE_ejectile_dc_none,               *aE_ejectile_dc_ejectile,               *aE_ejectile_dc_recoil;
+	TH1F *aE_recoil_dc_none,                 *aE_recoil_dc_ejectile,                 *aE_recoil_dc_recoil;
+	TH1F *aE_1p_ejectile_dc_none,            *aE_1p_ejectile_dc_ejectile,            *aE_1p_ejectile_dc_recoil;
+	TH1F *aE_1p_recoil_dc_none,              *aE_1p_recoil_dc_ejectile,              *aE_1p_recoil_dc_recoil;
+	TH1F *aE_2p_dc_none,                     *aE_2p_dc_ejectile,                     *aE_2p_dc_recoil;
+	TH2F *aE_ejectile_dc_none_t1,            *aE_ejectile_dc_ejectile_t1,            *aE_ejectile_dc_recoil_t1;
+	TH2F *aE_recoil_dc_none_t1,              *aE_recoil_dc_ejectile_t1,              *aE_recoil_dc_recoil_t1;
+	TH2F *aE_1p_ejectile_dc_none_t1,         *aE_1p_ejectile_dc_ejectile_t1,         *aE_1p_ejectile_dc_recoil_t1;
+	TH2F *aE_1p_recoil_dc_none_t1,           *aE_1p_recoil_dc_ejectile_t1,           *aE_1p_recoil_dc_recoil_t1;
+	TH2F *aE_2p_dc_none_t1,                  *aE_2p_dc_ejectile_t1,                  *aE_2p_dc_recoil_t1;
+	TH2F *aE_vs_theta_ejectile_dc_none,      *aE_vs_theta_ejectile_dc_ejectile,      *aE_vs_theta_ejectile_dc_recoil;
+	TH2F *aE_vs_theta_recoil_dc_none,        *aE_vs_theta_recoil_dc_ejectile,        *aE_vs_theta_recoil_dc_recoil;
+	TH2F *aE_vs_theta_1p_ejectile_dc_none,   *aE_vs_theta_1p_ejectile_dc_ejectile,   *aE_vs_theta_1p_ejectile_dc_recoil;
+	TH2F *aE_vs_theta_1p_recoil_dc_none,     *aE_vs_theta_1p_recoil_dc_ejectile,     *aE_vs_theta_1p_recoil_dc_recoil;
+	TH2F *aE_vs_theta_2p_dc_none,            *aE_vs_theta_2p_dc_ejectile,            *aE_vs_theta_2p_dc_recoil;
+	TH2F *aE_vs_crystal_ejectile_dc_none,    *aE_vs_crystal_ejectile_dc_ejectile,    *aE_vs_crystal_ejectile_dc_recoil;
+	TH2F *aE_vs_crystal_recoil_dc_none,      *aE_vs_crystal_recoil_dc_ejectile,      *aE_vs_crystal_recoil_dc_recoil;
+	TH2F *aE_vs_crystal_1p_ejectile_dc_none, *aE_vs_crystal_1p_ejectile_dc_ejectile, *aE_vs_crystal_1p_ejectile_dc_recoil;
+	TH2F *aE_vs_crystal_1p_recoil_dc_none,   *aE_vs_crystal_1p_recoil_dc_ejectile,   *aE_vs_crystal_1p_recoil_dc_recoil;
+	TH2F *aE_vs_crystal_2p_dc_none,          *aE_vs_crystal_2p_dc_ejectile,          *aE_vs_crystal_2p_dc_recoil;
+	TH2F *aaE_ejectile_dc_none,              *aaE_ejectile_dc_ejectile,              *aaE_ejectile_dc_recoil;
+	TH2F *aaE_recoil_dc_none,                *aaE_recoil_dc_ejectile,                *aaE_recoil_dc_recoil;
 
 	// Segment phi determination
 	std::vector<TH2F*> gE_vs_phi_dc_ejectile;
@@ -399,18 +415,22 @@ private:
 	TH2F *eE_costheta_ejectile, *eE_costheta_recoil;
   
 	// Doppler-corrected electrons
-	TH1F *eE_ejectile_dc_none, *eE_ejectile_dc_ejectile, *eE_ejectile_dc_recoil;
-	TH1F *eE_recoil_dc_none,   *eE_recoil_dc_ejectile,   *eE_recoil_dc_recoil;
-	TH1F *eE_2p_dc_none,       *eE_2p_dc_ejectile,       *eE_2p_dc_recoil;
-	TH2F *eE_vs_theta_ejectile_dc_none, *eE_vs_theta_ejectile_dc_ejectile, *eE_vs_theta_ejectile_dc_recoil;
-	TH2F *eE_vs_theta_recoil_dc_none,   *eE_vs_theta_recoil_dc_ejectile,   *eE_vs_theta_recoil_dc_recoil;
-	TH2F *eE_vs_theta_2p_dc_none,       *eE_vs_theta_2p_dc_ejectile,       *eE_vs_theta_2p_dc_recoil;
-	TH2F *eE_vs_ejectile_dc_none_segment, *eE_vs_ejectile_dc_ejectile_segment, *eE_vs_ejectile_dc_recoil_segment;
-	TH2F *eE_vs_recoil_dc_none_segment,   *eE_vs_recoil_dc_ejectile_segment,   *eE_vs_recoil_dc_recoil_segment;
-	TH2F *egE_ejectile_dc_none, *egE_ejectile_dc_ejectile, *egE_ejectile_dc_recoil;
-	TH2F *egE_recoil_dc_none,   *egE_recoil_dc_ejectile,   *egE_recoil_dc_recoil;
-	TH2F *eaE_ejectile_dc_none, *eaE_ejectile_dc_ejectile, *eaE_ejectile_dc_recoil;
-	TH2F *eaE_recoil_dc_none,   *eaE_recoil_dc_ejectile,   *eaE_recoil_dc_recoil;
+	TH1F *eE_ejectile_dc_none,             *eE_ejectile_dc_ejectile,             *eE_ejectile_dc_recoil;
+	TH1F *eE_recoil_dc_none,               *eE_recoil_dc_ejectile,               *eE_recoil_dc_recoil;
+	TH1F *eE_1p_ejectile_dc_none,          *eE_1p_ejectile_dc_ejectile,          *eE_1p_ejectile_dc_recoil;
+	TH1F *eE_1p_recoil_dc_none,            *eE_1p_recoil_dc_ejectile,            *eE_1p_recoil_dc_recoil;
+	TH1F *eE_2p_dc_none,                   *eE_2p_dc_ejectile,                   *eE_2p_dc_recoil;
+	TH2F *eE_vs_theta_ejectile_dc_none,    *eE_vs_theta_ejectile_dc_ejectile,    *eE_vs_theta_ejectile_dc_recoil;
+	TH2F *eE_vs_theta_recoil_dc_none,      *eE_vs_theta_recoil_dc_ejectile,      *eE_vs_theta_recoil_dc_recoil;
+	TH2F *eE_vs_theta_1p_ejectile_dc_none, *eE_vs_theta_1p_ejectile_dc_ejectile, *eE_vs_theta_1p_ejectile_dc_recoil;
+	TH2F *eE_vs_theta_1p_recoil_dc_none,   *eE_vs_theta_1p_recoil_dc_ejectile,   *eE_vs_theta_1p_recoil_dc_recoil;
+	TH2F *eE_vs_theta_2p_dc_none,          *eE_vs_theta_2p_dc_ejectile,          *eE_vs_theta_2p_dc_recoil;
+	TH2F *eE_vs_ejectile_dc_none_segment,  *eE_vs_ejectile_dc_ejectile_segment,  *eE_vs_ejectile_dc_recoil_segment;
+	TH2F *eE_vs_recoil_dc_none_segment,    *eE_vs_recoil_dc_ejectile_segment,    *eE_vs_recoil_dc_recoil_segment;
+	TH2F *egE_ejectile_dc_none,            *egE_ejectile_dc_ejectile,            *egE_ejectile_dc_recoil;
+	TH2F *egE_recoil_dc_none,              *egE_recoil_dc_ejectile,              *egE_recoil_dc_recoil;
+	TH2F *eaE_ejectile_dc_none,            *eaE_ejectile_dc_ejectile,            *eaE_ejectile_dc_recoil;
+	TH2F *eaE_recoil_dc_none,              *eaE_recoil_dc_ejectile,              *eaE_recoil_dc_recoil;
 
 	// Beam-dump histograms
 	TH1F *bdE_singles;

--- a/include/Reaction.hh
+++ b/include/Reaction.hh
@@ -513,6 +513,7 @@ public:
 	// Histogram options
 	inline bool HistSegmentPhi(){ return hist_segment_phi; };
 	inline bool HistByCrystal(){ return hist_by_crystal; };
+	inline bool HistByMultiplicity(){ return hist_by_pmult; };
 	inline bool HistBySector(){ return hist_by_sector; };
 	inline bool HistByT1(){ return hist_by_t1; };
 	inline bool HistGammaGamma(){ return hist_gamma_gamma; };
@@ -615,6 +616,7 @@ private:
 	// Histogram options
 	bool hist_segment_phi;
 	bool hist_by_crystal;
+	bool hist_by_pmult;
 	bool hist_by_sector;
 	bool hist_by_t1;
 	bool hist_gamma_gamma;

--- a/include/Reaction.hh
+++ b/include/Reaction.hh
@@ -564,20 +564,20 @@ private:
 	double t1_time[2];	///< event time - T1 cut window
 	
 	// Particle and Gamma coincidences windows
-	int pg_prompt[2];	// particle-gamma prompt
-	int pg_random[2];	// particle-gamma random
-	int gg_prompt[2];	// gamma-gamma prompt
-	int gg_random[2];	// gamma-gamma random
-	int pp_prompt[2];	// particle-particle prompt
-	int pp_random[2];	// particle-particle random
-	int ge_prompt[2];	// gamma-electron prompt
-	int ge_random[2];	// gamma-electron random
-	int ee_prompt[2];	// electron-electron prompt
-	int ee_random[2];	// electron-electron random
-	int pe_prompt[2];	// particle-electron prompt
-	int pe_random[2];	// particle-electron random
-	double pg_ratio, gg_ratio, pp_ratio; // fill ratios
-	double pe_ratio, ge_ratio, ee_ratio; // fill ratios
+	int pg_prompt[2];	///< particle-gamma prompt
+	int pg_random[2];	///< particle-gamma random
+	int gg_prompt[2];	///< gamma-gamma prompt
+	int gg_random[2];	///< gamma-gamma random
+	int pp_prompt[2];	///< particle-particle prompt
+	int pp_random[2];	///< particle-particle random
+	int ge_prompt[2];	///< gamma-electron prompt
+	int ge_random[2];	///< gamma-electron random
+	int ee_prompt[2];	///< electron-electron prompt
+	int ee_random[2];	///< electron-electron random
+	int pe_prompt[2];	///< particle-electron prompt
+	int pe_random[2];	///< particle-electron random
+	double pg_ratio, gg_ratio, pp_ratio; ///< fill ratios
+	double pe_ratio, ge_ratio, ee_ratio; ///< fill ratios
 
 	// Target thickness and offsets
 	double target_thickness;	///< target thickness in units of mg/cm^2
@@ -599,15 +599,15 @@ private:
 	double spede_dist;	///< distance from target to SPEDE detector
 	double spede_offset;	///< phi rotation of the SPEDE detector
 	
-	// Doppler mode, calculating the velocity for Doppler correction
-	// 0 = use angles and two-body kinematics at centre of the target
-	// 1 = like 0, but corrected for energy loss through the back of the target
-	// 2 = use energy of particle in the CD detector
-	// 3 = like 2, but corrected for energy loss in dead-layer and back of the target
-	unsigned char doppler_mode;
+	unsigned char doppler_mode; 	///< Doppler mode, calculating the velocity for Doppler correction
+									///< 0 = use angles and two-body kinematics at centre of the target
+									///< 1 = like 0, but corrected for energy loss through the back of the target
+									///< 2 = use energy of particle in the CD detector
+									///< 3 = like 2, but corrected for energy loss in dead-layer
+
 	
-	// Laser status mode: 0 = OFF, 1 = ON, 2 = OFF or ON
-	unsigned char laser_mode;
+	unsigned char laser_mode;		///< Laser status mode:
+									///< 0 = OFF, 1 = ON, 2 = OFF or ON
 	
 	// Events tree options
 	bool events_particle_gamma;

--- a/reaction.dat
+++ b/reaction.dat
@@ -135,6 +135,7 @@
 ## Histogram options
 #Histograms.SegmentPhi: false		# turn on/off the making of segment-by-sgement phi histograms (default false = off)
 #Histograms.ByCrystal: false		# turn on/off the individual crystal by crystal Doppler corrected spectra (default false = off)
+#Histograms.ByMultiplicity: false	# turn on/off the particle-gamma(-electron) spectra by multiplicity, i.e. 1p and 2p spectra (default false = off)
 #Histograms.BySector: false			# turn on/off the sector-by-sector plots for particle histograms (default false = off)
 #Histograms.ByT1: false				# turn on/off the sector-by-sector plots for particle histograms (default false = off)
 #Histograms.GammaGamma: true		# turn on/off the gamma-gamma histograms (default true = on)

--- a/src/Calibration.cc
+++ b/src/Calibration.cc
@@ -385,14 +385,20 @@ void MiniballCalibration::ReadCalibration() {
 		fAdcGainQuadr[i].resize( set->GetMaximumNumberOfAdcChannels() );
 		fAdcThreshold[i].resize( set->GetMaximumNumberOfAdcChannels() );
 		fAdcTime[i].resize( set->GetMaximumNumberOfAdcChannels() );
-	
+		
+		double defaultAdcOffset = config->GetValue( Form( "adc_%d.Offset", i ), (double)0.0 );
+		double defaultAdcGain = config->GetValue( Form( "adc_%d.Gain", i ), (double)1.0 );
+		double defaultAdcGainQuadr = config->GetValue( Form( "adc_%d.GainQuadr", i ), (double)0.0 );
+		unsigned int defaultAdcThreshold = (unsigned int)config->GetValue( Form( "adc_%d.Threshold", i ), (double)0 );
+		long defaultAdcTime = (long)config->GetValue( Form( "adc_%d.Time", i ), (double)0 );
+
 		for( unsigned char j = 0; j < set->GetMaximumNumberOfAdcChannels(); j++ ){
 
-			fAdcOffset[i][j] = config->GetValue( Form( "adc_%d_%d.Offset", i, j ), (double)0.0 );
-			fAdcGain[i][j] = config->GetValue( Form( "adc_%d_%d.Gain", i, j ), (double)1.0 );
-			fAdcGainQuadr[i][j] = config->GetValue( Form( "adc_%d_%d.GainQuadr", i, j ), (double)0.0 );
-			fAdcThreshold[i][j] = (unsigned int)config->GetValue( Form( "adc_%d_%d.Threshold", i, j ), (double)0 );
-			fAdcTime[i][j] = (long)config->GetValue( Form( "adc_%d_%d.Time", i, j ), (double)0 );
+			fAdcOffset[i][j] = config->GetValue( Form( "adc_%d_%d.Offset", i, j ), (double)defaultAdcOffset );
+			fAdcGain[i][j] = config->GetValue( Form( "adc_%d_%d.Gain", i, j ), (double)defaultAdcGain );
+			fAdcGainQuadr[i][j] = config->GetValue( Form( "adc_%d_%d.GainQuadr", i, j ), (double)defaultAdcGainQuadr );
+			fAdcThreshold[i][j] = (unsigned int)config->GetValue( Form( "adc_%d_%d.Threshold", i, j ), (double)defaultAdcThreshold );
+			fAdcTime[i][j] = (long)config->GetValue( Form( "adc_%d_%d.Time", i, j ), (double)defaultAdcTime );
 			
 		}
 
@@ -414,13 +420,19 @@ void MiniballCalibration::ReadCalibration() {
 		fDgfThreshold[i].resize( set->GetNumberOfDgfChannels() );
 		fDgfTime[i].resize( set->GetNumberOfDgfChannels() );
 	
+		double defaultDgfOffset = config->GetValue( Form( "dgf_%d.Offset", i ), (double)0.0 );
+		double defaultDgfGain = config->GetValue( Form( "dgf_%d.Gain", i ), (double)1.0 );
+		double defaultDgfGainQuadr = config->GetValue( Form( "dgf_%d.GainQuadr", i ), (double)0.0 );
+		unsigned int defaultDgfThreshold = (unsigned int)config->GetValue( Form( "dgf_%d.Threshold", i ), (double)0 );
+		long defaultDgfTime = (long)config->GetValue( Form( "dgf_%d.Time", i ), (double)0 );
+		
 		for( unsigned char j = 0; j < set->GetNumberOfDgfChannels(); j++ ){
 
-			fDgfOffset[i][j] = config->GetValue( Form( "dgf_%d_%d.Offset", i, j ), (double)0.0 );
-			fDgfGain[i][j] = config->GetValue( Form( "dgf_%d_%d.Gain", i, j ), (double)1.0 );
-			fDgfGainQuadr[i][j] = config->GetValue( Form( "dgf_%d_%d.GainQuadr", i, j ), (double)0.0 );
-			fDgfThreshold[i][j] = (unsigned int)config->GetValue( Form( "dgf_%d_%d.Threshold", i, j ), (double)0 );
-			fDgfTime[i][j] = (long)config->GetValue( Form( "dgf_%d_%d.Time", i, j ), (double)0 );
+			fDgfOffset[i][j] = config->GetValue( Form( "dgf_%d_%d.Offset", i, j ), (double)defaultDgfOffset );
+			fDgfGain[i][j] = config->GetValue( Form( "dgf_%d_%d.Gain", i, j ), (double)defaultDgfGain );
+			fDgfGainQuadr[i][j] = config->GetValue( Form( "dgf_%d_%d.GainQuadr", i, j ), (double)defaultDgfGainQuadr );
+			fDgfThreshold[i][j] = (unsigned int)config->GetValue( Form( "dgf_%d_%d.Threshold", i, j ), (double)defaultDgfThreshold );
+			fDgfTime[i][j] = (long)config->GetValue( Form( "dgf_%d_%d.Time", i, j ), (double)defaultDgfTime );
 			
 		}
 

--- a/src/Calibration.cc
+++ b/src/Calibration.cc
@@ -215,21 +215,17 @@ void MiniballCalibration::ReadCalibration() {
 
 	std::unique_ptr<TEnv> config = std::make_unique<TEnv>( fInputFile.data() );
 	
-	default_MWD_Decay		= 5000;
-	default_MWD_Rise		= 780; // L
-	default_MWD_Top			= 870; // mwd_cfd_trig_delay
-	default_MWD_Baseline	= 60;  // delay MWD in James' firmware
-	default_MWD_Window		= 880; // M
-	default_CFD_Delay		= 30;
-	default_CFD_HoldOff		= 100; // prevent double triggering?
-	default_CFD_Shaping		= 15;
-	default_CFD_Integration	= 10;
-	default_CFD_Threshold	= 500;
-	default_CFD_Fraction	= 0.3;
-	
-	std::string default_type = config->GetValue( "febex_default.Type", "Qshort" );
-	if( default_qint ) default_type = "Qint"; // override for MBS
-
+	default_FebexMWD_Decay			= 5000;
+	default_FebexMWD_Rise			= 780; // L
+	default_FebexMWD_Top			= 870; // mwd_cfd_trig_delay
+	default_FebexMWD_Baseline		= 60;  // delay MWD in James' firmware
+	default_FebexMWD_Window			= 880; // M
+	default_FebexCFD_Delay			= 30;
+	default_FebexCFD_HoldOff		= 100; // prevent double triggering?
+	default_FebexCFD_Shaping		= 15;
+	default_FebexCFD_Integration	= 10;
+	default_FebexCFD_Threshold		= 500;
+	default_FebexCFD_Fraction		= 0.3;
 	
 	// FEBEX initialisation
 	fFebexOffset.resize( set->GetNumberOfFebexSfps() );
@@ -249,6 +245,27 @@ void MiniballCalibration::ReadCalibration() {
 	fFebexCFD_Integration.resize( set->GetNumberOfFebexSfps() );
 	fFebexCFD_Threshold.resize( set->GetNumberOfFebexSfps() );
 	fFebexCFD_Fraction.resize( set->GetNumberOfFebexSfps() );
+	
+	// Global parameters
+	double default_FebexOffset = (double)config->GetValue( "febex.Offset", (double)0 );
+	double default_FebexGain = (double)config->GetValue( "febex.Gain", 0.25 );
+	double default_FebexGainQuadr = (double)config->GetValue( "febex.GainQuadr", (double)0 );
+	unsigned int default_FebexThreshold = (unsigned int)config->GetValue( "febex.Threshold", (double)0 );
+	std::string default_FebexType = config->GetValue( "febex.Type", "Qshort" );
+	if( default_qint ) default_FebexType = "Qint"; // override for MBS
+	long default_FebexTime = (long)config->GetValue( "febex.Time", (double)0 );
+	default_FebexMWD_Decay = (unsigned int)config->GetValue( "febex.MWD.DecayTime", (double)default_FebexMWD_Decay );
+	default_FebexMWD_Rise = (unsigned int)config->GetValue( "febex_.MWD.RiseTime", (double)default_FebexMWD_Rise );
+	default_FebexMWD_Top = (unsigned int)config->GetValue( "febex.MWD.FlatTop", (double)default_FebexMWD_Top );
+	default_FebexMWD_Baseline = (unsigned int)config->GetValue( "febex.MWD.Baseline", (double)default_FebexMWD_Baseline );
+	default_FebexMWD_Window = (unsigned int)config->GetValue( "febex.MWD.Window", (double)default_FebexMWD_Window );
+	default_FebexCFD_Delay = (unsigned int)config->GetValue( "febex.CFD.DelayTime", (double)default_FebexCFD_Delay );
+	default_FebexCFD_HoldOff = (unsigned int)config->GetValue( "febex.CFD.HoldOff", (double)default_FebexCFD_HoldOff );
+	default_FebexCFD_Shaping = (unsigned int)config->GetValue( "febex.CFD.ShapingTime", (double)default_FebexCFD_Shaping );
+	default_FebexCFD_Integration = (unsigned int)config->GetValue( "febex.CFD.IntegrationTime", (double)default_FebexCFD_Integration );
+	default_FebexCFD_Threshold = (int)config->GetValue( "febex.CFD.Threshold", (double)default_FebexCFD_Threshold );
+	default_FebexCFD_Fraction = (float)config->GetValue( "febex.CFD.Fraction", (double)default_FebexCFD_Fraction );
+
 
 	// FEBEX parameter read
 	for( unsigned char i = 0; i < set->GetNumberOfFebexSfps(); i++ ){
@@ -270,6 +287,24 @@ void MiniballCalibration::ReadCalibration() {
 		fFebexCFD_Integration[i].resize( set->GetNumberOfFebexBoards() );
 		fFebexCFD_Threshold[i].resize( set->GetNumberOfFebexBoards() );
 		fFebexCFD_Fraction[i].resize( set->GetNumberOfFebexBoards() );
+		
+		double sfpFebexOffset = (double)config->GetValue( Form( "febex_%d.Offset", i ), (double)default_FebexOffset );
+		double sfpFebexGain = (double)config->GetValue( Form( "febex_%d.Gain", i ), (double)default_FebexGain );
+		double sfpFebexGainQuadr = (double)config->GetValue( Form( "febex_%d.GainQuadr", i ), (double)default_FebexGainQuadr );
+		unsigned int sfpFebexThreshold = (unsigned int)config->GetValue( Form( "febex_%d.Threshold", i ), (double)default_FebexThreshold );
+		std::string sfpFebexType = config->GetValue( Form( "febex_%d.Type", i ), default_FebexType.data() );
+		long sfpFebexTime = (long)config->GetValue( Form( "febex_%d.Time", i ), (double)default_FebexTime );
+		unsigned int sfpFebexMWD_Decay = (unsigned int)config->GetValue( Form( "febex_%d.MWD.DecayTime", i ), (double)default_FebexMWD_Decay );
+		unsigned int sfpFebexMWD_Rise = (unsigned int)config->GetValue( Form( "febex_%d.MWD.RiseTime", i ), (double)default_FebexMWD_Rise );
+		unsigned int sfpFebexMWD_Top = (unsigned int)config->GetValue( Form( "febex_%d.MWD.FlatTop", i ), (double)default_FebexMWD_Top );
+		unsigned int sfpFebexMWD_Baseline = (unsigned int)config->GetValue( Form( "febex_%d.MWD.Baseline", i ), (double)default_FebexMWD_Baseline );
+		unsigned int sfpFebexMWD_Window = (unsigned int)config->GetValue( Form( "febex_%d.MWD.Window", i ), (double)default_FebexMWD_Window );
+		unsigned int sfpFebexCFD_Delay = (unsigned int)config->GetValue( Form( "febex_%d.CFD.DelayTime", i ), (double)default_FebexCFD_Delay );
+		unsigned int sfpFebexCFD_HoldOff = (unsigned int)config->GetValue( Form( "febex_%d.CFD.HoldOff", i ), (double)default_FebexCFD_HoldOff );
+		unsigned int sfpFebexCFD_Shaping = (unsigned int)config->GetValue( Form( "febex_%d.CFD.ShapingTime", i ), (double)default_FebexCFD_Shaping );
+		unsigned int sfpFebexCFD_Integration = (unsigned int)config->GetValue( Form( "febex_%d.CFD.IntegrationTime", i ), (double)default_FebexCFD_Integration );
+		int sfpFebexCFD_Threshold = (int)config->GetValue( Form( "febex_%d.CFD.Threshold", i ), (double)default_FebexCFD_Threshold );
+		float sfpFebexCFD_Fraction = (float)config->GetValue( Form( "febex_%d.CFD.Fraction", i ), (double)default_FebexCFD_Fraction );
 
 		for( unsigned char j = 0; j < set->GetNumberOfFebexBoards(); j++ ){
 
@@ -291,25 +326,43 @@ void MiniballCalibration::ReadCalibration() {
 			fFebexCFD_Threshold[i][j].resize( set->GetNumberOfFebexChannels() );
 			fFebexCFD_Fraction[i][j].resize( set->GetNumberOfFebexChannels() );
 
+			double boardFebexOffset = (double)config->GetValue( Form( "febex_%d_%d.Offset", i, j ), (double)sfpFebexOffset );
+			double boardFebexGain = (double)config->GetValue( Form( "febex_%d_%d.Gain", i, j ), (double)sfpFebexGain );
+			double boardFebexGainQuadr = (double)config->GetValue( Form( "febex_%d_%d.GainQuadr", i, j ), (double)sfpFebexGainQuadr );
+			unsigned int boardFebexThreshold = (unsigned int)config->GetValue( Form( "febex_%d_%d.Threshold", i, j ), (double)sfpFebexThreshold );
+			std::string boardFebexType = config->GetValue( Form( "febex_%d_%d.Type", i, j ), sfpFebexType.data() );
+			long boardFebexTime = (long)config->GetValue( Form( "febex_%d_%d.Time", i, j ), (double)sfpFebexTime );
+			unsigned int boardFebexMWD_Decay = (unsigned int)config->GetValue( Form( "febex_%d_%d.MWD.DecayTime", i, j ), (double)sfpFebexMWD_Decay );
+			unsigned int boardFebexMWD_Rise = (unsigned int)config->GetValue( Form( "febex_%d_%d.MWD.RiseTime", i, j ), (double)sfpFebexMWD_Rise );
+			unsigned int boardFebexMWD_Top = (unsigned int)config->GetValue( Form( "febex_%d_%d.MWD.FlatTop", i, j ), (double)sfpFebexMWD_Top );
+			unsigned int boardFebexMWD_Baseline = (unsigned int)config->GetValue( Form( "febex_%d_%d.MWD.Baseline", i, j ), (double)sfpFebexMWD_Baseline );
+			unsigned int boardFebexMWD_Window = (unsigned int)config->GetValue( Form( "febex_%d_%d.MWD.Window", i, j ), (double)sfpFebexMWD_Window );
+			unsigned int boardFebexCFD_Delay = (unsigned int)config->GetValue( Form( "febex_%d_%d.CFD.DelayTime", i, j ), (double)sfpFebexCFD_Delay );
+			unsigned int boardFebexCFD_HoldOff = (unsigned int)config->GetValue( Form( "febex_%d_%d.CFD.HoldOff", i, j ), (double)sfpFebexCFD_HoldOff );
+			unsigned int boardFebexCFD_Shaping = (unsigned int)config->GetValue( Form( "febex_%d_%d.CFD.ShapingTime", i, j ), (double)sfpFebexCFD_Shaping );
+			unsigned int boardFebexCFD_Integration = (unsigned int)config->GetValue( Form( "febex_%d_%d.CFD.IntegrationTime", i, j ), (double)sfpFebexCFD_Integration );
+			int boardFebexCFD_Threshold = (int)config->GetValue( Form( "febex_%d_%d.CFD.Threshold", i, j ), (double)sfpFebexCFD_Threshold );
+			float boardFebexCFD_Fraction = (float)config->GetValue( Form( "febex_%d_%d.CFD.Fraction", i, j ), (double)sfpFebexCFD_Fraction );
+
 			for( unsigned char k = 0; k < set->GetNumberOfFebexChannels(); k++ ){
 				
-				fFebexOffset[i][j][k] = (double)config->GetValue( Form( "febex_%d_%d_%d.Offset", i, j, k ), (double)0 );
-				fFebexGain[i][j][k] = (double)config->GetValue( Form( "febex_%d_%d_%d.Gain", i, j, k ), 0.25 );
-				fFebexGainQuadr[i][j][k] = (double)config->GetValue( Form( "febex_%d_%d_%d.GainQuadr", i, j, k ), (double)0 );
-				fFebexThreshold[i][j][k] = (unsigned int)config->GetValue( Form( "febex_%d_%d_%d.Threshold", i, j, k ), (double)0 );
-				fFebexType[i][j][k] = config->GetValue( Form( "febex_%d_%d_%d.Type", i, j, k ), default_type.data() );
-				fFebexTime[i][j][k] = (long)config->GetValue( Form( "febex_%d_%d_%d.Time", i, j, k ), (double)0 );
-				fFebexMWD_Decay[i][j][k] = (unsigned int)config->GetValue( Form( "febex_%d_%d_%d.MWD.DecayTime", i, j, k ), (double)default_MWD_Decay );
-				fFebexMWD_Rise[i][j][k] = (unsigned int)config->GetValue( Form( "febex_%d_%d_%d.MWD.RiseTime", i, j, k ), (double)default_MWD_Rise );
-				fFebexMWD_Top[i][j][k] = (unsigned int)config->GetValue( Form( "febex_%d_%d_%d.MWD.FlatTop", i, j, k ), (double)default_MWD_Top );
-				fFebexMWD_Baseline[i][j][k] = (unsigned int)config->GetValue( Form( "febex_%d_%d_%d.MWD.Baseline", i, j, k ), (double)default_MWD_Baseline );
-				fFebexMWD_Window[i][j][k] = (unsigned int)config->GetValue( Form( "febex_%d_%d_%d.MWD.Window", i, j, k ), (double)default_MWD_Window );
-				fFebexCFD_Delay[i][j][k] = (unsigned int)config->GetValue( Form( "febex_%d_%d_%d.CFD.DelayTime", i, j, k ), (double)default_CFD_Delay );
-				fFebexCFD_HoldOff[i][j][k] = (unsigned int)config->GetValue( Form( "febex_%d_%d_%d.CFD.HoldOff", i, j, k ), (double)default_CFD_HoldOff );
-				fFebexCFD_Shaping[i][j][k] = (unsigned int)config->GetValue( Form( "febex_%d_%d_%d.CFD.ShapingTime", i, j, k ), (double)default_CFD_Shaping );
-				fFebexCFD_Integration[i][j][k] = (unsigned int)config->GetValue( Form( "febex_%d_%d_%d.CFD.IntegrationTime", i, j, k ), (double)default_CFD_Integration );
-				fFebexCFD_Threshold[i][j][k] = (int)config->GetValue( Form( "febex_%d_%d_%d.CFD.Threshold", i, j, k ), (double)default_CFD_Threshold );
-				fFebexCFD_Fraction[i][j][k] = (float)config->GetValue( Form( "febex_%d_%d_%d.CFD.Fraction", i, j, k ), (double)default_CFD_Fraction );
+				fFebexOffset[i][j][k] = (double)config->GetValue( Form( "febex_%d_%d_%d.Offset", i, j, k ), (double)boardFebexOffset );
+				fFebexGain[i][j][k] = (double)config->GetValue( Form( "febex_%d_%d_%d.Gain", i, j, k ), (double)boardFebexGain );
+				fFebexGainQuadr[i][j][k] = (double)config->GetValue( Form( "febex_%d_%d_%d.GainQuadr", i, j, k ), (double)boardFebexGainQuadr );
+				fFebexThreshold[i][j][k] = (unsigned int)config->GetValue( Form( "febex_%d_%d_%d.Threshold", i, j, k ), (double)boardFebexThreshold );
+				fFebexType[i][j][k] = config->GetValue( Form( "febex_%d_%d_%d.Type", i, j, k ), boardFebexType.data() );
+				fFebexTime[i][j][k] = (long)config->GetValue( Form( "febex_%d_%d_%d.Time", i, j, k ), (double)boardFebexTime );
+				fFebexMWD_Decay[i][j][k] = (unsigned int)config->GetValue( Form( "febex_%d_%d_%d.MWD.DecayTime", i, j, k ), (double)boardFebexMWD_Decay );
+				fFebexMWD_Rise[i][j][k] = (unsigned int)config->GetValue( Form( "febex_%d_%d_%d.MWD.RiseTime", i, j, k ), (double)boardFebexMWD_Rise );
+				fFebexMWD_Top[i][j][k] = (unsigned int)config->GetValue( Form( "febex_%d_%d_%d.MWD.FlatTop", i, j, k ), (double)boardFebexMWD_Top );
+				fFebexMWD_Baseline[i][j][k] = (unsigned int)config->GetValue( Form( "febex_%d_%d_%d.MWD.Baseline", i, j, k ), (double)boardFebexMWD_Baseline );
+				fFebexMWD_Window[i][j][k] = (unsigned int)config->GetValue( Form( "febex_%d_%d_%d.MWD.Window", i, j, k ), (double)boardFebexMWD_Window );
+				fFebexCFD_Delay[i][j][k] = (unsigned int)config->GetValue( Form( "febex_%d_%d_%d.CFD.DelayTime", i, j, k ), (double)boardFebexCFD_Delay );
+				fFebexCFD_HoldOff[i][j][k] = (unsigned int)config->GetValue( Form( "febex_%d_%d_%d.CFD.HoldOff", i, j, k ), (double)boardFebexCFD_HoldOff );
+				fFebexCFD_Shaping[i][j][k] = (unsigned int)config->GetValue( Form( "febex_%d_%d_%d.CFD.ShapingTime", i, j, k ), (double)boardFebexCFD_Shaping );
+				fFebexCFD_Integration[i][j][k] = (unsigned int)config->GetValue( Form( "febex_%d_%d_%d.CFD.IntegrationTime", i, j, k ), (double)boardFebexCFD_Integration );
+				fFebexCFD_Threshold[i][j][k] = (int)config->GetValue( Form( "febex_%d_%d_%d.CFD.Threshold", i, j, k ), (double)boardFebexCFD_Threshold );
+				fFebexCFD_Fraction[i][j][k] = (float)config->GetValue( Form( "febex_%d_%d_%d.CFD.Fraction", i, j, k ), (double)boardFebexCFD_Fraction );
 
 			} // k: channel
 			

--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -1623,12 +1623,12 @@ unsigned long MiniballEventBuilder::BuildEvents() {
 					// Increment counts and open the event
 					n_miniball++;
 					hit_ctr++;
-					event_open = true;
 					
 					// Clipped rejection and pileup rejection
 					if( ( !myclipped || !set->GetClippedRejection() ) &&
 					    ( !mypileup || !set->GetPileupRejection() ) ) {
 
+						event_open = true;
 						mb_en_list.push_back( myenergy );
 						mb_ts_list.push_back( mytime );
 						mb_clu_list.push_back( set->GetMiniballCluster( mysfp, myboard, mych ) );
@@ -1645,12 +1645,12 @@ unsigned long MiniballEventBuilder::BuildEvents() {
 					// Increment counts and open the event
 					n_cd++;
 					hit_ctr++;
-					event_open = true;
 					
 					// Clipped rejection and pileup rejection
 					if( ( !myclipped || !set->GetClippedRejection() ) &&
 						( !mypileup || !set->GetPileupRejection() ) ) {
 						
+						event_open = true;
 						cd_en_list.push_back( myenergy );
 						cd_ts_list.push_back( mytime );
 						cd_det_list.push_back( set->GetCDDetector( mysfp, myboard, mych ) );
@@ -1668,12 +1668,12 @@ unsigned long MiniballEventBuilder::BuildEvents() {
 					// Increment counts and open the event
 					n_pad++;
 					hit_ctr++;
-					event_open = true;
 					
 					// Clipped rejection and pileup rejection
 					if( ( !myclipped || !set->GetClippedRejection() ) &&
 					    ( !mypileup || !set->GetPileupRejection() ) ) {
 
+						event_open = true;
 						pad_en_list.push_back( myenergy );
 						pad_ts_list.push_back( mytime );
 						pad_det_list.push_back( set->GetPadDetector( mysfp, myboard, mych ) );
@@ -1689,12 +1689,12 @@ unsigned long MiniballEventBuilder::BuildEvents() {
 					// Increment counts and open the event
 					n_spede++;
 					hit_ctr++;
-					event_open = true;
 					
 					// Clipped rejection and pileup rejection
 					if( ( !myclipped || !set->GetClippedRejection() ) &&
 					    ( !mypileup || !set->GetPileupRejection() ) ) {
 
+						event_open = true;
 						spede_en_list.push_back( myenergy );
 						spede_ts_list.push_back( mytime );
 						spede_seg_list.push_back( set->GetSpedeSegment( mysfp, myboard, mych ) );
@@ -1706,10 +1706,9 @@ unsigned long MiniballEventBuilder::BuildEvents() {
 				// Is it a gamma ray from the beam dump?
 				else if( set->IsBeamDump( mysfp, myboard, mych ) && mythres ) {
 					
-					// Increment counts and open the event
+					// Increment counts but do not open the event
 					n_bd++;
 					hit_ctr++;
-					event_open = true;
 					
 					// Clipped rejection and pileup rejection
 					if( ( !myclipped || !set->GetClippedRejection() ) &&
@@ -1726,10 +1725,9 @@ unsigned long MiniballEventBuilder::BuildEvents() {
 				// Is it an IonChamber event
 				else if( set->IsIonChamber( mysfp, myboard, mych ) && mythres ) {
 					
-					// Increment counts and open the event
+					// Increment counts but do not open the event
 					n_ic++;
 					hit_ctr++;
-					event_open = true;
 					
 					// Clipped rejection and pileup rejection
 					if( ( !myclipped || !set->GetClippedRejection() ) &&

--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -1843,18 +1843,13 @@ unsigned long MiniballEventBuilder::BuildEvents() {
 			// Is it a gamma ray from the beam dump?
 			else if( set->IsBeamDump( mydgf, mych ) && mythres ) {
 				
-				// Increment counts and open the event
+				// Increment counts but do not open the event
 				n_bd++;
 				hit_ctr++;
-				event_open = true;
 				
-				if( !mypileup || !set->GetPileupRejection() ) {
-					
-					bd_en_list.push_back( myenergy );
-					bd_ts_list.push_back( mytime );
-					bd_det_list.push_back( set->GetBeamDumpDetector( mydgf, mych ) );
-					
-				}
+				bd_en_list.push_back( myenergy );
+				bd_ts_list.push_back( mytime );
+				bd_det_list.push_back( set->GetBeamDumpDetector( mydgf, mych ) );
 				
 			}
 			
@@ -1899,15 +1894,15 @@ unsigned long MiniballEventBuilder::BuildEvents() {
 			n_adc[myadc]++;
 			
 			// Is it a particle from the CD?
-			if( set->IsCD( myadc, mych ) && mythres && !myclipped ) {
+			if( set->IsCD( myadc, mych ) && mythres ) {
 				
 				// Increment counts and open the event
 				n_cd++;
 				hit_ctr++;
-				event_open = true;
 				
-				if( !mypileup || !set->GetPileupRejection() ) {
-					
+				if( !myclipped || !set->GetClippedRejection() ) {
+
+					event_open = true;
 					cd_en_list.push_back( myenergy );
 					cd_ts_list.push_back( mytime );
 					cd_det_list.push_back( set->GetCDDetector( myadc, mych ) );
@@ -1920,15 +1915,15 @@ unsigned long MiniballEventBuilder::BuildEvents() {
 			}
 			
 			// Is it a particle from the Pad?
-			else if( set->IsPad( myadc, mych ) && mythres && !myclipped ) {
+			else if( set->IsPad( myadc, mych ) && mythres ) {
 				
 				// Increment counts and open the event
 				n_pad++;
 				hit_ctr++;
-				event_open = true;
 				
-				if( !mypileup || !set->GetPileupRejection() ) {
-					
+				if( !myclipped || !set->GetClippedRejection() ) {
+
+					event_open = true;
 					pad_en_list.push_back( myenergy );
 					pad_ts_list.push_back( mytime );
 					pad_det_list.push_back( set->GetPadDetector( myadc, mych ) );
@@ -1944,10 +1939,10 @@ unsigned long MiniballEventBuilder::BuildEvents() {
 				// Increment counts and open the event
 				n_ic++;
 				hit_ctr++;
-				event_open = true;
 				
-				if( !mypileup || !set->GetPileupRejection() ) {
-					
+				if( !myclipped || !set->GetClippedRejection() ) {
+
+					event_open = true;
 					ic_en_list.push_back( myenergy );
 					ic_ts_list.push_back( mytime );
 					ic_id_list.push_back( set->GetIonChamberLayer( myadc, mych ) );

--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -1706,7 +1706,7 @@ unsigned long MiniballEventBuilder::BuildEvents() {
 				// Is it a gamma ray from the beam dump?
 				else if( set->IsBeamDump( mysfp, myboard, mych ) && mythres ) {
 					
-					// Increment counts but do not open the event
+					// Increment counts and open the event
 					n_bd++;
 					hit_ctr++;
 					
@@ -1714,6 +1714,7 @@ unsigned long MiniballEventBuilder::BuildEvents() {
 					if( ( !myclipped || !set->GetClippedRejection() ) &&
 					    ( !mypileup || !set->GetPileupRejection() ) ) {
 
+						event_open = true;
 						bd_en_list.push_back( myenergy );
 						bd_ts_list.push_back( mytime );
 						bd_det_list.push_back( set->GetBeamDumpDetector( mysfp, myboard, mych ) );
@@ -1725,7 +1726,7 @@ unsigned long MiniballEventBuilder::BuildEvents() {
 				// Is it an IonChamber event
 				else if( set->IsIonChamber( mysfp, myboard, mych ) && mythres ) {
 					
-					// Increment counts but do not open the event
+					// Increment counts and open the event
 					n_ic++;
 					hit_ctr++;
 					
@@ -1733,6 +1734,7 @@ unsigned long MiniballEventBuilder::BuildEvents() {
 					if( ( !myclipped || !set->GetClippedRejection() ) &&
 					    ( !mypileup || !set->GetPileupRejection() ) ) {
 
+						event_open = true;
 						ic_en_list.push_back( myenergy );
 						ic_ts_list.push_back( mytime );
 						ic_id_list.push_back( set->GetIonChamberLayer( mysfp, myboard, mych ) );

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -457,20 +457,55 @@ void MiniballHistogrammer::MakeHists() {
 	htitle += "Energy [keV];Counts per 0.5 keV";
 	gE_recoil_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
 	
-	hname = "gE_2p_dc_none";
-	htitle = "Gamma-ray energy, in coincidence with ejectile and recoil with random subtraction;";
-	htitle += "Energy [keV];Counts per 0.5 keV";
-	gE_2p_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	
-	hname = "gE_2p_dc_ejectile";
-	htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
-	htitle += "Energy [keV];Counts per 0.5 keV";
-	gE_2p_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	
-	hname = "gE_2p_dc_recoil";
-	htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
-	htitle += "Energy [keV];Counts per 0.5 keV";
-	gE_2p_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+	// 1p and 2p gamma-ray histograms
+	if( react->HistByMultiplicity() ){
+		
+		hname = "gE_1p_ejectile_dc_none";
+		htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only with random subtraction;";
+		htitle += "Energy [keV];Counts per 0.5 keV";
+		gE_1p_ejectile_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		
+		hname = "gE_1p_ejectile_dc_ejectile";
+		htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+		htitle += "Energy [keV];Counts per 0.5 keV";
+		gE_1p_ejectile_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		
+		hname = "gE_1p_ejectile_dc_recoil";
+		htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+		htitle += "Energy [keV];Counts per 0.5 keV";
+		gE_1p_ejectile_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		
+		hname = "gE_1p_recoil_dc_none";
+		htitle = "Gamma-ray energy, gated on the recoil, 1-particle only with random subtraction;";
+		htitle += "Energy [keV];Counts per 0.5 keV";
+		gE_1p_recoil_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		
+		hname = "gE_1p_recoil_dc_ejectile";
+		htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+		htitle += "Energy [keV];Counts per 0.5 keV";
+		gE_1p_recoil_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		
+		hname = "gE_1p_recoil_dc_recoil";
+		htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+		htitle += "Energy [keV];Counts per 0.5 keV";
+		gE_1p_recoil_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		
+		hname = "gE_2p_dc_none";
+		htitle = "Gamma-ray energy, in coincidence with ejectile and recoil with random subtraction;";
+		htitle += "Energy [keV];Counts per 0.5 keV";
+		gE_2p_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		
+		hname = "gE_2p_dc_ejectile";
+		htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
+		htitle += "Energy [keV];Counts per 0.5 keV";
+		gE_2p_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		
+		hname = "gE_2p_dc_recoil";
+		htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
+		htitle += "Energy [keV];Counts per 0.5 keV";
+		gE_2p_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		
+	}
 	
 	hname = "gE_costheta_ejectile";
 	htitle = "Gamma-ray energy versus cos(#theta) of angle between ejectile and gamma-ray;Energy [keV];cos(#theta_p#gamma)";
@@ -510,21 +545,56 @@ void MiniballHistogrammer::MakeHists() {
 	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 	gE_vs_theta_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
 	
-	hname = "gE_vs_theta_2p_dc_none";
-	htitle = "Gamma-ray energy, in coincidence with ejectile and recoil with random subtraction;";
-	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-	gE_vs_theta_2p_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-	
-	hname = "gE_vs_theta_2p_dc_ejectile";
-	htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
-	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-	gE_vs_theta_2p_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-	
-	hname = "gE_vs_theta_2p_dc_recoil";
-	htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
-	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-	gE_vs_theta_2p_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-	
+	// 1p and 2p gamma-ray histograms
+	if( react->HistByMultiplicity() ){
+		
+		hname = "gE_vs_theta_1p_ejectile_dc_none";
+		htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only with random subtraction;";
+		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+		gE_vs_theta_1p_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+		
+		hname = "gE_vs_theta_1p_ejectile_dc_ejectile";
+		htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+		gE_vs_theta_1p_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+		
+		hname = "gE_vs_theta_1p_ejectile_dc_recoil";
+		htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+		gE_vs_theta_1p_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+		
+		hname = "gE_vs_theta_1p_recoil_dc_none";
+		htitle = "Gamma-ray energy, gated on the recoil, 1-particle only with random subtraction;";
+		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+		gE_vs_theta_1p_recoil_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+		
+		hname = "gE_vs_theta_1p_recoil_dc_ejectile";
+		htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+		gE_vs_theta_1p_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+		
+		hname = "gE_vs_theta_1p_recoil_dc_recoil";
+		htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+		gE_vs_theta_1p_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+		
+		hname = "gE_vs_theta_2p_dc_none";
+		htitle = "Gamma-ray energy, in coincidence with ejectile and recoil with random subtraction;";
+		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+		gE_vs_theta_2p_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+		
+		hname = "gE_vs_theta_2p_dc_ejectile";
+		htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
+		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+		gE_vs_theta_2p_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+		
+		hname = "gE_vs_theta_2p_dc_recoil";
+		htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
+		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+		gE_vs_theta_2p_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+		
+	}
+
 	// Per crystal Doppler-corrected spectra
 	if( react->HistByCrystal() ) {
 		
@@ -560,25 +630,65 @@ void MiniballHistogrammer::MakeHists() {
 		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 		gE_vs_crystal_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
 		
-		hname = "gE_vs_crystal_2p_dc_none";
-		htitle = "Gamma-ray energy, in coincidence with ejectile and recoil with random subtraction;";
-		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-		gE_vs_crystal_2p_dc_none = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-		
-		hname = "gE_vs_crystal_2p_dc_ejectile";
-		htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-		gE_vs_crystal_2p_dc_ejectile = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-		
-		hname = "gE_vs_crystal_2p_dc_recoil";
-		htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
-		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-		gE_vs_crystal_2p_dc_recoil = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
+		// 1p and 2p gamma-ray histograms
+		if( react->HistByMultiplicity() ){
+			
+			hname = "gE_vs_crystal_1p_ejectile_dc_none";
+			htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only with random subtraction;";
+			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+			gE_vs_crystal_1p_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
+			
+			hname = "gE_vs_crystal_1p_ejectile_dc_ejectile";
+			htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+			gE_vs_crystal_1p_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
+			
+			hname = "gE_vs_crystal_1p_ejectile_dc_recoil";
+			htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+			gE_vs_crystal_1p_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
+			
+			hname = "gE_vs_crystal_1p_recoil_dc_none";
+			htitle = "Gamma-ray energy, gated on the recoil, 1-particle only with random subtraction;";
+			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+			gE_vs_crystal_1p_recoil_dc_none = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
+			
+			hname = "gE_vs_crystal_1p_recoil_dc_ejectile";
+			htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+			gE_vs_crystal_1p_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
+			
+			hname = "gE_vs_crystal_1p_recoil_dc_recoil";
+			htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+			gE_vs_crystal_1p_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
+			
+			hname = "gE_vs_crystal_2p_dc_none";
+			htitle = "Gamma-ray energy, in coincidence with ejectile and recoil with random subtraction;";
+			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+			gE_vs_crystal_2p_dc_none = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
+			
+			hname = "gE_vs_crystal_2p_dc_ejectile";
+			htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+			gE_vs_crystal_2p_dc_ejectile = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
+			
+			hname = "gE_vs_crystal_2p_dc_recoil";
+			htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
+			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+			gE_vs_crystal_2p_dc_recoil = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
+			
+		}
 		
 	} // by crystal
 	
 	// T1 impact time
 	if( react->HistByT1() ) {
+		
+		hname = "gE_ejectile_dc_none_t1";
+		htitle = "Gamma-ray energy, gated on the ejectile, with random subtraction;";
+		htitle += "T1 time [ns];Energy [keV];Counts per keV";
+		gE_ejectile_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
 		
 		hname = "gE_ejectile_dc_ejectile_t1";
 		htitle = "Gamma-ray energy, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
@@ -590,6 +700,11 @@ void MiniballHistogrammer::MakeHists() {
 		htitle += "T1 time [ns];Energy [keV];Counts per keV";
 		gE_ejectile_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
 		
+		hname = "gE_recoil_dc_none_t1";
+		htitle = "Gamma-ray energy, gated on the recoil, with random subtraction;";
+		htitle += "T1 time [ns];Energy [keV];Counts per keV";
+		gE_recoil_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+		
 		hname = "gE_recoil_dc_ejectile_t1";
 		htitle = "Gamma-ray energy, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "T1 time [ns];Energy [keV];Counts per keV";
@@ -600,15 +715,50 @@ void MiniballHistogrammer::MakeHists() {
 		htitle += "T1 time [ns];Energy [keV];Counts per eV";
 		gE_recoil_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
 		
-		hname = "gE_2p_dc_ejectile_t1";
-		htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "Energy [keV];Counts per keV";
-		gE_2p_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-		
-		hname = "gE_2p_dc_recoil_t1";
-		htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
-		htitle += "Energy [keV];Counts per keV";
-		gE_2p_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+		// 1p and 2p gamma-ray histograms
+		if( react->HistByMultiplicity() ){
+			
+			hname = "gE_1p_ejectile_dc_none_t1";
+			htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, with random subtraction;";
+			htitle += "T1 time [ns];Energy [keV];Counts per keV";
+			gE_1p_ejectile_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+			
+			hname = "gE_1p_ejectile_dc_ejectile_t1";
+			htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "T1 time [ns];Energy [keV];Counts per keV";
+			gE_1p_ejectile_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+			
+			hname = "gE_1p_ejectile_dc_recoil_t1";
+			htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+			htitle += "T1 time [ns];Energy [keV];Counts per keV";
+			gE_1p_ejectile_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+			
+			hname = "gE_1p_recoil_dc_none_t1";
+			htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, with random subtraction;";
+			htitle += "T1 time [ns];Energy [keV];Counts per keV";
+			gE_1p_recoil_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+			
+			hname = "gE_1p_recoil_dc_ejectile_t1";
+			htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "T1 time [ns];Energy [keV];Counts per keV";
+			gE_1p_recoil_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+			
+			hname = "gE_1p_recoil_dc_recoil_t1";
+			htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+			htitle += "T1 time [ns];Energy [keV];Counts per eV";
+			gE_1p_recoil_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+
+			hname = "gE_2p_dc_ejectile_t1";
+			htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Energy [keV];Counts per keV";
+			gE_2p_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+			
+			hname = "gE_2p_dc_recoil_t1";
+			htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
+			htitle += "Energy [keV];Counts per keV";
+			gE_2p_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+			
+		}
 		
 	}
 	// Gamma-gamma hists
@@ -705,20 +855,55 @@ void MiniballHistogrammer::MakeHists() {
 	htitle += "Energy [keV];Counts per 0.5 keV";
 	aE_recoil_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
 
-	hname = "aE_2p_dc_none";
-	htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil with random subtraction;";
-	htitle += "Energy [keV];Counts per 0.5 keV";
-	aE_2p_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-
-	hname = "aE_2p_dc_ejectile";
-	htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
-	htitle += "Energy [keV];Counts per 0.5 keV";
-	aE_2p_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-
-	hname = "aE_2p_dc_recoil";
-	htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
-	htitle += "Energy [keV];Counts per 0.5 keV";
-	aE_2p_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+	// 1p and 2p gamma-ray histograms
+	if( react->HistByMultiplicity() ){
+		
+		hname = "aE_1p_ejectile_dc_none";
+		htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only with random subtraction;";
+		htitle += "Energy [keV];Counts per 0.5 keV";
+		aE_1p_ejectile_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		
+		hname = "aE_1p_ejectile_dc_ejectile";
+		htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+		htitle += "Energy [keV];Counts per 0.5 keV";
+		aE_1p_ejectile_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		
+		hname = "aE_1p_ejectile_dc_recoil";
+		htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+		htitle += "Energy [keV];Counts per 0.5 keV";
+		aE_1p_ejectile_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		
+		hname = "aE_1p_recoil_dc_none";
+		htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only with random subtraction;";
+		htitle += "Energy [keV];Counts per 0.5 keV";
+		aE_1p_recoil_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		
+		hname = "aE_1p_recoil_dc_ejectile";
+		htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+		htitle += "Energy [keV];Counts per 0.5 keV";
+		aE_1p_recoil_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		
+		hname = "aE_1p_recoil_dc_recoil";
+		htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+		htitle += "Energy [keV];Counts per 0.5 keV";
+		aE_1p_recoil_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		
+		hname = "aE_2p_dc_none";
+		htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil with random subtraction;";
+		htitle += "Energy [keV];Counts per 0.5 keV";
+		aE_2p_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		
+		hname = "aE_2p_dc_ejectile";
+		htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
+		htitle += "Energy [keV];Counts per 0.5 keV";
+		aE_2p_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		
+		hname = "aE_2p_dc_recoil";
+		htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
+		htitle += "Energy [keV];Counts per 0.5 keV";
+		aE_2p_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		
+	}
 
 	hname = "aE_costheta_ejectile";
 	htitle = "Gamma-ray energy with addback versus cos(#theta) of angle between ejectile and gamma-ray;";
@@ -760,20 +945,55 @@ void MiniballHistogrammer::MakeHists() {
 	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 	aE_vs_theta_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
 	
-	hname = "aE_vs_theta_2p_dc_none";
-	htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil with random subtraction;";
-	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-	aE_vs_theta_2p_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-	
-	hname = "aE_vs_theta_2p_dc_ejectile";
-	htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
-	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-	aE_vs_theta_2p_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-	
-	hname = "aE_vs_theta_2p_dc_recoil";
-	htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
-	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-	aE_vs_theta_2p_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+	// 1p and 2p gamma-ray histograms
+	if( react->HistByMultiplicity() ){
+		
+		hname = "aE_1p_vs_theta_1p_ejectile_dc_none";
+		htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only with random subtraction;";
+		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+		aE_vs_theta_1p_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+		
+		hname = "aE_vs_theta_1p_ejectile_dc_ejectile";
+		htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+		aE_vs_theta_1p_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+		
+		hname = "aE_vs_theta_1p_ejectile_dc_recoil";
+		htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+		aE_vs_theta_1p_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+		
+		hname = "aE_vs_theta_1p_recoil_dc_none";
+		htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only with random subtraction;";
+		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+		aE_vs_theta_1p_recoil_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+		
+		hname = "aE_vs_theta_1p_recoil_dc_ejectile";
+		htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+		aE_vs_theta_1p_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+		
+		hname = "aE_vs_theta_1p_recoil_dc_recoil";
+		htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+		aE_vs_theta_1p_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+		
+		hname = "aE_vs_theta_2p_dc_none";
+		htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil with random subtraction;";
+		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+		aE_vs_theta_2p_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+		
+		hname = "aE_vs_theta_2p_dc_ejectile";
+		htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
+		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+		aE_vs_theta_2p_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+		
+		hname = "aE_vs_theta_2p_dc_recoil";
+		htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
+		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+		aE_vs_theta_2p_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+		
+	}
 	
 	// Per crystal Doppler-corrected spectra
 	if( react->HistByCrystal() ) {
@@ -814,28 +1034,74 @@ void MiniballHistogrammer::MakeHists() {
 		aE_vs_crystal_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), 
 												  set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
 		
-		hname = "aE_vs_crystal_2p_dc_none";
-		htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil with random subtraction;";
-		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-		aE_vs_crystal_2p_dc_none = new TH2F( hname.data(), htitle.data(), 
-											set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-		
-		hname = "aE_vs_crystal_2p_dc_ejectile";
-		htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-		aE_vs_crystal_2p_dc_ejectile = new TH2F( hname.data(), htitle.data(), 
+		// 1p and 2p gamma-ray histograms
+		if( react->HistByMultiplicity() ){
+			
+			hname = "aE_vs_crystal_1p_ejectile_dc_none";
+			htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only with random subtraction;";
+			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+			aE_vs_crystal_1p_ejectile_dc_none = new TH2F( hname.data(), htitle.data(),
+													  set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
+			
+			hname = "aE_vs_crystal_1p_ejectile_dc_ejectile";
+			htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+			aE_vs_crystal_1p_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(),
+														  set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
+			
+			hname = "aE_vs_crystal_1p_ejectile_dc_recoil";
+			htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+			aE_vs_crystal_1p_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(),
+														set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
+			
+			hname = "aE_vs_crystal_1p_recoil_dc_none";
+			htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only with random subtraction;";
+			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+			aE_vs_crystal_1p_recoil_dc_none = new TH2F( hname.data(), htitle.data(),
+													set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
+			
+			hname = "aE_vs_crystal_1p_recoil_dc_ejectile";
+			htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+			aE_vs_crystal_1p_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(),
+														set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
+			
+			hname = "aE_vs_crystal_1p_recoil_dc_recoil";
+			htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+			aE_vs_crystal_1p_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(),
+													  set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
+			
+			hname = "aE_vs_crystal_2p_dc_none";
+			htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil with random subtraction;";
+			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+			aE_vs_crystal_2p_dc_none = new TH2F( hname.data(), htitle.data(),
 												set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-		
-		hname = "aE_vs_crystal_2p_dc_recoil";
-		htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
-		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-		aE_vs_crystal_2p_dc_recoil = new TH2F( hname.data(), htitle.data(), 
-											  set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
+			
+			hname = "aE_vs_crystal_2p_dc_ejectile";
+			htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+			aE_vs_crystal_2p_dc_ejectile = new TH2F( hname.data(), htitle.data(),
+													set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
+			
+			hname = "aE_vs_crystal_2p_dc_recoil";
+			htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
+			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+			aE_vs_crystal_2p_dc_recoil = new TH2F( hname.data(), htitle.data(),
+												  set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
+			
+		}
 		
 	} // by crystal
 	
 	// T1 impact time
 	if( react->HistByT1() ) {
+		
+		hname = "aE_ejectile_dc_none_t1";
+		htitle = "Gamma-ray energy with addback, gated on the ejectile, with random subtraction;";
+		htitle += "T1 time [ns];Energy [keV];Counts per keV";
+		aE_ejectile_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
 		
 		hname = "aE_ejectile_dc_ejectile_t1";
 		htitle = "Gamma-ray energy with addback, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
@@ -847,6 +1113,11 @@ void MiniballHistogrammer::MakeHists() {
 		htitle += "T1 time [ns];Energy [keV];Counts per keV";
 		aE_ejectile_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
 		
+		hname = "aE_recoil_dc_none_t1";
+		htitle = "Gamma-ray energy with addback, gated on the recoil, with random subtraction;";
+		htitle += "T1 time [ns];Energy [keV];Counts per keV";
+		aE_recoil_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+		
 		hname = "aE_recoil_dc_ejectile_t1";
 		htitle = "Gamma-ray energy with addback, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "T1 time [ns];Energy [keV];Counts per keV";
@@ -857,15 +1128,55 @@ void MiniballHistogrammer::MakeHists() {
 		htitle += "T1 time [ns];Energy [keV];Counts per eV";
 		aE_recoil_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
 
-		hname = "aE_2p_dc_ejectile_t1";
-		htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "Energy [keV];Counts per keV";
-		aE_2p_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-		
-		hname = "aE_2p_dc_recoil_t1";
-		htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
-		htitle += "Energy [keV];Counts per keV";
-		aE_2p_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+		// 1p and 2p gamma-ray histograms
+		if( react->HistByMultiplicity() ){
+			
+			hname = "aE_1p_ejectile_dc_none_t1";
+			htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, with random subtraction;";
+			htitle += "T1 time [ns];Energy [keV];Counts per keV";
+			aE_1p_ejectile_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+			
+			hname = "aE_1p_ejectile_dc_ejectile_t1";
+			htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "T1 time [ns];Energy [keV];Counts per keV";
+			aE_1p_ejectile_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+			
+			hname = "aE_1p_ejectile_dc_recoil_t1";
+			htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+			htitle += "T1 time [ns];Energy [keV];Counts per keV";
+			aE_1p_ejectile_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+			
+			hname = "aE_1p_recoil_dc_none_t1";
+			htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, with random subtraction;";
+			htitle += "T1 time [ns];Energy [keV];Counts per keV";
+			aE_1p_recoil_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+			
+			hname = "aE_1p_recoil_dc_ejectile_t1";
+			htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "T1 time [ns];Energy [keV];Counts per keV";
+			aE_1p_recoil_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+			
+			hname = "aE_1p_recoil_dc_recoil_t1";
+			htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+			htitle += "T1 time [ns];Energy [keV];Counts per eV";
+			aE_1p_recoil_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+			
+			hname = "aE_2p_dc_none_t1";
+			htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, with random subtraction;";
+			htitle += "Energy [keV];Counts per keV";
+			aE_2p_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+			
+			hname = "aE_2p_dc_ejectile_t1";
+			htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Energy [keV];Counts per keV";
+			aE_2p_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+			
+			hname = "aE_2p_dc_recoil_t1";
+			htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
+			htitle += "Energy [keV];Counts per keV";
+			aE_2p_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+			
+		}
 		
 	}
 	
@@ -997,21 +1308,56 @@ void MiniballHistogrammer::MakeHists() {
 		htitle += "Energy [keV];Counts per keV";
 		eE_recoil_dc_recoil = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
 		
-		hname = "eE_2p_dc_none";
-		htitle = "Electron energy, in coincidence with ejectile and recoil with random subtraction;";
-		htitle += "Energy [keV];Counts per keV";
-		eE_2p_dc_none = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
-		
-		hname = "eE_2p_dc_ejectile";
-		htitle = "Electron energy, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "Energy [keV];Counts per keV";
-		eE_2p_dc_ejectile = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
-		
-		hname = "eE_2p_dc_recoil";
-		htitle = "Electron energy, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
-		htitle += "Energy [keV];Counts per keV";
-		eE_2p_dc_recoil = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
-		
+		// 1p and 2p gamma-ray histograms
+		if( react->HistByMultiplicity() ){
+			
+			hname = "eE_1p_ejectile_dc_none";
+			htitle = "Electron energy, gated on the ejectile, 1-particle only with random subtraction;";
+			htitle += "Energy [keV];Counts per keV";
+			eE_1p_ejectile_dc_none = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
+			
+			hname = "eE_1p_ejectile_dc_ejectile";
+			htitle = "Electron energy, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Energy [keV];Counts per keV";
+			eE_1p_ejectile_dc_ejectile = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
+			
+			hname = "eE_1p_ejectile_dc_recoil";
+			htitle = "Electron energy, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+			htitle += "Energy [keV];Counts per keV";
+			eE_1p_ejectile_dc_recoil = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
+			
+			hname = "eE_1p_recoil_dc_none";
+			htitle = "Electron energy, gated on the recoil, 1-particle only with random subtraction;";
+			htitle += "Energy [keV];Counts per keV";
+			eE_1p_recoil_dc_none = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
+			
+			hname = "eE_1p_recoil_dc_ejectile";
+			htitle = "Electron energy, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Energy [keV];Counts per keV";
+			eE_1p_recoil_dc_ejectile = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
+			
+			hname = "eE_1p_recoil_dc_recoil";
+			htitle = "Electron energy, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+			htitle += "Energy [keV];Counts per keV";
+			eE_1p_recoil_dc_recoil = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
+			
+			hname = "eE_2p_dc_none";
+			htitle = "Electron energy, in coincidence with ejectile and recoil with random subtraction;";
+			htitle += "Energy [keV];Counts per keV";
+			eE_2p_dc_none = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
+			
+			hname = "eE_2p_dc_ejectile";
+			htitle = "Electron energy, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Energy [keV];Counts per keV";
+			eE_2p_dc_ejectile = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
+			
+			hname = "eE_2p_dc_recoil";
+			htitle = "Electron energy, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
+			htitle += "Energy [keV];Counts per keV";
+			eE_2p_dc_recoil = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
+			
+		}
+
 		hname = "eE_vs_theta_ejectile_dc_none";
 		htitle = "Electron energy, gated on the ejectile with random subtraction;";
 		htitle += "Theta [deg];Energy [keV];Counts per keV per strip";
@@ -1042,20 +1388,55 @@ void MiniballHistogrammer::MakeHists() {
 		htitle += "Theta [deg];Energy [keV];Counts per keV per strip";
 		eE_vs_theta_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), EBIN, EMIN, EMAX );
 		
-		hname = "eE_vs_theta_2p_dc_none";
-		htitle = "Electron energy, in coincidence with ejectile and recoil with random subtraction;";
-		htitle += "Theta [deg];Energy [keV];Counts per keV per strip";
-		eE_vs_theta_2p_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), EBIN, EMIN, EMAX );
-		
-		hname = "eE_vs_theta_2p_dc_ejectile";
-		htitle = "Electron energy, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "Theta [deg];Energy [keV];Counts per keV per strip";
-		eE_vs_theta_2p_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), EBIN, EMIN, EMAX );
-		
-		hname = "eE_vs_theta_2p_dc_recoil";
-		htitle = "Electron energy, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
-		htitle += "Theta [deg];Energy [keV];Counts per keV per strip";
-		eE_vs_theta_2p_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), EBIN, EMIN, EMAX );
+		// 1p and 2p gamma-ray histograms
+		if( react->HistByMultiplicity() ){
+			
+			hname = "eE_vs_theta_1p_ejectile_dc_none";
+			htitle = "Electron energy, gated on the ejectile, 1-particle only with random subtraction;";
+			htitle += "Theta [deg];Energy [keV];Counts per keV per strip";
+			eE_vs_theta_1p_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), EBIN, EMIN, EMAX );
+			
+			hname = "eE_vs_theta_1p_ejectile_dc_ejectile";
+			htitle = "Electron energy, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Theta [deg];Energy [keV];Counts per keV per strip";
+			eE_vs_theta_1p_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), EBIN, EMIN, EMAX );
+			
+			hname = "eE_vs_theta_1p_ejectile_dc_recoil";
+			htitle = "Electron energy, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+			htitle += "Theta [deg];Energy [keV];Counts per keV per strip";
+			eE_vs_theta_1p_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), EBIN, EMIN, EMAX );
+			
+			hname = "eE_vs_theta_1p_recoil_dc_none";
+			htitle = "Electron energy, gated on the recoil, 1-particle only with random subtraction;";
+			htitle += "Theta [deg];Energy [keV];Counts per keV per strip";
+			eE_vs_theta_1p_recoil_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), EBIN, EMIN, EMAX );
+			
+			hname = "eE_vs_theta_1p_recoil_dc_ejectile";
+			htitle = "Electron energy, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Theta [deg];Energy [keV];Counts per keV per strip";
+			eE_vs_theta_1p_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), EBIN, EMIN, EMAX );
+			
+			hname = "eE_vs_theta_1p_recoil_dc_recoil";
+			htitle = "Electron energy, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+			htitle += "Theta [deg];Energy [keV];Counts per keV per strip";
+			eE_vs_theta_1p_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), EBIN, EMIN, EMAX );
+			
+			hname = "eE_vs_theta_2p_dc_none";
+			htitle = "Electron energy, in coincidence with ejectile and recoil with random subtraction;";
+			htitle += "Theta [deg];Energy [keV];Counts per keV per strip";
+			eE_vs_theta_2p_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), EBIN, EMIN, EMAX );
+			
+			hname = "eE_vs_theta_2p_dc_ejectile";
+			htitle = "Electron energy, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Theta [deg];Energy [keV];Counts per keV per strip";
+			eE_vs_theta_2p_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), EBIN, EMIN, EMAX );
+			
+			hname = "eE_vs_theta_2p_dc_recoil";
+			htitle = "Electron energy, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
+			htitle += "Theta [deg];Energy [keV];Counts per keV per strip";
+			eE_vs_theta_2p_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), EBIN, EMIN, EMAX );
+			
+		}
 		
 		hname = "eE_costheta_ejectile";
 		htitle = "Electron energy versus cos(#theta) of angle between ejectile and electron;";
@@ -1266,9 +1647,6 @@ void MiniballHistogrammer::ResetHists() {
 	gE_recoil_dc_none->Reset("ICESM");
 	gE_recoil_dc_ejectile->Reset("ICESM");
 	gE_recoil_dc_recoil->Reset("ICESM");
-	gE_2p_dc_none->Reset("ICESM");
-	gE_2p_dc_ejectile->Reset("ICESM");
-	gE_2p_dc_recoil->Reset("ICESM");
 	gE_costheta_ejectile->Reset("ICESM");
 	gE_costheta_recoil->Reset("ICESM");
 	gE_vs_theta_ejectile_dc_none->Reset("ICESM");
@@ -1277,9 +1655,6 @@ void MiniballHistogrammer::ResetHists() {
 	gE_vs_theta_recoil_dc_none->Reset("ICESM");
 	gE_vs_theta_recoil_dc_ejectile->Reset("ICESM");
 	gE_vs_theta_recoil_dc_recoil->Reset("ICESM");
-	gE_vs_theta_2p_dc_none->Reset("ICESM");
-	gE_vs_theta_2p_dc_ejectile->Reset("ICESM");
-	gE_vs_theta_2p_dc_recoil->Reset("ICESM");
 	aE_prompt->Reset("ICESM");
 	aE_prompt_1p->Reset("ICESM");
 	aE_prompt_2p->Reset("ICESM");
@@ -1292,9 +1667,6 @@ void MiniballHistogrammer::ResetHists() {
 	aE_recoil_dc_none->Reset("ICESM");
 	aE_recoil_dc_ejectile->Reset("ICESM");
 	aE_recoil_dc_recoil->Reset("ICESM");
-	aE_2p_dc_none->Reset("ICESM");
-	aE_2p_dc_ejectile->Reset("ICESM");
-	aE_2p_dc_recoil->Reset("ICESM");
 	aE_costheta_ejectile->Reset("ICESM");
 	aE_costheta_recoil->Reset("ICESM");
 	aE_vs_theta_ejectile_dc_none->Reset("ICESM");
@@ -1303,25 +1675,89 @@ void MiniballHistogrammer::ResetHists() {
 	aE_vs_theta_recoil_dc_none->Reset("ICESM");
 	aE_vs_theta_recoil_dc_ejectile->Reset("ICESM");
 	aE_vs_theta_recoil_dc_recoil->Reset("ICESM");
-	aE_vs_theta_2p_dc_none->Reset("ICESM");
-	aE_vs_theta_2p_dc_ejectile->Reset("ICESM");
-	aE_vs_theta_2p_dc_recoil->Reset("ICESM");
+
+	// 1p and 2p gamma-ray histograms
+	if( react->HistByMultiplicity() ){
+		
+		gE_1p_ejectile_dc_none->Reset("ICESM");
+		gE_1p_ejectile_dc_ejectile->Reset("ICESM");
+		gE_1p_ejectile_dc_recoil->Reset("ICESM");
+		gE_1p_recoil_dc_none->Reset("ICESM");
+		gE_1p_recoil_dc_ejectile->Reset("ICESM");
+		gE_1p_recoil_dc_recoil->Reset("ICESM");
+		gE_2p_dc_none->Reset("ICESM");
+		gE_2p_dc_ejectile->Reset("ICESM");
+		gE_2p_dc_recoil->Reset("ICESM");
+		gE_vs_theta_1p_ejectile_dc_none->Reset("ICESM");
+		gE_vs_theta_1p_ejectile_dc_ejectile->Reset("ICESM");
+		gE_vs_theta_1p_ejectile_dc_recoil->Reset("ICESM");
+		gE_vs_theta_1p_recoil_dc_none->Reset("ICESM");
+		gE_vs_theta_1p_recoil_dc_ejectile->Reset("ICESM");
+		gE_vs_theta_1p_recoil_dc_recoil->Reset("ICESM");
+		gE_vs_theta_2p_dc_none->Reset("ICESM");
+		gE_vs_theta_2p_dc_ejectile->Reset("ICESM");
+		gE_vs_theta_2p_dc_recoil->Reset("ICESM");
+
+		aE_1p_ejectile_dc_none->Reset("ICESM");
+		aE_1p_ejectile_dc_ejectile->Reset("ICESM");
+		aE_1p_ejectile_dc_recoil->Reset("ICESM");
+		aE_1p_recoil_dc_none->Reset("ICESM");
+		aE_1p_recoil_dc_ejectile->Reset("ICESM");
+		aE_1p_recoil_dc_recoil->Reset("ICESM");
+		aE_2p_dc_none->Reset("ICESM");
+		aE_2p_dc_ejectile->Reset("ICESM");
+		aE_2p_dc_recoil->Reset("ICESM");
+		aE_vs_theta_1p_ejectile_dc_none->Reset("ICESM");
+		aE_vs_theta_1p_ejectile_dc_ejectile->Reset("ICESM");
+		aE_vs_theta_1p_ejectile_dc_recoil->Reset("ICESM");
+		aE_vs_theta_1p_recoil_dc_none->Reset("ICESM");
+		aE_vs_theta_1p_recoil_dc_ejectile->Reset("ICESM");
+		aE_vs_theta_1p_recoil_dc_recoil->Reset("ICESM");
+		aE_vs_theta_2p_dc_none->Reset("ICESM");
+		aE_vs_theta_2p_dc_ejectile->Reset("ICESM");
+		aE_vs_theta_2p_dc_recoil->Reset("ICESM");
+
+	}
 	
 	// T1 impact time
 	if( react->HistByT1() ) {
 		
+		gE_ejectile_dc_none_t1->Reset("ICESM");
 		gE_ejectile_dc_ejectile_t1->Reset("ICESM");
 		gE_ejectile_dc_recoil_t1->Reset("ICESM");
+		gE_recoil_dc_none_t1->Reset("ICESM");
 		gE_recoil_dc_ejectile_t1->Reset("ICESM");
 		gE_recoil_dc_recoil_t1->Reset("ICESM");
-		gE_2p_dc_ejectile_t1->Reset("ICESM");
-		gE_2p_dc_recoil_t1->Reset("ICESM");
+
+		aE_ejectile_dc_none_t1->Reset("ICESM");
 		aE_ejectile_dc_ejectile_t1->Reset("ICESM");
 		aE_ejectile_dc_recoil_t1->Reset("ICESM");
+		aE_recoil_dc_none_t1->Reset("ICESM");
 		aE_recoil_dc_ejectile_t1->Reset("ICESM");
 		aE_recoil_dc_recoil_t1->Reset("ICESM");
-		aE_2p_dc_ejectile_t1->Reset("ICESM");
-		aE_2p_dc_recoil_t1->Reset("ICESM");
+
+		// 1p and 2p gamma-ray histograms
+		if( react->HistByMultiplicity() ){
+			
+			gE_1p_ejectile_dc_none_t1->Reset("ICESM");
+			gE_1p_ejectile_dc_ejectile_t1->Reset("ICESM");
+			gE_1p_ejectile_dc_recoil_t1->Reset("ICESM");
+			gE_1p_recoil_dc_none_t1->Reset("ICESM");
+			gE_1p_recoil_dc_ejectile_t1->Reset("ICESM");
+			gE_1p_recoil_dc_recoil_t1->Reset("ICESM");
+			gE_2p_dc_ejectile_t1->Reset("ICESM");
+			gE_2p_dc_recoil_t1->Reset("ICESM");
+			
+			aE_1p_ejectile_dc_none_t1->Reset("ICESM");
+			aE_1p_ejectile_dc_ejectile_t1->Reset("ICESM");
+			aE_1p_ejectile_dc_recoil_t1->Reset("ICESM");
+			aE_1p_recoil_dc_none_t1->Reset("ICESM");
+			aE_1p_recoil_dc_ejectile_t1->Reset("ICESM");
+			aE_1p_recoil_dc_recoil_t1->Reset("ICESM");
+			aE_2p_dc_ejectile_t1->Reset("ICESM");
+			aE_2p_dc_recoil_t1->Reset("ICESM");
+
+		}
 		
 	}
 	
@@ -1334,18 +1770,38 @@ void MiniballHistogrammer::ResetHists() {
 		gE_vs_crystal_recoil_dc_none->Reset("ICESM");
 		gE_vs_crystal_recoil_dc_ejectile->Reset("ICESM");
 		gE_vs_crystal_recoil_dc_recoil->Reset("ICESM");
-		gE_vs_crystal_2p_dc_none->Reset("ICESM");
-		gE_vs_crystal_2p_dc_ejectile->Reset("ICESM");
-		gE_vs_crystal_2p_dc_recoil->Reset("ICESM");
+
 		aE_vs_crystal_ejectile_dc_none->Reset("ICESM");
 		aE_vs_crystal_ejectile_dc_ejectile->Reset("ICESM");
 		aE_vs_crystal_ejectile_dc_recoil->Reset("ICESM");
 		aE_vs_crystal_recoil_dc_none->Reset("ICESM");
 		aE_vs_crystal_recoil_dc_ejectile->Reset("ICESM");
 		aE_vs_crystal_recoil_dc_recoil->Reset("ICESM");
-		aE_vs_crystal_2p_dc_none->Reset("ICESM");
-		aE_vs_crystal_2p_dc_ejectile->Reset("ICESM");
-		aE_vs_crystal_2p_dc_recoil->Reset("ICESM");
+
+		// 1p and 2p gamma-ray histograms
+		if( react->HistByMultiplicity() ){
+			
+			gE_vs_crystal_1p_ejectile_dc_none->Reset("ICESM");
+			gE_vs_crystal_1p_ejectile_dc_ejectile->Reset("ICESM");
+			gE_vs_crystal_1p_ejectile_dc_recoil->Reset("ICESM");
+			gE_vs_crystal_1p_recoil_dc_none->Reset("ICESM");
+			gE_vs_crystal_1p_recoil_dc_ejectile->Reset("ICESM");
+			gE_vs_crystal_1p_recoil_dc_recoil->Reset("ICESM");
+			gE_vs_crystal_2p_dc_none->Reset("ICESM");
+			gE_vs_crystal_2p_dc_ejectile->Reset("ICESM");
+			gE_vs_crystal_2p_dc_recoil->Reset("ICESM");
+			
+			aE_vs_crystal_1p_ejectile_dc_none->Reset("ICESM");
+			aE_vs_crystal_1p_ejectile_dc_ejectile->Reset("ICESM");
+			aE_vs_crystal_1p_ejectile_dc_recoil->Reset("ICESM");
+			aE_vs_crystal_1p_recoil_dc_none->Reset("ICESM");
+			aE_vs_crystal_1p_recoil_dc_ejectile->Reset("ICESM");
+			aE_vs_crystal_1p_recoil_dc_recoil->Reset("ICESM");
+			aE_vs_crystal_2p_dc_none->Reset("ICESM");
+			aE_vs_crystal_2p_dc_ejectile->Reset("ICESM");
+			aE_vs_crystal_2p_dc_recoil->Reset("ICESM");
+			
+		}
 
 	}
 	
@@ -1390,7 +1846,7 @@ void MiniballHistogrammer::ResetHists() {
 		eE_singles_ebis_on->Reset("ICESM");
 		eE_singles_ebis_off->Reset("ICESM");
 		electron_xy_map->Reset("ICESM");
-
+		
 		eE_prompt->Reset("ICESM");
 		eE_prompt_1p->Reset("ICESM");
 		eE_prompt_2p->Reset("ICESM");
@@ -1403,18 +1859,37 @@ void MiniballHistogrammer::ResetHists() {
 		eE_recoil_dc_none->Reset("ICESM");
 		eE_recoil_dc_ejectile->Reset("ICESM");
 		eE_recoil_dc_recoil->Reset("ICESM");
-		eE_2p_dc_none->Reset("ICESM");
-		eE_2p_dc_ejectile->Reset("ICESM");
-		eE_2p_dc_recoil->Reset("ICESM");
 		eE_vs_theta_ejectile_dc_none->Reset("ICESM");
 		eE_vs_theta_ejectile_dc_ejectile->Reset("ICESM");
 		eE_vs_theta_ejectile_dc_recoil->Reset("ICESM");
 		eE_vs_theta_recoil_dc_none->Reset("ICESM");
 		eE_vs_theta_recoil_dc_ejectile->Reset("ICESM");
 		eE_vs_theta_recoil_dc_recoil->Reset("ICESM");
-		eE_vs_theta_2p_dc_none->Reset("ICESM");
-		eE_vs_theta_2p_dc_ejectile->Reset("ICESM");
-		eE_vs_theta_2p_dc_recoil->Reset("ICESM");
+		
+		// 1p and 2p gamma-ray histograms
+		if( react->HistByMultiplicity() ){
+			
+			eE_1p_ejectile_dc_none->Reset("ICESM");
+			eE_1p_ejectile_dc_ejectile->Reset("ICESM");
+			eE_1p_ejectile_dc_recoil->Reset("ICESM");
+			eE_1p_recoil_dc_none->Reset("ICESM");
+			eE_1p_recoil_dc_ejectile->Reset("ICESM");
+			eE_1p_recoil_dc_recoil->Reset("ICESM");
+			eE_2p_dc_none->Reset("ICESM");
+			eE_2p_dc_ejectile->Reset("ICESM");
+			eE_2p_dc_recoil->Reset("ICESM");
+			eE_vs_theta_1p_ejectile_dc_none->Reset("ICESM");
+			eE_vs_theta_1p_ejectile_dc_ejectile->Reset("ICESM");
+			eE_vs_theta_1p_ejectile_dc_recoil->Reset("ICESM");
+			eE_vs_theta_1p_recoil_dc_none->Reset("ICESM");
+			eE_vs_theta_1p_recoil_dc_ejectile->Reset("ICESM");
+			eE_vs_theta_1p_recoil_dc_recoil->Reset("ICESM");
+			eE_vs_theta_2p_dc_none->Reset("ICESM");
+			eE_vs_theta_2p_dc_ejectile->Reset("ICESM");
+			eE_vs_theta_2p_dc_recoil->Reset("ICESM");
+			
+		}
+	
 		eE_costheta_ejectile->Reset("ICESM");
 		eE_costheta_recoil->Reset("ICESM");
 		eE_vs_ejectile_dc_none_segment->Reset("ICESM");
@@ -1547,22 +2022,55 @@ void MiniballHistogrammer::FillParticleGammaHists( std::shared_ptr<GammaRayEvt> 
 		gE_vs_theta_ejectile_dc_ejectile->Fill( react->GetEjectile()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, true ), weight );
 		gE_vs_theta_ejectile_dc_recoil->Fill( react->GetEjectile()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, false ), weight );
 
+		// Check if it is 1-particle only
+		if( !react->IsRecoilDetected() && react->HistByMultiplicity() ){
+			
+			gE_1p_ejectile_dc_none->Fill( g->GetEnergy(), weight );
+			gE_1p_ejectile_dc_ejectile->Fill( react->DopplerCorrection( g, true ), weight );
+			gE_1p_ejectile_dc_recoil->Fill( react->DopplerCorrection( g, false ), weight );
+			
+			gE_vs_theta_1p_ejectile_dc_none->Fill( react->GetEjectile()->GetTheta() * TMath::RadToDeg(), g->GetEnergy(), weight );
+			gE_vs_theta_1p_ejectile_dc_ejectile->Fill( react->GetEjectile()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, true ), weight );
+			gE_vs_theta_1p_ejectile_dc_recoil->Fill( react->GetEjectile()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, false ), weight );
+			
+
+		}
+		
 		// T1 impact time
 		if( react->HistByT1() ) {
 			
+			gE_ejectile_dc_none_t1->Fill( g->GetTime() - read_evts->GetT1(), g->GetEnergy(), weight );
 			gE_ejectile_dc_ejectile_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, true ), weight );
 			gE_ejectile_dc_recoil_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, false ), weight );
+			
+			// Check if it is 1-particle only
+			if( !react->IsRecoilDetected() && react->HistByMultiplicity() ){
+				
+				gE_1p_ejectile_dc_none_t1->Fill( g->GetTime() - read_evts->GetT1(), g->GetEnergy(), weight );
+				gE_1p_ejectile_dc_ejectile_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, true ), weight );
+				gE_1p_ejectile_dc_recoil_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, false ), weight );
+
+			}
 			
 		}
 		
 		// Per crystal Doppler-corrected spectra
 		if( react->HistByCrystal() ) {
-		
+			
 			int cry = g->GetCrystal() + set->GetNumberOfMiniballCrystals() * g->GetCluster();
 			gE_vs_crystal_ejectile_dc_none->Fill( cry, g->GetEnergy(), weight );
 			gE_vs_crystal_ejectile_dc_ejectile->Fill( cry, react->DopplerCorrection( g, true ), weight );
 			gE_vs_crystal_ejectile_dc_recoil->Fill( cry, react->DopplerCorrection( g, false ), weight );
+			
+			// Check if it is 1-particle only
+			if( !react->IsRecoilDetected() && react->HistByMultiplicity() ){
+				
+				gE_vs_crystal_1p_ejectile_dc_none->Fill( cry, g->GetEnergy(), weight );
+				gE_vs_crystal_1p_ejectile_dc_ejectile->Fill( cry, react->DopplerCorrection( g, true ), weight );
+				gE_vs_crystal_1p_ejectile_dc_recoil->Fill( cry, react->DopplerCorrection( g, false ), weight );
 
+			}
+			
 		}
 		
 	}
@@ -1580,12 +2088,35 @@ void MiniballHistogrammer::FillParticleGammaHists( std::shared_ptr<GammaRayEvt> 
 		gE_vs_theta_recoil_dc_ejectile->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, true ), weight );
 		gE_vs_theta_recoil_dc_recoil->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, false ), weight );
 
+		// Check if it is 1-particle only
+		if( !react->IsEjectileDetected() && react->HistByMultiplicity() ){
+			
+			gE_1p_recoil_dc_none->Fill( g->GetEnergy(), weight );
+			gE_1p_recoil_dc_ejectile->Fill( react->DopplerCorrection( g, true ), weight );
+			gE_1p_recoil_dc_recoil->Fill( react->DopplerCorrection( g, false ), weight );
+			
+			gE_vs_theta_1p_recoil_dc_none->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), g->GetEnergy(), weight );
+			gE_vs_theta_1p_recoil_dc_ejectile->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, true ), weight );
+			gE_vs_theta_1p_recoil_dc_recoil->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, false ), weight );
+
+		}
+		
 		// T1 impact time
 		if( react->HistByT1() ) {
 			
+			gE_recoil_dc_none_t1->Fill( g->GetTime() - read_evts->GetT1(), g->GetEnergy(), weight );
 			gE_recoil_dc_ejectile_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, true ), weight );
 			gE_recoil_dc_recoil_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, false ), weight );
-
+			
+			// Check if it is 1-particle only
+			if( !react->IsEjectileDetected() && react->HistByMultiplicity() ){
+				
+				gE_1p_recoil_dc_none_t1->Fill( g->GetTime() - read_evts->GetT1(), g->GetEnergy(), weight );
+				gE_1p_recoil_dc_ejectile_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, true ), weight );
+				gE_1p_recoil_dc_recoil_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, false ), weight );
+				
+			}
+			
 		}
 
 		// Per crystal Doppler-corrected spectra
@@ -1595,6 +2126,15 @@ void MiniballHistogrammer::FillParticleGammaHists( std::shared_ptr<GammaRayEvt> 
 			gE_vs_crystal_recoil_dc_none->Fill( cry, g->GetEnergy(), weight );
 			gE_vs_crystal_recoil_dc_ejectile->Fill( cry, react->DopplerCorrection( g, true ), weight );
 			gE_vs_crystal_recoil_dc_recoil->Fill( cry, react->DopplerCorrection( g, false ), weight );
+			
+			// Check if it is 1-particle only
+			if( !react->IsEjectileDetected() && react->HistByMultiplicity() ){
+				
+				gE_vs_crystal_1p_recoil_dc_none->Fill( cry, g->GetEnergy(), weight );
+				gE_vs_crystal_1p_recoil_dc_ejectile->Fill( cry, react->DopplerCorrection( g, true ), weight );
+				gE_vs_crystal_1p_recoil_dc_recoil->Fill( cry, react->DopplerCorrection( g, false ), weight );
+
+			}
 			
 		}
 
@@ -1618,6 +2158,7 @@ void MiniballHistogrammer::FillParticleGammaHists( std::shared_ptr<GammaRayEvt> 
 		// T1 impact time
 		if( react->HistByT1() ) {
 			
+			gE_2p_dc_none_t1->Fill( g->GetTime() - read_evts->GetT1(), g->GetEnergy(), weight );
 			gE_2p_dc_ejectile_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, true ), weight );
 			gE_2p_dc_recoil_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, false ), weight );
 			
@@ -1703,11 +2244,34 @@ void MiniballHistogrammer::FillParticleGammaHists( std::shared_ptr<GammaRayAddba
 		aE_vs_theta_ejectile_dc_ejectile->Fill( react->GetEjectile()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, true ), weight );
 		aE_vs_theta_ejectile_dc_recoil->Fill( react->GetEjectile()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, false ), weight );
 
+		// Check if it is 1-particle only
+		if( !react->IsRecoilDetected() && react->HistByMultiplicity() ){
+			
+			aE_1p_ejectile_dc_none->Fill( g->GetEnergy(), weight );
+			aE_1p_ejectile_dc_ejectile->Fill( react->DopplerCorrection( g, true ), weight );
+			aE_1p_ejectile_dc_recoil->Fill( react->DopplerCorrection( g, false ), weight );
+			
+			aE_vs_theta_1p_ejectile_dc_none->Fill( react->GetEjectile()->GetTheta() * TMath::RadToDeg(), g->GetEnergy(), weight );
+			aE_vs_theta_1p_ejectile_dc_ejectile->Fill( react->GetEjectile()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, true ), weight );
+			aE_vs_theta_1p_ejectile_dc_recoil->Fill( react->GetEjectile()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, false ), weight );
+
+		}
+		
 		// T1 impact time
 		if( react->HistByT1() ) {
 			
+			aE_ejectile_dc_none_t1->Fill( g->GetTime() - read_evts->GetT1(), g->GetEnergy(), weight );
 			aE_ejectile_dc_ejectile_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, true ), weight );
 			aE_ejectile_dc_recoil_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, false ), weight );
+			
+			// Check if it is 1-particle only
+			if( !react->IsRecoilDetected() && react->HistByMultiplicity() ){
+				
+				aE_1p_ejectile_dc_none_t1->Fill( g->GetTime() - read_evts->GetT1(), g->GetEnergy(), weight );
+				aE_1p_ejectile_dc_ejectile_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, true ), weight );
+				aE_1p_ejectile_dc_recoil_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, false ), weight );
+				
+			}
 			
 		}
 
@@ -1719,6 +2283,15 @@ void MiniballHistogrammer::FillParticleGammaHists( std::shared_ptr<GammaRayAddba
 			aE_vs_crystal_ejectile_dc_ejectile->Fill( cry, react->DopplerCorrection( g, true ), weight );
 			aE_vs_crystal_ejectile_dc_recoil->Fill( cry, react->DopplerCorrection( g, false ), weight );
 			
+			// Check if it is 1-particle only
+			if( !react->IsRecoilDetected() && react->HistByMultiplicity() ){
+				
+				aE_vs_crystal_1p_ejectile_dc_none->Fill( cry, g->GetEnergy(), weight );
+				aE_vs_crystal_1p_ejectile_dc_ejectile->Fill( cry, react->DopplerCorrection( g, true ), weight );
+				aE_vs_crystal_1p_ejectile_dc_recoil->Fill( cry, react->DopplerCorrection( g, false ), weight );
+				
+			}
+
 		}
 
 	}
@@ -1736,12 +2309,35 @@ void MiniballHistogrammer::FillParticleGammaHists( std::shared_ptr<GammaRayAddba
 		aE_vs_theta_recoil_dc_ejectile->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, true ), weight );
 		aE_vs_theta_recoil_dc_recoil->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, false ), weight );
 
+		// Check if it is 1-particle only
+		if( !react->IsEjectileDetected() && react->HistByMultiplicity() ){
+
+			aE_1p_recoil_dc_none->Fill( g->GetEnergy(), weight );
+			aE_1p_recoil_dc_ejectile->Fill( react->DopplerCorrection( g, true ), weight );
+			aE_1p_recoil_dc_recoil->Fill( react->DopplerCorrection( g, false ), weight );
+			
+			aE_vs_theta_1p_recoil_dc_none->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), g->GetEnergy(), weight );
+			aE_vs_theta_1p_recoil_dc_ejectile->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, true ), weight );
+			aE_vs_theta_1p_recoil_dc_recoil->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, false ), weight );
+			
+		}
+
 		// T1 impact time
 		if( react->HistByT1() ) {
 			
+			aE_recoil_dc_none_t1->Fill( g->GetTime() - read_evts->GetT1(), g->GetEnergy(), weight );
 			aE_recoil_dc_ejectile_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, true ), weight );
 			aE_recoil_dc_recoil_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, false ), weight );
 			
+			// Check if it is 1-particle only
+			if( !react->IsEjectileDetected() && react->HistByMultiplicity() ){
+				
+				aE_1p_recoil_dc_none_t1->Fill( g->GetTime() - read_evts->GetT1(), g->GetEnergy(), weight );
+				aE_1p_recoil_dc_ejectile_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, true ), weight );
+				aE_1p_recoil_dc_recoil_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, false ), weight );
+				
+			}
+
 		}
 
 		// Per crystal Doppler-corrected spectra
@@ -1752,6 +2348,15 @@ void MiniballHistogrammer::FillParticleGammaHists( std::shared_ptr<GammaRayAddba
 			aE_vs_crystal_recoil_dc_ejectile->Fill( cry, react->DopplerCorrection( g, true ), weight );
 			aE_vs_crystal_recoil_dc_recoil->Fill( cry, react->DopplerCorrection( g, false ), weight );
 			
+			// Check if it is 1-particle only
+			if( !react->IsEjectileDetected() && react->HistByMultiplicity() ){
+				
+				aE_vs_crystal_1p_recoil_dc_none->Fill( cry, g->GetEnergy(), weight );
+				aE_vs_crystal_1p_recoil_dc_ejectile->Fill( cry, react->DopplerCorrection( g, true ), weight );
+				aE_vs_crystal_1p_recoil_dc_recoil->Fill( cry, react->DopplerCorrection( g, false ), weight );
+				
+			}
+
 		}
 
 	}
@@ -1774,6 +2379,7 @@ void MiniballHistogrammer::FillParticleGammaHists( std::shared_ptr<GammaRayAddba
 		// T1 impact time
 		if( react->HistByT1() ) {
 			
+			aE_2p_dc_none_t1->Fill( g->GetTime() - read_evts->GetT1(), g->GetEnergy(), weight );
 			aE_2p_dc_ejectile_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, true ), weight );
 			aE_2p_dc_recoil_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, false ), weight );
 			
@@ -1833,6 +2439,19 @@ void MiniballHistogrammer::FillParticleElectronHists( std::shared_ptr<SpedeEvt> 
 		eE_vs_theta_ejectile_dc_ejectile->Fill( react->GetEjectile()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( e, true ), weight );
 		eE_vs_theta_ejectile_dc_recoil->Fill( react->GetEjectile()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( e, false ), weight );
     
+		// Check if it is 1-particle only
+		if( !react->IsRecoilDetected() && react->HistByMultiplicity() ){
+			
+			eE_1p_ejectile_dc_none->Fill( e->GetEnergy(), weight );
+			eE_1p_ejectile_dc_ejectile->Fill( react->DopplerCorrection( e, true ), weight );
+			eE_1p_ejectile_dc_recoil->Fill( react->DopplerCorrection( e, false ), weight );
+			
+			eE_vs_theta_1p_ejectile_dc_none->Fill( react->GetEjectile()->GetTheta() * TMath::RadToDeg(), e->GetEnergy(), weight );
+			eE_vs_theta_1p_ejectile_dc_ejectile->Fill( react->GetEjectile()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( e, true ), weight );
+			eE_vs_theta_1p_ejectile_dc_recoil->Fill( react->GetEjectile()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( e, false ), weight );
+			
+		}
+
 		eE_vs_ejectile_dc_none_segment->Fill( e->GetEnergy(), e->GetSegment(), weight );
 		eE_vs_ejectile_dc_ejectile_segment->Fill( react->DopplerCorrection( e, true ), e->GetSegment(), weight );
 		eE_vs_ejectile_dc_recoil_segment->Fill( react->DopplerCorrection( e, false ), e->GetSegment(), weight );
@@ -1847,15 +2466,29 @@ void MiniballHistogrammer::FillParticleElectronHists( std::shared_ptr<SpedeEvt> 
 		eE_recoil_dc_none->Fill( e->GetEnergy(), weight );
 		eE_recoil_dc_ejectile->Fill( react->DopplerCorrection( e, true ), weight );
 		eE_recoil_dc_recoil->Fill( react->DopplerCorrection( e, false ), weight );
-
+		
 		eE_vs_theta_recoil_dc_none->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), e->GetEnergy(), weight );
 		eE_vs_theta_recoil_dc_ejectile->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( e, true ), weight );
 		eE_vs_theta_recoil_dc_recoil->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( e, false ), weight );
-    
+		
+		// Check if it is 1-particle only
+		if( !react->IsEjectileDetected() && react->HistByMultiplicity() ){
+			
+			eE_1p_recoil_dc_none->Fill( e->GetEnergy(), weight );
+			eE_1p_recoil_dc_ejectile->Fill( react->DopplerCorrection( e, true ), weight );
+			eE_1p_recoil_dc_recoil->Fill( react->DopplerCorrection( e, false ), weight );
+			
+			eE_vs_theta_1p_recoil_dc_none->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), e->GetEnergy(), weight );
+			eE_vs_theta_1p_recoil_dc_ejectile->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( e, true ), weight );
+			eE_vs_theta_1p_recoil_dc_recoil->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( e, false ), weight );
+			
+
+		}
+
 		eE_vs_recoil_dc_none_segment->Fill( e->GetEnergy(), e->GetSegment(), weight );
 		eE_vs_recoil_dc_ejectile_segment->Fill( react->DopplerCorrection( e, true ), e->GetSegment(), weight );
 		eE_vs_recoil_dc_recoil_segment->Fill( react->DopplerCorrection( e, false ), e->GetSegment(), weight );
- 
+		
 	}
 	
 	// Two-particle spectra

--- a/src/Reaction.cc
+++ b/src/Reaction.cc
@@ -269,6 +269,7 @@ void MiniballReaction::ReadReaction() {
 	// Histogram options
 	hist_segment_phi = config->GetValue( "Histograms.SegmentPhi", false );	// turn on histograms for segment phi
 	hist_by_crystal = config->GetValue( "Histograms.ByCrystal", false );	// turn on histograms for gamma-gamma
+	hist_by_pmult = config->GetValue( "Histograms.ByMultiplicity", false );	// turn on particle-gamma(-electron) spectra by multiplicity, i.e. 1p and 2p spectra
 	hist_by_sector = config->GetValue( "Histograms.BySector", false );	// turn on sector-by-sector histograms for particles
 	hist_by_t1 = config->GetValue( "Histograms.ByT1", false );	// turn on histograms as a function of T1
 	hist_gamma_gamma = config->GetValue( "Histograms.GammaGamma", true );	// turn on histograms for gamma-gamma


### PR DESCRIPTION
Calibration defaults can now be given globally, per sfp or per board, as well as the individual channels. Useful for making time shifts on a board level, for example.

Some changes to the event builder such that a beamdump or ionisation chamber won't open an event were considered but reversed. This is in case there is a high rate in the beam dump detector that might interfere with event building. However, this can lead to huge and unphysical events if there are no Miniball or CD triggers to officially open the event. If the user wants to suppress the ionisation chamber or beam dump triggers, they will need to increase the software threshold instead.

Histogrammer changes so that the particle multiplicity is explicitly given for the gamma-ray histograms to help splitting of the data for Gosia analysis, for example.

Clipped and pileup logic fixed for old DAQ and confirmed to not effect "Info" events such as the EBIS or T1 pulses.