### PR TITLE
SuperSuperSorter

### DIFF
--- a/include/Converter.hh
+++ b/include/Converter.hh
@@ -73,7 +73,9 @@ public:
 	inline bool EBISWindow( long long int t ){
 		if( ebis_period == 0 ) return false;
 		else {
-			long long test_t = ( t - ebis_tm_stp ) % ebis_period;
+			// Note: (a % b) is not in range 0..b-1 for negative a.
+			long long test_t = ((( t - ebis_tm_stp ) % ebis_period ) +
+								ebis_period ) % ebis_period;
 			return ( test_t < 4000000 && test_t > 0 );
 		}
 	};
@@ -146,7 +148,7 @@ protected:
 	
 	// Maximum size of the ADC value
 	unsigned long long qmax_default;
-	
+
 	// Data types
 	std::shared_ptr<MBSInfoPackets> mbsinfo_packet = nullptr;
 	std::shared_ptr<MiniballDataPackets> write_packet = nullptr;

--- a/include/Converter.hh
+++ b/include/Converter.hh
@@ -148,15 +148,15 @@ protected:
 	unsigned long long qmax_default;
 	
 	// Data types
-	std::unique_ptr<MBSInfoPackets> mbsinfo_packet = nullptr;
-	std::unique_ptr<MiniballDataPackets> data_packet = nullptr;
+	std::shared_ptr<MBSInfoPackets> mbsinfo_packet = nullptr;
+	std::shared_ptr<MiniballDataPackets> write_packet = nullptr;
 	std::shared_ptr<DgfData> dgf_data;
 	std::shared_ptr<AdcData> adc_data;
 	std::shared_ptr<FebexData> febex_data;
 	std::shared_ptr<InfoData> info_data;
 
 	// Vector for storing the data packets before time ordering
-	std::vector<MiniballDataPackets> data_vector;
+	std::vector<std::shared_ptr<MiniballDataPackets>> data_vector;
 
 	// Output stuff
 	std::string output_dir_name;

--- a/include/Converter.hh
+++ b/include/Converter.hh
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <sstream>
 #include <string>
+#include <algorithm>
 
 #include <TFile.h>
 #include <TTree.h>
@@ -48,7 +49,10 @@ public:
 	void MakeTree();
 	void StartFile();
 	void BuildMbsIndex();
+	void SortDataVector();
 	unsigned long long int SortTree( bool do_sort = true );
+	static bool TimeComparator( const std::shared_ptr<MiniballDataPackets> &lhs,
+							    const std::shared_ptr<MiniballDataPackets> &rhs );
 
 	void SetOutput( std::string output_file_name );
 	inline void SetOutputDirectory( std::string output_dir ){ output_dir_name = output_dir; };

--- a/include/Converter.hh
+++ b/include/Converter.hh
@@ -50,9 +50,12 @@ public:
 	void StartFile();
 	void BuildMbsIndex();
 	void SortDataVector();
+	void SortDataMap();
 	unsigned long long int SortTree( bool do_sort = true );
 	static bool TimeComparator( const std::shared_ptr<MiniballDataPackets> &lhs,
 							    const std::shared_ptr<MiniballDataPackets> &rhs );
+	static bool MapComparator( const std::pair<unsigned long,double> &lhs,
+							   const std::pair<unsigned long,double> &rhs );
 
 	void SetOutput( std::string output_file_name );
 	inline void SetOutputDirectory( std::string output_dir ){ output_dir_name = output_dir; };
@@ -163,6 +166,7 @@ protected:
 
 	// Vector for storing the data packets before time ordering
 	std::vector<std::shared_ptr<MiniballDataPackets>> data_vector;
+	std::vector<std::pair<unsigned long,double>> data_map;
 
 	// Output stuff
 	std::string output_dir_name;

--- a/include/DataPackets.hh
+++ b/include/DataPackets.hh
@@ -463,8 +463,8 @@ public:
 	unsigned char GetChannel() const;
 
 	// Sorting function to do time ordering
-	bool operator < ( const MiniballDataPackets &data ) const {
-		return( this->GetTime() < data.GetTime() );
+	bool operator <( const MiniballDataPackets &rhs ) const {
+		return( GetTime() < rhs.GetTime() );
 	};
 
 	void ClearData();

--- a/include/DataPackets.hh
+++ b/include/DataPackets.hh
@@ -416,23 +416,22 @@ public:
 	MiniballDataPackets() {};
 	~MiniballDataPackets() {};
 
-	MiniballDataPackets( std::unique_ptr<MiniballDataPackets> &in ) {
-		if( in->IsDgf() )	SetData( in->GetDgfData() );
-		if( in->IsAdc() )	SetData( in->GetAdcData() );
-		if( in->IsFebex() )	SetData( in->GetFebexData() );
-		if( in->IsInfo() )	SetData( in->GetInfoData() );
-	};
+	MiniballDataPackets( std::shared_ptr<MiniballDataPackets> in ) { SetData(in); };
+	MiniballDataPackets( std::shared_ptr<DgfData> in ){ SetData(in); };
+	MiniballDataPackets( std::shared_ptr<AdcData> in ){ SetData(in); };
+	MiniballDataPackets( std::shared_ptr<FebexData> in ){ SetData(in); };
+	MiniballDataPackets( std::shared_ptr<InfoData> in ){ SetData(in); };
 
 	inline bool	IsDgf() const { return dgf_packets.size(); };
 	inline bool	IsAdc() const { return adc_packets.size(); };
 	inline bool	IsFebex() const { return febex_packets.size(); };
 	inline bool	IsInfo() const { return info_packets.size(); };
 
-	void SetData( MiniballDataPackets in ){
-		if( in.IsDgf() )	SetData( in.GetDgfData() );
-		if( in.IsAdc() )	SetData( in.GetAdcData() );
-		if( in.IsFebex() )	SetData( in.GetFebexData() );
-		if( in.IsInfo() )	SetData( in.GetInfoData() );
+	void SetData( std::shared_ptr<MiniballDataPackets> in ){
+		if( in->IsDgf() )	SetData( in->GetDgfData() );
+		if( in->IsAdc() )	SetData( in->GetAdcData() );
+		if( in->IsFebex() )	SetData( in->GetFebexData() );
+		if( in->IsInfo() )	SetData( in->GetInfoData() );
 	};
 	void SetData( std::shared_ptr<DgfData> data );
 	void SetData( std::shared_ptr<AdcData> data );
@@ -477,7 +476,7 @@ protected:
 	std::vector<FebexData>		febex_packets;
 	std::vector<InfoData>		info_packets;
 
-	ClassDef( MiniballDataPackets, 3 )
+	ClassDef( MiniballDataPackets, 5 )
 
 };
 

--- a/include/MidasConverter.hh
+++ b/include/MidasConverter.hh
@@ -98,7 +98,8 @@ private:
 	static const int DATA_BLOCK_SIZE = 0x10000; // Block size for FEBEX data = 64 kB?
 	static const int MAIN_SIZE = DATA_BLOCK_SIZE - HEADER_SIZE;
 	static const int WORD_SIZE = 5 * ( MAIN_SIZE / ( 5 * sizeof(ULong64_t) ) );
-	
+	unsigned int BLOCKS_NUM = 0;
+
 	// Set the arrays for the block components.
 	char block_header[HEADER_SIZE];
 	char block_data[MAIN_SIZE];

--- a/mb_sort.cc
+++ b/mb_sort.cc
@@ -456,6 +456,10 @@ void do_convert() {
 			ftest.close();
 			rtest = new TFile( name_output_file.data() );
 			if( rtest->IsZombie() ) force_convert.at(i) = true;
+			if( rtest->TestBit(TFile::kRecovered) ){
+				std::cout << name_output_file << " possibly corrupted, reconverting" << std::endl;
+				force_convert.at(i) = true;
+			}
 			if( !flag_convert && !force_convert.at(i) )
 				std::cout << name_output_file << " already converted" << std::endl;
 			rtest->Close();
@@ -591,6 +595,10 @@ bool do_build() {
 				ftest.close();
 				rtest = new TFile( name_output_file.data() );
 				if( rtest->IsZombie() ) force_events = true;
+				if( rtest->TestBit(TFile::kRecovered) ){
+					std::cout << name_output_file << " possibly corrupted, rebuilding" << std::endl;
+					force_events = true;
+				}
 				if( !force_events )
 					std::cout << name_output_file << " already built" << std::endl;
 				rtest->Close();

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -567,6 +567,19 @@ void MiniballConverter::BuildMbsIndex(){
 	
 }
 
+bool MiniballConverter::TimeComparator( const std::shared_ptr<MiniballDataPackets> &lhs,
+									    const std::shared_ptr<MiniballDataPackets> &rhs ) {
+
+	return lhs->GetTime() < rhs->GetTime();
+
+}
+
+void MiniballConverter::SortDataVector() {
+
+	// Sort the data vector as we go along
+	std::sort( data_vector.begin(), data_vector.end(), TimeComparator );
+
+}
 
 unsigned long long int MiniballConverter::SortTree( bool do_sort ){
 
@@ -577,19 +590,14 @@ unsigned long long int MiniballConverter::SortTree( bool do_sort ){
 	long long int n_ents = data_vector.size();	// std::vector method
 
 	// Check we have entries and build time-ordered index
-	if( n_ents && do_sort ){
-
-		std::cout << "Building time-ordered index of events..." << std::endl;
-		//std::sort( data_vector.begin(), data_vector.end() ); // std::vector method
-		std::sort( data_vector.begin(), data_vector.end(),
-				  []( std::shared_ptr<MiniballDataPackets> &lhs, std::shared_ptr<MiniballDataPackets> &rhs) {
-			return lhs->GetTime() < rhs->GetTime();
-		} );
-
+	if( n_ents && do_sort ) {
+		std::cout << "Time ordering the data items..." << std::endl;
+		SortDataVector();
 	}
 	else return 0;
 
 	// Loop on t_raw entries and fill t
+	std::cout << "Writing time-ordered data items to the output tree..." << std::endl;
 	for( long long int i = 0; i < n_ents; ++i ) {
 
 		// Get the data item back from the vector

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -580,7 +580,11 @@ unsigned long long int MiniballConverter::SortTree( bool do_sort ){
 	if( n_ents && do_sort ){
 
 		std::cout << "Building time-ordered index of events..." << std::endl;
-		std::sort( data_vector.begin(), data_vector.end() ); // std::vector method
+		//std::sort( data_vector.begin(), data_vector.end() ); // std::vector method
+		std::sort( data_vector.begin(), data_vector.end(),
+				  []( std::shared_ptr<MiniballDataPackets> &lhs, std::shared_ptr<MiniballDataPackets> &rhs) {
+			return lhs->GetTime() < rhs->GetTime();
+		} );
 
 	}
 	else return 0;
@@ -589,7 +593,7 @@ unsigned long long int MiniballConverter::SortTree( bool do_sort ){
 	for( long long int i = 0; i < n_ents; ++i ) {
 
 		// Get the data item back from the vector
-		write_packet = data_vector[i];
+		write_packet->SetData( data_vector[i] );
 
 		// Fill the sorted tree
 		sorted_tree->Fill();

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -87,6 +87,7 @@ void MiniballConverter::StartFile(){
 
 	// clear the data vectors
 	std::vector<std::shared_ptr<MiniballDataPackets>>().swap(data_vector);
+	std::vector<std::pair<unsigned long,double>>().swap(data_map);
 
 	return;
 	
@@ -574,10 +575,24 @@ bool MiniballConverter::TimeComparator( const std::shared_ptr<MiniballDataPacket
 
 }
 
+bool MiniballConverter::MapComparator( const std::pair<unsigned long,double> &lhs,
+									   const std::pair<unsigned long,double> &rhs ) {
+
+	return lhs.second < rhs.second;
+
+}
+
 void MiniballConverter::SortDataVector() {
 
 	// Sort the data vector as we go along
 	std::sort( data_vector.begin(), data_vector.end(), TimeComparator );
+
+}
+
+void MiniballConverter::SortDataMap() {
+
+	// Sort the data vector as we go along
+	std::sort( data_map.begin(), data_map.end(), MapComparator );
 
 }
 
@@ -591,8 +606,8 @@ unsigned long long int MiniballConverter::SortTree( bool do_sort ){
 
 	// Check we have entries and build time-ordered index
 	if( n_ents && do_sort ) {
-		std::cout << "Time ordering the data items..." << std::endl;
-		SortDataVector();
+		std::cout << "Time ordering " << n_ents << " data items..." << std::endl;
+		SortDataMap();
 	}
 	else return 0;
 
@@ -601,7 +616,8 @@ unsigned long long int MiniballConverter::SortTree( bool do_sort ){
 	for( long long int i = 0; i < n_ents; ++i ) {
 
 		// Get the data item back from the vector
-		write_packet->SetData( data_vector[i] );
+		unsigned long idx = data_map[i].first;
+		write_packet->SetData( data_vector[idx] );
 
 		// Fill the sorted tree
 		sorted_tree->Fill();

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -86,7 +86,7 @@ void MiniballConverter::StartFile(){
 	buffer_full = false;	// first buffer not yet assumed to be full
 
 	// clear the data vectors
-	std::vector<MiniballDataPackets>().swap(data_vector);
+	std::vector<std::shared_ptr<MiniballDataPackets>>().swap(data_vector);
 
 	return;
 	
@@ -109,9 +109,9 @@ void MiniballConverter::MakeTree() {
 	const int bufsize = sizeof(FebexData) + sizeof(InfoData);
 	sorted_tree = new TTree( "mb_sort", "Time sorted, calibrated Miniball data" );
 	mbsinfo_tree = new TTree( "mbsinfo", "mbsinfo" );
-	data_packet = std::make_unique<MiniballDataPackets>();
-	mbsinfo_packet = std::make_unique<MBSInfoPackets>();
-	sorted_tree->Branch( "data", "MiniballDataPackets", data_packet.get(), bufsize, splitLevel );
+	write_packet = std::make_shared<MiniballDataPackets>();
+	mbsinfo_packet = std::make_shared<MBSInfoPackets>();
+	sorted_tree->Branch( "data", "MiniballDataPackets", write_packet.get(), bufsize, splitLevel );
 	mbsinfo_tree->Branch( "mbsinfo", "MBSInfoPackets", mbsinfo_packet.get(), sizeof(MBSInfoPackets), 0 );
 	
 	sorted_tree->SetDirectory( output_file->GetDirectory("/") );
@@ -589,7 +589,7 @@ unsigned long long int MiniballConverter::SortTree( bool do_sort ){
 	for( long long int i = 0; i < n_ents; ++i ) {
 
 		// Get the data item back from the vector
-		data_packet->SetData( data_vector[i] );
+		write_packet = data_vector[i];
 
 		// Fill the sorted tree
 		sorted_tree->Fill();

--- a/src/DataPackets.cc
+++ b/src/DataPackets.cc
@@ -120,11 +120,6 @@ void MiniballDataPackets::SetData( std::shared_ptr<InfoData> data ){
 
 void MiniballDataPackets::ClearData(){
 	
-	dgf_packets.clear();
-	adc_packets.clear();
-	febex_packets.clear();
-	info_packets.clear();
-	
 	std::vector<DgfData>().swap(dgf_packets);
 	std::vector<AdcData>().swap(adc_packets);
 	std::vector<FebexData>().swap(febex_packets);

--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -1450,9 +1450,9 @@ unsigned long MiniballEventBuilder::BuildEvents() {
 	/// Function to loop over the sort tree and build array and recoil events
 
 	// Load the full tree if possible
-	output_tree->SetMaxVirtualSize(1.0e9);	// 1.0 GB
-	input_tree->SetMaxVirtualSize(2.2e9); 	// 2.2 GB
-	input_tree->LoadBaskets(2.0e9); 		// Load 2.0 GB of data to memory
+	//output_tree->SetMaxVirtualSize(1.0e9);	// 1.0 GB
+	//input_tree->SetMaxVirtualSize(2.2e9); 	// 2.2 GB
+	//input_tree->LoadBaskets(2.0e9); 		// Load 2.0 GB of data to memory
 
 	if( input_tree->LoadTree(0) < 0 ){
 		

--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -1450,9 +1450,9 @@ unsigned long MiniballEventBuilder::BuildEvents() {
 	/// Function to loop over the sort tree and build array and recoil events
 
 	// Load the full tree if possible
-	//output_tree->SetMaxVirtualSize(200e6);	// 200 MB
-	//input_tree->SetMaxVirtualSize(200e6); 	// 200 MB
-	//input_tree->LoadBaskets(200e6); 		// Load 200 MB of data to memory
+	output_tree->SetMaxVirtualSize(1.0e9);	// 1.0 GB
+	input_tree->SetMaxVirtualSize(2.2e9); 	// 2.2 GB
+	input_tree->LoadBaskets(2.0e9); 		// Load 2.0 GB of data to memory
 
 	if( input_tree->LoadTree(0) < 0 ){
 		
@@ -1478,10 +1478,6 @@ unsigned long MiniballEventBuilder::BuildEvents() {
 	// ------------------------------------------------------------------------ //
 	for( unsigned long i = 0; i < n_entries; ++i ) {
 		
-		// Current event data
-		//if( input_tree->MemoryFull(30e6) )
-		//	input_tree->DropBaskets();
-
 		// First event, yes please!
 		if( i == 0 ){
 
@@ -2287,11 +2283,6 @@ unsigned long MiniballEventBuilder::BuildEvents() {
 				    write_evts->GetIonChamberMultiplicity() ||
 				    write_evts->GetBeamDumpMultiplicity() )
 					output_tree->Fill();
-
-
-				// Clean up if the next event is going to make the tree full
-				//if( output_tree->MemoryFull(30e6) )
-				//	output_tree->DropBaskets();
 
 			}
 			

--- a/src/MbsConverter.cc
+++ b/src/MbsConverter.cc
@@ -414,8 +414,14 @@ void MiniballMbsConverter::FinishFebexData(){
 		info_data->SetSfp( febex_data->GetSfp() );
 		info_data->SetBoard( febex_data->GetBoard() );
 		info_data->SetCode( my_info_code );
-		write_packet->SetData( info_data );
-		data_vector.emplace_back( write_packet ); // std::vector method for time ordering
+
+		if( !flag_source ) {
+			std::shared_ptr<MiniballDataPackets> data_packet =
+				std::make_shared<MiniballDataPackets>( info_data );
+			data_vector.emplace_back( data_packet );
+			data_map.push_back( std::make_pair<unsigned long,double>(
+				 data_vector.size()-1, data_packet->GetTime() ) );
+		}
 
 	}
 	
@@ -437,8 +443,13 @@ void MiniballMbsConverter::FinishFebexData(){
 		// Set this data and fill event to tree
 		// Also add the time offset when we do this
 		febex_data->SetTime( time_corr );
-		write_packet->SetData( febex_data );
-		data_vector.emplace_back( write_packet ); // std::vector method for time ordering
+		if( !flag_source ) {
+			std::shared_ptr<MiniballDataPackets> data_packet =
+				std::make_shared<MiniballDataPackets>( febex_data );
+			data_vector.emplace_back( data_packet );
+			data_map.push_back( std::make_pair<unsigned long,double>(
+				data_vector.size()-1, data_packet->GetTime() ) );
+		}
 
 	}
 	

--- a/src/MbsConverter.cc
+++ b/src/MbsConverter.cc
@@ -417,7 +417,6 @@ void MiniballMbsConverter::FinishFebexData(){
 		write_packet->SetData( info_data );
 		data_vector.emplace_back( write_packet ); // std::vector method for time ordering
 
-
 	}
 	
 	// Otherwise it is real data, so fill a FEBEX event

--- a/src/MbsConverter.cc
+++ b/src/MbsConverter.cc
@@ -414,8 +414,8 @@ void MiniballMbsConverter::FinishFebexData(){
 		info_data->SetSfp( febex_data->GetSfp() );
 		info_data->SetBoard( febex_data->GetBoard() );
 		info_data->SetCode( my_info_code );
-		data_packet->SetData( info_data );
-		data_vector.emplace_back( data_packet ); // std::vector method for time ordering
+		write_packet->SetData( info_data );
+		data_vector.emplace_back( write_packet ); // std::vector method for time ordering
 
 
 	}
@@ -438,8 +438,8 @@ void MiniballMbsConverter::FinishFebexData(){
 		// Set this data and fill event to tree
 		// Also add the time offset when we do this
 		febex_data->SetTime( time_corr );
-		data_packet->SetData( febex_data );
-		data_vector.emplace_back( data_packet ); // std::vector method for time ordering
+		write_packet->SetData( febex_data );
+		data_vector.emplace_back( write_packet ); // std::vector method for time ordering
 
 	}
 	
@@ -461,7 +461,7 @@ void MiniballMbsConverter::FinishFebexData(){
 	ctr_febex_hit[febex_data->GetSfp()][febex_data->GetBoard()]++;
 	
 	// Clean up.
-	data_packet->ClearData();
+	write_packet->ClearData();
 	febex_data->ClearData();
 	info_data->ClearData();
 

--- a/src/MedConverter.cc
+++ b/src/MedConverter.cc
@@ -200,7 +200,7 @@ void MiniballMedConverter::ProcessMesytecAdcData() {
 
 			// Clear the old stuff
 			adc_data->ClearData();
-			data_packet->ClearData();
+			//data_packet->ClearData();
 
 			// Some basic info for every event
 			adc_data->SetEventID( my_event_id );
@@ -223,8 +223,8 @@ void MiniballMedConverter::ProcessMesytecAdcData() {
 			adc_data->SetClipped( clipped );
 
 			// Fill the tree
-			data_packet->SetData( adc_data );
-			data_vector.emplace_back( data_packet ); // std::vector method for time ordering
+			write_packet->SetData( adc_data );
+			data_vector.emplace_back( write_packet ); // std::vector method for time ordering
 
 			// Fill histograms
 			hadc_qshort[mod][ch_vec[item]]->Fill( qshort_vec[item] );
@@ -663,7 +663,7 @@ void MiniballMedConverter::ProcessDgfData() {
 						// Clear the old stuff
 						dgf_data->ClearData();
 						info_data->ClearData();
-						data_packet->ClearData();
+						//data_packet->ClearData();
 
 						//std::cout << "DGF module " << mod << ", time = ";
 						//std::cout << LongFastTriggerTime << ", Qshort = ";
@@ -694,8 +694,8 @@ void MiniballMedConverter::ProcessDgfData() {
 								info_data->SetBoard( mod );
 
 								// Fill the tree
-								data_packet->SetData( info_data );
-								data_vector.emplace_back( data_packet ); // std::vector method for time ordering
+								write_packet->SetData( info_data );
+								data_vector.emplace_back( write_packet ); // std::vector method for time ordering
 
 							}
 
@@ -719,8 +719,8 @@ void MiniballMedConverter::ProcessDgfData() {
 							dgf_data->SetUserValues( trace );
 
 							// Fill the tree
-							data_packet->SetData( dgf_data );
-							data_vector.emplace_back( data_packet ); // std::vector method for time ordering
+							write_packet->SetData( dgf_data );
+							data_vector.emplace_back( write_packet ); // std::vector method for time ordering
 
 						}
 

--- a/src/MedConverter.cc
+++ b/src/MedConverter.cc
@@ -223,8 +223,13 @@ void MiniballMedConverter::ProcessMesytecAdcData() {
 			adc_data->SetClipped( clipped );
 
 			// Fill the tree
-			write_packet->SetData( adc_data );
-			data_vector.emplace_back( write_packet ); // std::vector method for time ordering
+			if( !flag_source ) {
+				std::shared_ptr<MiniballDataPackets> data_packet =
+					std::make_shared<MiniballDataPackets>( adc_data );
+				data_vector.emplace_back( data_packet );
+				data_map.push_back( std::make_pair<unsigned long,double>(
+					data_vector.size()-1, data_packet->GetTime() ) );
+			}
 
 			// Fill histograms
 			hadc_qshort[mod][ch_vec[item]]->Fill( qshort_vec[item] );
@@ -694,8 +699,13 @@ void MiniballMedConverter::ProcessDgfData() {
 								info_data->SetBoard( mod );
 
 								// Fill the tree
-								write_packet->SetData( info_data );
-								data_vector.emplace_back( write_packet ); // std::vector method for time ordering
+								if( !flag_source ) {
+									std::shared_ptr<MiniballDataPackets> data_packet =
+										std::make_shared<MiniballDataPackets>( info_data );
+									data_vector.emplace_back( data_packet );
+									data_map.push_back( std::make_pair<unsigned long,double>(
+										data_vector.size()-1, data_packet->GetTime() ) );
+								}
 
 							}
 
@@ -719,8 +729,13 @@ void MiniballMedConverter::ProcessDgfData() {
 							dgf_data->SetUserValues( trace );
 
 							// Fill the tree
-							write_packet->SetData( dgf_data );
-							data_vector.emplace_back( write_packet ); // std::vector method for time ordering
+							if( !flag_source ) {
+								std::shared_ptr<MiniballDataPackets> data_packet =
+									std::make_shared<MiniballDataPackets>( dgf_data );
+								data_vector.emplace_back( data_packet );
+								data_map.push_back( std::make_pair<unsigned long,double>(
+									data_vector.size()-1, data_packet->GetTime() ) );
+							}
 
 						}
 

--- a/src/MidasConverter.cc
+++ b/src/MidasConverter.cc
@@ -872,6 +872,9 @@ bool MiniballMidasConverter::ProcessCurrentBlock( long nblock ) {
 	//
 	//}
 
+	// Occassionally, sort the data vector to speed things up?
+	//if( (nblock+1) % 3000 == 0 && (BLOCKS_NUM-nblock) > 3000 ) SortDataVector();
+
 	return true;
 
 }
@@ -924,7 +927,7 @@ int MiniballMidasConverter::ConvertFile( std::string input_file_name,
 	unsigned long long int FILE_SIZE = size_end - size_beg;
 	
 	// Calculate the number of blocks in the file.
-	unsigned long BLOCKS_NUM = FILE_SIZE / DATA_BLOCK_SIZE;
+	BLOCKS_NUM = FILE_SIZE / DATA_BLOCK_SIZE;
 	
 	// a sanity check for file size...
 	if( FILE_SIZE % DATA_BLOCK_SIZE != 0 ){

--- a/src/MidasConverter.cc
+++ b/src/MidasConverter.cc
@@ -604,10 +604,10 @@ void MiniballMidasConverter::FinishFebexData( long nblock ){
 				info_data->SetSfp( febex_data->GetSfp() );
 				info_data->SetBoard( febex_data->GetBoard() );
 				info_data->SetCode( my_info_code );
-				data_packet->SetData( info_data );
-				
+				write_packet->SetData( info_data );
+
 				// Fill only if we are not doing a source run
-				if( !flag_source ) data_vector.emplace_back( data_packet ); // std::vector method for time ordering
+				if( !flag_source ) data_vector.emplace_back( write_packet ); // std::vector method for time ordering
 				data_ctr++;
 
 			}
@@ -619,10 +619,10 @@ void MiniballMidasConverter::FinishFebexData( long nblock ){
 				// Set this data and fill event to tree
 				// Also add the time offset when we do this
 				febex_data->SetTime( time_corr );
-				data_packet->SetData( febex_data );
-				
+				write_packet->SetData( febex_data );
+
 				// Fill only if we are not doing a source run
-				if( !flag_source ) data_vector.emplace_back( data_packet ); // std::vector method for time ordering
+				if( !flag_source ) data_vector.emplace_back( write_packet ); // std::vector method for time ordering
 				data_ctr++;
 				
 			}
@@ -839,11 +839,11 @@ void MiniballMidasConverter::ProcessInfoData( long nblock ){
 		info_data->SetBoard( my_board_id );
 		info_data->SetTime( my_tm_stp*10 );
 		info_data->SetCode( my_info_code );
-		data_packet->SetData( info_data );
-		
+		write_packet->SetData( info_data );
+
 		// Fill only if we are not doing a source run
 		// Or comment out if we want to skip them because we're not debugging
-		if( !flag_source ) data_vector.emplace_back( data_packet ); // std::vector method for time ordering
+		if( !flag_source ) data_vector.emplace_back( write_packet ); // std::vector method for time ordering
 		info_data->Clear();
 
 	}

--- a/src/MidasConverter.cc
+++ b/src/MidasConverter.cc
@@ -604,10 +604,15 @@ void MiniballMidasConverter::FinishFebexData( long nblock ){
 				info_data->SetSfp( febex_data->GetSfp() );
 				info_data->SetBoard( febex_data->GetBoard() );
 				info_data->SetCode( my_info_code );
-				std::shared_ptr<MiniballDataPackets> data_packet = std::make_shared<MiniballDataPackets>( info_data );
 
 				// Fill only if we are not doing a source run
-				if( !flag_source ) data_vector.emplace_back( data_packet ); // std::vector method for time ordering
+				if( !flag_source ) {
+					std::shared_ptr<MiniballDataPackets> data_packet =
+						std::make_shared<MiniballDataPackets>( info_data );
+					data_vector.emplace_back( data_packet );
+					data_map.push_back( std::make_pair<unsigned long,double>(
+						data_vector.size()-1, data_packet->GetTime() ) );
+				}
 				data_ctr++;
 
 			}
@@ -619,10 +624,15 @@ void MiniballMidasConverter::FinishFebexData( long nblock ){
 				// Set this data and fill event to tree
 				// Also add the time offset when we do this
 				febex_data->SetTime( time_corr );
-				std::shared_ptr<MiniballDataPackets> data_packet = std::make_shared<MiniballDataPackets>( febex_data );
 
 				// Fill only if we are not doing a source run
-				if( !flag_source ) data_vector.emplace_back( data_packet ); // std::vector method for time ordering
+				if( !flag_source ) {
+					std::shared_ptr<MiniballDataPackets> data_packet =
+						std::make_shared<MiniballDataPackets>( febex_data );
+					data_vector.emplace_back( data_packet );
+					data_map.push_back( std::make_pair<unsigned long,double>(
+						data_vector.size()-1, data_packet->GetTime() ) );
+				}
 				data_ctr++;
 				
 			}
@@ -843,7 +853,13 @@ void MiniballMidasConverter::ProcessInfoData( long nblock ){
 
 		// Fill only if we are not doing a source run
 		// Or comment out if we want to skip them because we're not debugging
-		if( !flag_source ) data_vector.emplace_back( data_packet ); // std::vector method for time ordering
+		if( !flag_source ) {
+			std::shared_ptr<MiniballDataPackets> data_packet =
+				std::make_shared<MiniballDataPackets>( info_data );
+			data_vector.emplace_back( data_packet );
+			data_map.push_back( std::make_pair<unsigned long,double>(
+				data_vector.size()-1, data_packet->GetTime() ) );
+		}
 		info_data->Clear();
 
 	}

--- a/src/MidasConverter.cc
+++ b/src/MidasConverter.cc
@@ -604,10 +604,10 @@ void MiniballMidasConverter::FinishFebexData( long nblock ){
 				info_data->SetSfp( febex_data->GetSfp() );
 				info_data->SetBoard( febex_data->GetBoard() );
 				info_data->SetCode( my_info_code );
-				write_packet->SetData( info_data );
+				std::shared_ptr<MiniballDataPackets> data_packet = std::make_shared<MiniballDataPackets>( info_data );
 
 				// Fill only if we are not doing a source run
-				if( !flag_source ) data_vector.emplace_back( write_packet ); // std::vector method for time ordering
+				if( !flag_source ) data_vector.emplace_back( data_packet ); // std::vector method for time ordering
 				data_ctr++;
 
 			}
@@ -619,10 +619,10 @@ void MiniballMidasConverter::FinishFebexData( long nblock ){
 				// Set this data and fill event to tree
 				// Also add the time offset when we do this
 				febex_data->SetTime( time_corr );
-				write_packet->SetData( febex_data );
+				std::shared_ptr<MiniballDataPackets> data_packet = std::make_shared<MiniballDataPackets>( febex_data );
 
 				// Fill only if we are not doing a source run
-				if( !flag_source ) data_vector.emplace_back( write_packet ); // std::vector method for time ordering
+				if( !flag_source ) data_vector.emplace_back( data_packet ); // std::vector method for time ordering
 				data_ctr++;
 				
 			}
@@ -839,11 +839,11 @@ void MiniballMidasConverter::ProcessInfoData( long nblock ){
 		info_data->SetBoard( my_board_id );
 		info_data->SetTime( my_tm_stp*10 );
 		info_data->SetCode( my_info_code );
-		write_packet->SetData( info_data );
+		std::shared_ptr<MiniballDataPackets> data_packet = std::make_shared<MiniballDataPackets>( info_data );
 
 		// Fill only if we are not doing a source run
 		// Or comment out if we want to skip them because we're not debugging
-		if( !flag_source ) data_vector.emplace_back( write_packet ); // std::vector method for time ordering
+		if( !flag_source ) data_vector.emplace_back( data_packet ); // std::vector method for time ordering
 		info_data->Clear();
 
 	}


### PR DESCRIPTION
The latest sorting upgrade, now using smart pointers inside the vector so that we don't need to move the data around when we sort it, only the pointers to the memory. Tested with 50 sub runs and it is significantly faster and doesn't appear to be leaking memory.

For a single subrun as comparison:

```
Super^2-sorter = 14.24s user 1.79s system 93% cpu 17.082 total
Super-sorter   = 36.81s user 2.53s system 97% cpu 40.183 total
Root sorter    = 94.80s user 3.54s system 99% cpu 1:38.86 total
```

A factor of a 6.6 times faster overall.

This PR also includes Nigel's catch for corrupted input files in Issue #58.