### PR TITLE
SuperSpy

### DIFF
--- a/include/Converter.hh
+++ b/include/Converter.hh
@@ -47,7 +47,6 @@ public:
 
 	void MakeHists();
 	void NewBuffer();
-	void ResetHist( TObject *obj );
 	void ResetHists();
 	void MakeTree();
 	void StartFile();
@@ -223,6 +222,9 @@ protected:
 	// Progress bar
 	bool _prog_;
 	std::shared_ptr<TGProgressBar> prog;
+
+	// List of histograms for reset later
+	std::unique_ptr<TList> histlist;
 
 
 

--- a/include/Converter.hh
+++ b/include/Converter.hh
@@ -62,11 +62,11 @@ public:
 
 	inline void CloseOutput(){
 		std::cout << "\n Writing data and closing the file" << std::endl;
+		output_file->Write( nullptr, TObject::kOverwrite );
 		PurgeOutput();
 		output_file->Close();
 	};
 	inline void PurgeOutput(){
-		output_file->Write( nullptr, TObject::kOverwrite );
 		output_file->Purge(2);
 	}
 	inline TFile* GetFile(){ return output_file; };

--- a/include/Converter.hh
+++ b/include/Converter.hh
@@ -19,6 +19,8 @@
 #include <TProfile.h>
 #include <TGProgressBar.h>
 #include <TSystem.h>
+#include <TKey.h>
+#include <TROOT.h>
 
 // Settings header
 #ifndef __SETTINGS_HH
@@ -45,6 +47,7 @@ public:
 
 	void MakeHists();
 	void NewBuffer();
+	void ResetHist( TObject *obj );
 	void ResetHists();
 	void MakeTree();
 	void StartFile();

--- a/include/DataSpy.hh
+++ b/include/DataSpy.hh
@@ -34,7 +34,7 @@ extern "C" {
 #define MAX_ID 8
 #define MAX_BUFFER_SIZE 64*1024
 
-#define SHMSIZE 0x401000
+#define SHMSIZE 0x8020000
 #define SHM_KEY 110205   /* base Key */
 
 

--- a/include/EventBuilder.hh
+++ b/include/EventBuilder.hh
@@ -83,6 +83,10 @@ public:
 	inline TFile* GetFile(){ return output_file; };
 	inline TTree* GetTree(){ return output_tree; };
 	inline void CloseOutput(){
+		std::cout << "Writing output file...\r";
+		std::cout.flush();
+		output_file->Write( nullptr, TObject::kOverwrite );
+		std::cout << "Writing output file... Done!" << std::endl << std::endl;
 		output_tree->ResetBranchAddresses();
 		PurgeOutput();
 		output_file->Close();

--- a/include/EventBuilder.hh
+++ b/include/EventBuilder.hh
@@ -59,7 +59,6 @@ public:
 	void	StartFile();	///< called for every file
 	void	Initialise();	///< called for every event
 	void	MakeEventHists();
-	void	ResetHist( TObject *obj );
 	void	ResetHists();
 	
 	inline void AddCalibration( std::shared_ptr<MiniballCalibration> mycal ){
@@ -141,6 +140,9 @@ private:
 	
 	// Check if histograms are made
 	bool hists_ready = false;
+
+	// List of histograms for reset later
+	std::unique_ptr<TList> histlist;
 
 	// Log file
 	std::ofstream log_file; ///< Log file for recording the results of the MiniballEventBuilder

--- a/include/EventBuilder.hh
+++ b/include/EventBuilder.hh
@@ -59,7 +59,7 @@ public:
 	void	StartFile();	///< called for every file
 	void	Initialise();	///< called for every event
 	void	MakeEventHists();
-	void	ResetHist( TObject *obj, std::string cls );
+	void	ResetHist( TObject *obj );
 	void	ResetHists();
 	
 	inline void AddCalibration( std::shared_ptr<MiniballCalibration> mycal ){

--- a/include/Histogrammer.hh
+++ b/include/Histogrammer.hh
@@ -57,7 +57,8 @@ public:
 	void FillParticleElectronGammaHists( std::shared_ptr<SpedeEvt> s, std::shared_ptr<GammaRayEvt> g );
 	void FillParticleElectronGammaHists( std::shared_ptr<SpedeEvt> s, std::shared_ptr<GammaRayAddbackEvt> g );
 
-	void PlotPhysicsHists( std::vector<std::vector<std::string>> hists, short layout[2] );
+	void PlotPhysicsHists();
+	void SetSpyHists( std::vector<std::vector<std::string>> hists, short layout[2] );
 
 	void SetInputFile( std::vector<std::string> input_file_names );
 	void SetInputFile( std::string input_file_name );
@@ -286,8 +287,10 @@ private:
 	// Check if histograms are made
 	bool hists_ready = false;
 
-	// Canvas for the spy
+	// Canvas and hist lists for the spy
 	std::shared_ptr<TCanvas> cspy;
+	std::vector<std::vector<std::string>> spyhists;
+	short spylayout[2];
 
 	// Counters
 	unsigned long n_entries;

--- a/include/Histogrammer.hh
+++ b/include/Histogrammer.hh
@@ -88,10 +88,6 @@ public:
 		_prog_ = true;
 	};
 
-	inline void AddSpyCanvas( std::shared_ptr<TCanvas> cin ){
-		cspy = cin;
-	}; ///< Adds the canvas for the DataSpy
-
 	// Coincidence conditions (to be put in settings file eventually?)
 	inline bool	PromptCoincidence( std::shared_ptr<GammaRayEvt> g, std::shared_ptr<ParticleEvt> p ){
 		return PromptCoincidence( g, p->GetTime() );
@@ -289,10 +285,9 @@ private:
 	bool hists_ready = false;
 
 	// Canvas and hist lists for the spy
-	std::shared_ptr<TCanvas> cspy;
 	std::vector<std::vector<std::string>> spyhists;
 	short spylayout[2];
-	std::unique_ptr<TCanvas> c1;
+	std::unique_ptr<TCanvas> c1, c2;
 
 	// Counters
 	unsigned long n_entries;

--- a/include/Histogrammer.hh
+++ b/include/Histogrammer.hh
@@ -46,7 +46,6 @@ public:
 	~MiniballHistogrammer() {};
 	
 	void MakeHists();
-	void ResetHist( TObject *obj );
 	void ResetHists();
 	unsigned long FillHists();
 	void FillParticleGammaHists( std::shared_ptr<GammaRayEvt> g );
@@ -285,6 +284,9 @@ private:
 	
 	// Check if histograms are made
 	bool hists_ready = false;
+
+	// List of histograms for reset later
+	std::unique_ptr<TList> histlist;
 
 	// Canvas and hist lists for the spy
 	std::vector<std::vector<std::string>> spyhists;

--- a/include/Histogrammer.hh
+++ b/include/Histogrammer.hh
@@ -46,7 +46,7 @@ public:
 	~MiniballHistogrammer() {};
 	
 	void MakeHists();
-	void ResetHist( TObject *obj, std::string cls );
+	void ResetHist( TObject *obj );
 	void ResetHists();
 	unsigned long FillHists();
 	void FillParticleGammaHists( std::shared_ptr<GammaRayEvt> g );

--- a/include/Histogrammer.hh
+++ b/include/Histogrammer.hh
@@ -57,6 +57,7 @@ public:
 	void FillParticleElectronGammaHists( std::shared_ptr<SpedeEvt> s, std::shared_ptr<GammaRayEvt> g );
 	void FillParticleElectronGammaHists( std::shared_ptr<SpedeEvt> s, std::shared_ptr<GammaRayAddbackEvt> g );
 
+	void PlotDefaultHists();
 	void PlotPhysicsHists();
 	void SetSpyHists( std::vector<std::vector<std::string>> hists, short layout[2] );
 
@@ -291,6 +292,7 @@ private:
 	std::shared_ptr<TCanvas> cspy;
 	std::vector<std::vector<std::string>> spyhists;
 	short spylayout[2];
+	std::unique_ptr<TCanvas> c1;
 
 	// Counters
 	unsigned long n_entries;

--- a/include/Histogrammer.hh
+++ b/include/Histogrammer.hh
@@ -69,6 +69,7 @@ public:
 		MakeHists();
 	};
 	inline void CloseOutput( ){
+		output_file->Write( nullptr, TObject::kOverwrite );
 		PurgeOutput();
 		output_file->Close();
 		input_tree->ResetBranchAddresses();

--- a/include/Histogrammer.hh
+++ b/include/Histogrammer.hh
@@ -66,7 +66,6 @@ public:
 
 	inline void SetOutput( std::string output_file_name ){
 		output_file = new TFile( output_file_name.data(), "recreate" );
-		gROOT->GetListOfFiles()->Remove(output_file);
 		MakeHists();
 	};
 	inline void CloseOutput( ){

--- a/include/Histogrammer.hh
+++ b/include/Histogrammer.hh
@@ -65,6 +65,7 @@ public:
 
 	inline void SetOutput( std::string output_file_name ){
 		output_file = new TFile( output_file_name.data(), "recreate" );
+		gROOT->GetListOfFiles()->Remove(output_file);
 		MakeHists();
 	};
 	inline void CloseOutput( ){

--- a/include/Histogrammer.hh
+++ b/include/Histogrammer.hh
@@ -68,6 +68,8 @@ public:
 	inline void SetOutput( std::string output_file_name ){
 		output_file = new TFile( output_file_name.data(), "recreate" );
 		MakeHists();
+		hists_ready = true;
+		output_file->Write();
 	};
 	inline void CloseOutput( ){
 		output_file->Write( nullptr, TObject::kOverwrite );

--- a/include/MonitorMacros.hh
+++ b/include/MonitorMacros.hh
@@ -26,7 +26,7 @@ int ResetConv(){
 
 int ResetEvnt(){
 	reset_evnt_hists();
-	std::cout << "Reset event builder stage histograms (not working yet)" << std::endl;
+	std::cout << "Reset event builder stage histograms" << std::endl;
 	return 0;
 }
 

--- a/include/MonitorMacros.hh
+++ b/include/MonitorMacros.hh
@@ -4,12 +4,6 @@
 
 #include <iostream>
 
-int PlotPhysicsHists(){
-	plot_physics_hists();
-	std::cout << "Plotting physics histograms in Canvas" << std::endl;
-	return 0;
-}
-
 int ResetAll(){
 	reset_conv_hists();
 	reset_evnt_hists();

--- a/include/Reaction.hh
+++ b/include/Reaction.hh
@@ -514,6 +514,8 @@ public:
 	inline bool EventsCdPadVeto(){ return events_particle_cdpad_veto; };
 
 	// Histogram options
+	inline bool HistWithoutAddback(){ return hist_wo_addback; };
+	inline bool HistWithAddback(){ return hist_w_addback; };
 	inline bool HistSegmentPhi(){ return hist_segment_phi; };
 	inline bool HistByCrystal(){ return hist_by_crystal; };
 	inline bool HistByMultiplicity(){ return hist_by_pmult; };
@@ -625,6 +627,8 @@ private:
 	bool events_particle_cdpad_veto;
 
 	// Histogram options
+	bool hist_wo_addback;
+	bool hist_w_addback;
 	bool hist_segment_phi;
 	bool hist_by_crystal;
 	bool hist_by_pmult;

--- a/mb_sort.cc
+++ b/mb_sort.cc
@@ -289,7 +289,7 @@ void* monitor_run( void* ptr ){
 
 				// Keep reading until we have all the data
 				// This could be multi-threaded to process data and go back to read more
-				int wait_time = 20; // ms - between each read
+				int wait_time = 10; // ms - between each read
 				int block_ctr = 0;
 				long byte_ctr = 0;
 				int poll_ctr = 0;

--- a/mb_sort.cc
+++ b/mb_sort.cc
@@ -443,10 +443,12 @@ void ReadSpyHistogramList() {
 		// If not, just use some defaults
 		spylayout[0] = 2; // x
 		spylayout[1] = 2; // y
-		physhists.push_back( {"gE_singles_ebis", "TH1", "hist"} );
-		physhists.push_back( {"pE_theta", "TH2", "colz"} );
-		physhists.push_back( {"ebis_td_particle", "TH1", "hist"} );
-		physhists.push_back( {"ebis_td_gamma", "TH1", "hist"} );
+		physhists.push_back( {"GammaRaySingles/gE_singles_ebis", "TH1", "hist"} );
+		physhists.push_back( {"ParticleSpectra/pE_theta", "TH2", "colz"} );
+		physhists.push_back( {"Timing/ebis_td_particle", "TH1", "hist"} );
+		physhists.push_back( {"Timing/ebis_td_gamma", "TH1", "hist"} );
+		physhists.push_back( {"GammaRayParticleCoincidences/gE_recoil_dc_ejectile", "TH1", "hist"} );
+		physhists.push_back( {"GammaRayParticleCoincidences/gE_recoil_dc_recoil", "TH1", "hist"} );
 
 		return;
 

--- a/mb_sort.cc
+++ b/mb_sort.cc
@@ -191,8 +191,6 @@ void* monitor_run( void* ptr ){
 	std::string rootline = ".L " + std::string(CUR_DIR) + "include/MonitorMacros.hh";
 	gROOT->ProcessLine( rootline.data() );
 
-	std::cout << __LINE__ << std::endl;
-
 	// This function is called to run when monitoring
 	if( flag_mbs ){
 		conv_mbs_mon = std::make_shared<MiniballMbsConverter>( inputptr->myset );
@@ -214,8 +212,6 @@ void* monitor_run( void* ptr ){
 	
 	}
 	
-	std::cout << __LINE__ << std::endl;
-
 	// Daresbury MIDAS DataSpy
 	DataSpy myspy;
 	long long buffer[2048*1024];
@@ -223,8 +219,6 @@ void* monitor_run( void* ptr ){
 	if( flag_spy && flag_midas ) myspy.Open( file_id ); /// open the data spy
 	int spy_length = 0;
 	
-	std::cout << __LINE__ << std::endl;
-
 	// GSI MBS EventServer
 	MBS mbs;
 	if( flag_spy && flag_mbs ) mbs.OpenEventServer( "localhost", 8020 );
@@ -233,8 +227,6 @@ void* monitor_run( void* ptr ){
 	int start_block = 0, start_subevt = 0;
 	int nblocks = 0, nsubevts = 0;
 	unsigned long nbuild = 0;
-
-	std::cout << __LINE__ << std::endl;
 
 	// Converter setup
 	if( !flag_spy ) curFileMon = input_names.at(0); // maybe change in GUI later?
@@ -245,13 +237,9 @@ void* monitor_run( void* ptr ){
 	conv_mon->MakeTree();
 	conv_mon->MakeHists();
 
-	std::cout << __LINE__ << std::endl;
-
 	// Add canvas and hists for spy
 	hist_mon->SetSpyHists( inputptr->physhists, inputptr->spylayout );
 	hist_mon->AddSpyCanvas( inputptr->cspy );
-
-	std::cout << __LINE__ << std::endl;
 
 	// Update server settings
 	// title of web page
@@ -261,8 +249,6 @@ void* monitor_run( void* ptr ){
 	else toptitle = "DataSpy ";
 	toptitle += " (" + std::to_string( mon_time ) + " s)";
 	serv->SetItemField("/", "_toptitle", toptitle.data() );
-
-	std::cout << __LINE__ << std::endl;
 
 	// While the sort is running
 	while( inputptr->flag_alive ) {

--- a/mb_sort.cc
+++ b/mb_sort.cc
@@ -293,7 +293,7 @@ void* monitor_run( void* ptr ){
 				int block_ctr = 0;
 				long byte_ctr = 0;
 				int poll_ctr = 0;
-				while( block_ctr < 256 && poll_ctr < 1000 * mon_time / wait_time ){
+				while( block_ctr < 1024 && poll_ctr < 1000 * mon_time / wait_time ){
 
 					//std::cout << "Got " << spy_length << " bytes of data from DataSpy" << std::endl;
 					if( spy_length > 0 ) {

--- a/mb_sort.cc
+++ b/mb_sort.cc
@@ -120,7 +120,6 @@ std::shared_ptr<MiniballReaction> myreact;
 // Server and controls for the GUI
 std::unique_ptr<THttpServer> serv;
 int port_num = 8030;
-std::shared_ptr<TCanvas> cspy;
 std::string spy_hists_file;
 std::vector<std::vector<std::string>> physhists;
 short spylayout[2] = {2,2};
@@ -131,7 +130,6 @@ typedef struct thptr {
 	std::shared_ptr<MiniballCalibration> mycal;
 	std::shared_ptr<MiniballSettings> myset;
 	std::shared_ptr<MiniballReaction> myreact;
-	std::shared_ptr<TCanvas> cspy;
 	std::vector<std::vector<std::string>> physhists;
 	short spylayout[2];
 	bool flag_alive;
@@ -244,7 +242,6 @@ void* monitor_run( void* ptr ){
 
 	// Add canvas and hists for spy
 	hist_mon->SetSpyHists( inputptr->physhists, inputptr->spylayout );
-	hist_mon->AddSpyCanvas( inputptr->cspy );
 
 	// Update server settings
 	// title of web page
@@ -1183,9 +1180,6 @@ int main( int argc, char *argv[] ){
 			return 0;
 			
 		}
-		
-		// Make the canvas for later
-		cspy = std::make_shared<TCanvas>();
 
 		// Read the histogram list from the file
 		ReadSpyHistogramList();
@@ -1196,7 +1190,6 @@ int main( int argc, char *argv[] ){
 		data.myset = myset;
 		data.myreact = myreact;
 		data.flag_alive = flag_alive;
-		data.cspy = cspy;
 		data.physhists = physhists;
 		data.spylayout[0] = spylayout[0];
 		data.spylayout[1] = spylayout[1];

--- a/mb_sort.cc
+++ b/mb_sort.cc
@@ -220,9 +220,9 @@ void* monitor_run( void* ptr ){
 	unsigned long nbuild = 0;
 
 	// Filenames for spy
-	std::string spyname_singles = datadir_name + "/monitor_singles.root";
-	std::string spyname_events = datadir_name + "/monitor_events.root";
-	std::string spyname_hists = datadir_name + "/monitor_hists.root";
+	std::string spyname_singles = datadir_name + "/singles.root";
+	std::string spyname_events = datadir_name + "/events.root";
+	std::string spyname_hists = datadir_name + "/hists.root";
 
 	// Converter setup
 	if( !flag_spy ) curFileMon = input_names.at(0); // maybe change in GUI later?

--- a/mb_sort.cc
+++ b/mb_sort.cc
@@ -229,9 +229,9 @@ void* monitor_run( void* ptr ){
 	unsigned long nbuild = 0;
 
 	// Filenames for spy
-	std::string spyname_singles = datadir_name + "monitor_singles.root";
-	std::string spyname_events = datadir_name + "monitor_events.root";
-	std::string spyname_hists = datadir_name + "monitor_hists.root";
+	std::string spyname_singles = datadir_name + "/monitor_singles.root";
+	std::string spyname_events = datadir_name + "/monitor_events.root";
+	std::string spyname_hists = datadir_name + "/monitor_hists.root";
 
 	// Converter setup
 	if( !flag_spy ) curFileMon = input_names.at(0); // maybe change in GUI later?

--- a/mb_sort.cc
+++ b/mb_sort.cc
@@ -289,7 +289,7 @@ void* monitor_run( void* ptr ){
 
 				// Keep reading until we have all the data
 				// This could be multi-threaded to process data and go back to read more
-				int wait_time = 100; // ms - between each read
+				int wait_time = 50; // ms - between each read
 				int block_ctr = 0;
 				long byte_ctr = 0;
 				int poll_ctr = 0;
@@ -301,13 +301,14 @@ void* monitor_run( void* ptr ){
 						block_ctr += nblocks;
 						//gSystem->Sleep(1); // wait 1 ms before reading next block
 					}
-					else gSystem->Sleep( wait_time ); // wait for new data in buffer
+					else {
+						gSystem->Sleep( wait_time ); // wait for new data in buffer
+						poll_ctr++;
+					}
 
 					// Read a new block
 					spy_length = myspy.Read( file_id, (char*)buffer, inputptr->myset->GetBlockSize() );
-
 					byte_ctr += spy_length;
-					poll_ctr++;
 
 					//std::cout << block_ctr << " blocks in " << poll_ctr << " polls" << std::endl;
 

--- a/mb_sort.cc
+++ b/mb_sort.cc
@@ -298,10 +298,11 @@ void* monitor_run( void* ptr ){
 					if( spy_length > 0 ) {
 						nblocks = conv_midas_mon->ConvertBlock( (char*)buffer, 0 );
 						block_ctr += nblocks;
+						//gSystem->Sleep(1); // wait 1 ms before reading next block
 					}
+					else gSystem->Sleep( wait_time ); // wait for new data in buffer
 
 					// Read a new block
-					gSystem->Sleep( wait_time ); // wait 2 ms between each read
 					spy_length = myspy.Read( file_id, (char*)buffer, calfiles->myset->GetBlockSize() );
 					
 					byte_ctr += spy_length;

--- a/mb_sort.cc
+++ b/mb_sort.cc
@@ -442,11 +442,11 @@ void ReadSpyHistogramList() {
 
 		// If not, just use some defaults
 		spylayout[0] = 2; // x
-		spylayout[1] = 2; // y
+		spylayout[1] = 3; // y
+		physhists.push_back( {"ParticleSpectra/pE_theta_coinc", "TH2", "colz"} );
+		physhists.push_back( {"ParticleSpectra/pE_dE0", "TH2", "colz"} );
 		physhists.push_back( {"GammaRaySingles/gE_singles_ebis", "TH1", "hist"} );
-		physhists.push_back( {"ParticleSpectra/pE_theta", "TH2", "colz"} );
-		physhists.push_back( {"Timing/ebis_td_particle", "TH1", "hist"} );
-		physhists.push_back( {"Timing/ebis_td_gamma", "TH1", "hist"} );
+		physhists.push_back( {"GammaRaySingles/gE_singles_ebis_dc", "TH1", "hist"} );
 		physhists.push_back( {"GammaRayParticleCoincidences/gE_recoil_dc_ejectile", "TH1", "hist"} );
 		physhists.push_back( {"GammaRayParticleCoincidences/gE_recoil_dc_recoil", "TH1", "hist"} );
 

--- a/mb_sort.cc
+++ b/mb_sort.cc
@@ -144,13 +144,6 @@ std::shared_ptr<MiniballMidasConverter> conv_midas_mon;
 std::shared_ptr<MiniballEventBuilder> eb_mon;
 std::shared_ptr<MiniballHistogrammer> hist_mon;
 
-void plot_physics_hists(){
-	if( hist_mon.get() != nullptr )
-		hist_mon->PlotPhysicsHists();
-	else
-		std::cout << "Not ready yet, try again" << std::endl;
-}
-
 void reset_conv_hists(){
 	conv_mon->ResetHists();
 }
@@ -429,7 +422,6 @@ void start_http(){
 	serv->RegisterCommand("/ResetSingles", "ResetConv()");
 	serv->RegisterCommand("/ResetEvents", "ResetEvnt()");
 	serv->RegisterCommand("/ResetHists", "ResetHist()");
-	serv->RegisterCommand("/PlotPhysicsHists", "PlotPhysicsHists()");
 
 	// hide commands so the only show as buttons
 	//serv->Hide("/Start");

--- a/mb_sort.cc
+++ b/mb_sort.cc
@@ -228,12 +228,17 @@ void* monitor_run( void* ptr ){
 	int nblocks = 0, nsubevts = 0;
 	unsigned long nbuild = 0;
 
+	// Filenames for spy
+	std::string spyname_singles = datadir_name + "monitor_singles.root";
+	std::string spyname_events = datadir_name + "monitor_events.root";
+	std::string spyname_hists = datadir_name + "monitor_hists.root";
+
 	// Converter setup
 	if( !flag_spy ) curFileMon = input_names.at(0); // maybe change in GUI later?
 	if( flag_source ) conv_mon->SourceOnly();
 	if( flag_ebis ) conv_mon->EBISOnly();
 	conv_mon->AddCalibration( inputptr->mycal );
-	conv_mon->SetOutput( "monitor_singles.root" );
+	conv_mon->SetOutput( spyname_singles );
 	conv_mon->MakeTree();
 	conv_mon->MakeHists();
 
@@ -345,7 +350,7 @@ void* monitor_run( void* ptr ){
 			
 				// Event builder
 				if( bFirstRun ) {
-					eb_mon->SetOutput( "monitor_events.root" );
+					eb_mon->SetOutput( spyname_events );
 					eb_mon->StartFile();
 
 				}
@@ -362,7 +367,7 @@ void* monitor_run( void* ptr ){
 
 				// Histogrammer
 				if( bFirstRun ) {
-					hist_mon->SetOutput( "monitor_hists.root" );
+					hist_mon->SetOutput( spyname_hists );
 				}
 				if( nbuild ) {
 					// TODO: This could be done better with smart pointers
@@ -1011,18 +1016,16 @@ int main( int argc, char *argv[] ){
 			
 		}
 		
-		else if( flag_spy ) datadir_name = "dataspy";
-		else if( flag_angle_fit ) datadir_name = "positions";
-		else datadir_name = "mb_sort_outputs";
-				
+		else if( flag_spy ) datadir_name = "./dataspy";
+		else if( flag_angle_fit ) datadir_name = "./positions";
+		else datadir_name = "./mb_sort_outputs";
+
 	}
 	
 	// Create the directory if it doesn't exist (not Windows compliant)
 	std::string cmd = "mkdir -p " + datadir_name;
 	gSystem->Exec( cmd.data() );	
 	std::cout << "Sorted data files being saved to " << datadir_name << std::endl;
-
-	ReadSpyHistogramList();
 
 	// Check the ouput file name
 	if( output_name.length() == 0 ) {
@@ -1201,7 +1204,7 @@ int main( int argc, char *argv[] ){
 		gSystem->ProcessEvents();
 
 		// Thread for the monitor process
-		TThread *th0 = new TThread( "monitor", monitor_run, &data );
+		TThread *th0 = new TThread( "monitor", monitor_run, (void*)&data );
 		th0->Run();
 
 		// wait until we finish

--- a/mb_sort.cc
+++ b/mb_sort.cc
@@ -214,7 +214,7 @@ void* monitor_run( void* ptr ){
 	
 	// Daresbury MIDAS DataSpy
 	DataSpy myspy;
-	long long buffer[2048*1024];
+	long long buffer[8*1024];
 	int file_id = 0; ///> TapeServer volume = /dev/file/<id> ... <id> = 0 on issdaqpc2
 	if( flag_spy && flag_midas ) myspy.Open( file_id ); /// open the data spy
 	int spy_length = 0;

--- a/mb_sort.cc
+++ b/mb_sort.cc
@@ -288,10 +288,11 @@ void* monitor_run( void* ptr ){
 
 				// Keep reading until we have all the data
 				// This could be multi-threaded to process data and go back to read more
+				int wait_time = 20; // ms - between each read
 				int block_ctr = 0;
 				long byte_ctr = 0;
 				int poll_ctr = 0;
-				while( block_ctr < 2048 && poll_ctr < 1000 ){
+				while( block_ctr < 256 && poll_ctr < 1000 * mon_time / wait_time ){
 
 					//std::cout << "Got some data from DataSpy" << std::endl;
 					if( spy_length > 0 ) {
@@ -300,7 +301,7 @@ void* monitor_run( void* ptr ){
 					}
 
 					// Read a new block
-					gSystem->Sleep( 2 ); // wait 2 ms between each read
+					gSystem->Sleep( wait_time ); // wait 2 ms between each read
 					spy_length = myspy.Read( file_id, (char*)buffer, calfiles->myset->GetBlockSize() );
 					
 					byte_ctr += spy_length;

--- a/mb_sort.cc
+++ b/mb_sort.cc
@@ -446,7 +446,7 @@ void ReadSpyHistogramList() {
 		physhists.push_back( {"ParticleSpectra/pE_theta_coinc", "TH2", "colz"} );
 		physhists.push_back( {"ParticleSpectra/pE_dE0", "TH2", "colz"} );
 		physhists.push_back( {"GammaRaySingles/gE_singles_ebis", "TH1", "hist"} );
-		physhists.push_back( {"GammaRaySingles/gE_singles_ebis_dc", "TH1", "hist"} );
+		physhists.push_back( {"GammaRaySingles/gE_singles_dc_ebis", "TH1", "hist"} );
 		physhists.push_back( {"GammaRayParticleCoincidences/gE_recoil_dc_ejectile", "TH1", "hist"} );
 		physhists.push_back( {"GammaRayParticleCoincidences/gE_recoil_dc_recoil", "TH1", "hist"} );
 

--- a/mb_sort.cc
+++ b/mb_sort.cc
@@ -381,6 +381,8 @@ void* monitor_run( void* ptr ){
 				// If this was the first time we ran, do stuff?
 				if( bFirstRun ) {
 					
+					hist_mon->PlotDefaultHists();
+					hist_mon->PlotPhysicsHists();
 					bFirstRun = kFALSE;
 					
 				}

--- a/mb_sort.cc
+++ b/mb_sort.cc
@@ -964,7 +964,7 @@ int main( int argc, char *argv[] ){
 	if( flag_spy ) {
 
 		// Register signal and signal handler for DataSpy only
-		std::signal( SIGINT, signal_callback_handler );
+		//std::signal( SIGINT, signal_callback_handler );
 
 		flag_monitor = true;
 		if( mon_time < 0 ) mon_time = 30;

--- a/mb_sort.cc
+++ b/mb_sort.cc
@@ -951,7 +951,7 @@ int main( int argc, char *argv[] ){
 	if( flag_spy ) {
 
 		// Register signal and signal handler for DataSpy only
-		signal( SIGINT, signal_callback_handler );
+		std::signal( SIGINT, signal_callback_handler );
 
 		flag_monitor = true;
 		if( mon_time < 0 ) mon_time = 30;

--- a/mb_sort.cc
+++ b/mb_sort.cc
@@ -289,13 +289,13 @@ void* monitor_run( void* ptr ){
 
 				// Keep reading until we have all the data
 				// This could be multi-threaded to process data and go back to read more
-				int wait_time = 10; // ms - between each read
+				int wait_time = 100; // ms - between each read
 				int block_ctr = 0;
 				long byte_ctr = 0;
 				int poll_ctr = 0;
 				while( block_ctr < 256 && poll_ctr < 1000 * mon_time / wait_time ){
 
-					//std::cout << "Got some data from DataSpy" << std::endl;
+					//std::cout << "Got " << spy_length << " bytes of data from DataSpy" << std::endl;
 					if( spy_length > 0 ) {
 						nblocks = conv_midas_mon->ConvertBlock( (char*)buffer, 0 );
 						block_ctr += nblocks;
@@ -309,8 +309,16 @@ void* monitor_run( void* ptr ){
 					byte_ctr += spy_length;
 					poll_ctr++;
 
+					//std::cout << block_ctr << " blocks in " << poll_ctr << " polls" << std::endl;
+
 				}
-				
+
+				// Finish the last block
+				if( spy_length > 0 ) {
+					nblocks = conv_midas_mon->ConvertBlock( (char*)buffer, 0 );
+					block_ctr += nblocks;
+				}
+
 				std::cout << "Got " << byte_ctr << " bytes of data in " << block_ctr << " blocks from DataSpy" << std::endl;
 
 				// Sort the packets we just got, then do the rest of the analysis

--- a/mb_sort.cc
+++ b/mb_sort.cc
@@ -321,7 +321,7 @@ void* monitor_run( void* ptr ){
 
 				}
 				
-				std::cout << "Got " << byte_ctr << " bytes of data from DataSpy" << std::endl;
+				std::cout << "Got " << byte_ctr << " bytes of data in " << block_ctr << " blocks from DataSpy" << std::endl;
 
 				// Sort the packets we just got, then do the rest of the analysis
 				conv_midas_mon->SortTree();

--- a/mb_sort.cc
+++ b/mb_sort.cc
@@ -374,7 +374,7 @@ void* monitor_run( void* ptr ){
 					TTree *evt_tree = eb_mon->GetTree()->CloneTree();
 					hist_mon->SetInputTree( evt_tree );
 					hist_mon->FillHists();
-					//hist_mon->PurgeOutput();
+					hist_mon->PurgeOutput();
 					delete evt_tree;
 				}
 				

--- a/mb_sort.cc
+++ b/mb_sort.cc
@@ -374,7 +374,7 @@ void* monitor_run( void* ptr ){
 					TTree *evt_tree = eb_mon->GetTree()->CloneTree();
 					hist_mon->SetInputTree( evt_tree );
 					hist_mon->FillHists();
-					hist_mon->PurgeOutput();
+					//hist_mon->PurgeOutput();
 					delete evt_tree;
 				}
 				

--- a/reaction.dat
+++ b/reaction.dat
@@ -141,7 +141,7 @@
 #Events.CdPadVeto: false			# only include particle events without CD-Pad coincidences (veto) when reading from events tree
 
 ## Histogram options
-#Histograms.WithoutAddback: false	# turn on/off the making of histograms for gamma-rays without addback (default true = on)
+#Histograms.WithoutAddback: true	# turn on/off the making of histograms for gamma-rays without addback (default true = on)
 #Histograms.WithAddback: false		# turn on/off the making of histograms for gamma-rays with addback (default false = off)
 #Histograms.SegmentPhi: false		# turn on/off the making of segment-by-sgement phi histograms (default false = off)
 #Histograms.ByCrystal: false		# turn on/off the individual crystal by crystal Doppler corrected spectra (default false = off)

--- a/reaction.dat
+++ b/reaction.dat
@@ -141,6 +141,8 @@
 #Events.CdPadVeto: false			# only include particle events without CD-Pad coincidences (veto) when reading from events tree
 
 ## Histogram options
+#Histograms.WithoutAddback: false	# turn on/off the making of histograms for gamma-rays without addback (default true = on)
+#Histograms.WithAddback: false		# turn on/off the making of histograms for gamma-rays with addback (default false = off)
 #Histograms.SegmentPhi: false		# turn on/off the making of segment-by-sgement phi histograms (default false = off)
 #Histograms.ByCrystal: false		# turn on/off the individual crystal by crystal Doppler corrected spectra (default false = off)
 #Histograms.ByMultiplicity: false	# turn on/off the particle-gamma(-electron) spectra by multiplicity, i.e. 1p and 2p spectra (default false = off)

--- a/scripts/calculate_alpha_energies.cc
+++ b/scripts/calculate_alpha_energies.cc
@@ -39,13 +39,15 @@ void calculate_alpha_energies( std::string reactionfile = "default", std::string
 
 
 	// Loop over angles
-	std::vector<double> thetas = myreact->GetParticleThetas();
-	for( unsigned int i = 0; i < thetas.size()-1; i++ ){
+	for( unsigned int i = 0; i <  myset->GetNumberOfCDPStrips(); i++ ){
+
+		// Get theta
+		double theta = myreact->GetParticleTheta( 0, 0, i, 0 );
 
 		// Effective thickness
-		double thick = cd_dead / TMath::Abs( TMath::Cos( thetas[i]*TMath::DegToRad() ) );
+		double thick = cd_dead / TMath::Abs( TMath::Cos( theta ) );
 
-		std::cout << "Ring " << i << ", theta = " << thetas[i] << std::endl;
+		std::cout << "Ring " << i << ", theta = " << theta*TMath::RadToDeg() << std::endl;
 
 		// Loop over alpha energies
 		for( unsigned int j = 0; j < AlphaEnergy.size(); j++ ){

--- a/spyhists.dat
+++ b/spyhists.dat
@@ -10,9 +10,9 @@
 #
 2
 3
-GammaRaySingles/gE_singles_ebis						TH1		hist
+ParticleSpectra/pE_theta_coinc						TH2		colz
 ParticleSpectra/pE_theta							TH2		colz
-Timing/ebis_td_particle								TH1		hist
-Timing/ebis_td_gamma								TH1		hist
+GammaRaySingles/gE_singles_ebis						TH1		hist
+GammaRaySingles/gE_singles_ebis_dc					TH1		hist
 GammaRayParticleCoincidences/gE_recoil_dc_ejectile	TH1		hist
 GammaRayParticleCoincidences/gE_recoil_dc_recoil	TH1		hist

--- a/spyhists.dat
+++ b/spyhists.dat
@@ -9,8 +9,10 @@
 ## Line N = <string> <string> <string>: histogram name, type and draw option
 #
 2
-2
-gE_singles_ebis			TH1		hist
-pE_theta				TH2		colz
-ebis_td_particle		TH1		hist
-ebis_td_gamma			TH1		hist
+3
+GammaRaySingles/gE_singles_ebis						TH1		hist
+ParticleSpectra/pE_theta							TH2		colz
+Timing/ebis_td_particle								TH1		hist
+Timing/ebis_td_gamma								TH1		hist
+GammaRayParticleCoincidences/gE_recoil_dc_ejectile	TH1		hist
+GammaRayParticleCoincidences/gE_recoil_dc_recoil	TH1		hist

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -46,6 +46,9 @@ MiniballConverter::MiniballConverter( std::shared_ptr<MiniballSettings> myset ) 
 	// Histogrammer options
 	//TH1::AddDirectory(kFALSE);
 
+	// Intialise the hist list
+	histlist = std::make_unique<TList>();
+
 }
 
 void MiniballConverter::NewBuffer(){
@@ -206,21 +209,11 @@ void MiniballConverter::MakeHists() {
 				htitle = "Raw FEBEX spectra for SFP " + std::to_string(i);
 				htitle += ", board " + std::to_string(j);
 				htitle += ", channel " + std::to_string(k);
-				
 				htitle += ";Charge value;Counts";
 
-				if( output_file->GetListOfKeys()->Contains( hname.data() ) )
-					hfebex_qshort[i][j][k] = (TH1F*)output_file->Get( hname.data() );
-				
-				else {
-					
-					hfebex_qshort[i][j][k] = new TH1F( hname.data(), htitle.data(),
-													16384, 0, (unsigned long long)1<<16 );
-					
-					hfebex_qshort[i][j][k]->SetDirectory( output_file->GetDirectory( dirname.data() ) );
-					
-				}
-				
+				hfebex_qshort[i][j][k] = new TH1F( hname.data(), htitle.data(), 16384, 0, (unsigned long long)1<<16 );
+				histlist->Add(hfebex_qshort[i][j][k]);
+
 				// Uncalibrated energy 32-bit value
 				hname = "febex_" + std::to_string(i);
 				hname += "_" + std::to_string(j);
@@ -230,21 +223,11 @@ void MiniballConverter::MakeHists() {
 				htitle = "Raw FEBEX spectra for SFP " + std::to_string(i);
 				htitle += ", board " + std::to_string(j);
 				htitle += ", channel " + std::to_string(k);
-				
 				htitle += ";Charge value;Counts";
 				
-				if( output_file->GetListOfKeys()->Contains( hname.data() ) )
-					hfebex_qint[i][j][k] = (TH1F*)output_file->Get( hname.data() );
-				
-				else {
-					
-					hfebex_qint[i][j][k] = new TH1F( hname.data(), htitle.data(),
-													16384, 0, qmax_default );
-					
-					hfebex_qint[i][j][k]->SetDirectory( output_file->GetDirectory( dirname.data() ) );
-					
-				}
-				
+				hfebex_qint[i][j][k] = new TH1F( hname.data(), htitle.data(), 16384, 0, qmax_default );
+				histlist->Add(hfebex_qint[i][j][k]);
+
 				// Calibrated energy
 				hname = "febex_" + std::to_string(i);
 				hname += "_" + std::to_string(j);
@@ -254,7 +237,6 @@ void MiniballConverter::MakeHists() {
 				htitle = "Calibrated FEBEX spectra for SFP " + std::to_string(i);
 				htitle += ", board " + std::to_string(j);
 				htitle += ", channel " + std::to_string(k);
-
 				htitle += ";Energy (keV);Counts per 0.5 keV";
 				
 				// Assume gamma-ray spectrum
@@ -282,18 +264,10 @@ void MiniballConverter::MakeHists() {
 					
 				}
 				
-				if( output_file->GetListOfKeys()->Contains( hname.data() ) )
-					hfebex_cal[i][j][k] = (TH1F*)output_file->Get( hname.data() );
-				
-				else {
-					
-					hfebex_cal[i][j][k] = new TH1F( hname.data(), htitle.data(),
+				hfebex_cal[i][j][k] = new TH1F( hname.data(), htitle.data(),
 												ebins, emin, emax );
-					
-					hfebex_cal[i][j][k]->SetDirectory( output_file->GetDirectory( dirname.data() ) );
-					
-				}
-				
+				histlist->Add(hfebex_cal[i][j][k]);
+
 				// MWD energy
 				hname = "febex_" + std::to_string(i);
 				hname += "_" + std::to_string(j);
@@ -303,21 +277,11 @@ void MiniballConverter::MakeHists() {
 				htitle = "MWD FEBEX spectra for SFP " + std::to_string(i);
 				htitle += ", board " + std::to_string(j);
 				htitle += ", channel " + std::to_string(k);
-
 				htitle += ";Energy (keV);Counts per 0.5 keV";
 				
-				if( output_file->GetListOfKeys()->Contains( hname.data() ) )
-					hfebex_mwd[i][j][k] = (TH1F*)output_file->Get( hname.data() );
-				
-				else {
-					
-					hfebex_mwd[i][j][k] = new TH1F( hname.data(), htitle.data(),
-												32768, -0.25, 16383.75 );
-					
-					hfebex_mwd[i][j][k]->SetDirectory( output_file->GetDirectory( dirname.data() ) );
-					
-				}
-				
+				hfebex_mwd[i][j][k] = new TH1F( hname.data(), htitle.data(), 32768, -0.25, 16383.75 );
+				histlist->Add(hfebex_mwd[i][j][k]);
+
 			} // k - channel
 
 			// Hit ID vs timestamp
@@ -325,64 +289,32 @@ void MiniballConverter::MakeHists() {
 			hname += "_" + std::to_string(j);
 			htitle = "Profile of ts versus hit_id in SFP " + std::to_string(i);
 			htitle += ", board " + std::to_string(j);
-
-			if( output_file->GetListOfKeys()->Contains( hname.data() ) )
-				hfebex_hit[i][j] = (TProfile*)output_file->Get( hname.data() );
-			
-			else {
-				
-				hfebex_hit[i][j] = new TProfile( hname.data(), htitle.data(), 10800, 0., 108000., "" );
-				hfebex_hit[i][j]->SetDirectory( output_file->GetDirectory( dirname.data() ) );
-				
-			}
+			hfebex_hit[i][j] = new TProfile( hname.data(), htitle.data(), 10800, 0., 108000., "" );
+			histlist->Add(hfebex_hit[i][j]);
 
 			// Pause events vs timestamp
 			hname = "hfebex_pause_" + std::to_string(i);
 			hname += "_" + std::to_string(j);
 			htitle = "Profile of ts versus pause events in SFP " + std::to_string(i);
 			htitle += ", board " + std::to_string(j);
+			hfebex_pause[i][j] = new TProfile( hname.data(), htitle.data(), 1000, 0., 10000., "" );
+			histlist->Add(hfebex_pause[i][j]);
 
-			if( output_file->GetListOfKeys()->Contains( hname.data() ) )
-				hfebex_pause[i][j] = (TProfile*)output_file->Get( hname.data() );
-			
-			else {
-				
-				hfebex_pause[i][j] = new TProfile( hname.data(), htitle.data(), 1000, 0., 10000., "" );
-				hfebex_pause[i][j]->SetDirectory( output_file->GetDirectory( dirname.data() ) );
-				
-			}
-			
 			// Resume events vs timestamp
 			hname = "hfebex_resume_" + std::to_string(i);
 			hname += "_" + std::to_string(j);
 			htitle = "Profile of ts versus resume events in SFP " + std::to_string(i);
 			htitle += ", board " + std::to_string(j);
+			hfebex_resume[i][j] = new TProfile( hname.data(), htitle.data(), 1000, 0., 10000., "" );
+			histlist->Add(hfebex_resume[i][j]);
 
-			if( output_file->GetListOfKeys()->Contains( hname.data() ) )
-				hfebex_resume[i][j] = (TProfile*)output_file->Get( hname.data() );
-			
-			else {
-				
-				hfebex_resume[i][j] = new TProfile( hname.data(), htitle.data(), 1000, 0., 10000., "" );
-				hfebex_resume[i][j]->SetDirectory( output_file->GetDirectory( dirname.data() ) );
-				
-			}
-			
 			// External sync trigger vs timestamp
 			output_file->cd( maindirname.data() );
 			hname = "hfebex_sync_" + std::to_string(i);
 			hname += "_" + std::to_string(j);
 			htitle = "Profile of external sync trigger ts versus hit_id";
-			
-			if( output_file->GetListOfKeys()->Contains( hname.data() ) )
-				hfebex_sync[i][j] = (TProfile*)output_file->Get( hname.data() );
-			
-			else {
-				
-				hfebex_sync[i][j] = new TProfile( hname.data(), htitle.data(), 10800, 0., 108000., "" );
-				hfebex_sync[i][j]->SetDirectory( output_file->GetDirectory( dirname.data() ) );
-				
-			}
+			hfebex_sync[i][j] = new TProfile( hname.data(), htitle.data(), 10800, 0., 108000., "" );
+			histlist->Add(hfebex_sync[i][j]);
 
 				
 		} // j - board
@@ -416,21 +348,11 @@ void MiniballConverter::MakeHists() {
 			
 			htitle = "Raw DGF spectra for module " + std::to_string(i);
 			htitle += ", channel " + std::to_string(j);
-			
 			htitle += ";Charge value;Counts";
 			
-			if( output_file->GetListOfKeys()->Contains( hname.data() ) )
-				hdgf_qshort[i][j] = (TH1F*)output_file->Get( hname.data() );
-			
-			else {
-				
-				hdgf_qshort[i][j] = new TH1F( hname.data(), htitle.data(),
-												16384, 0, 65536 );
-				
-				hdgf_qshort[i][j]->SetDirectory( output_file->GetDirectory( dirname.data() ) );
-				
-			}
-			
+			hdgf_qshort[i][j] = new TH1F( hname.data(), htitle.data(), 16384, 0, 65536 );
+			histlist->Add(hdgf_qshort[i][j]);
+
 			// Calibrated energy
 			hname = "dgf_" + std::to_string(i);
 			hname += "_" + std::to_string(j);
@@ -438,7 +360,6 @@ void MiniballConverter::MakeHists() {
 
 			htitle = "Calibrated DGF spectra for module " + std::to_string(i);
 			htitle += ", channel " + std::to_string(j);
-			
 			htitle += ";Energy (keV);Counts per 0.5 keV";
 			
 			// Assume gamma-ray spectrum
@@ -446,17 +367,8 @@ void MiniballConverter::MakeHists() {
 			float emin = -0.25;
 			float emax = 4000.0 + emin; // 4 MeV range
 
-			if( output_file->GetListOfKeys()->Contains( hname.data() ) )
-				hdgf_cal[i][j] = (TH1F*)output_file->Get( hname.data() );
-			
-			else {
-				
-				hdgf_cal[i][j] = new TH1F( hname.data(), htitle.data(),
-											   ebins, emin, emax );
-				
-				hdgf_cal[i][j]->SetDirectory( output_file->GetDirectory( dirname.data() ) );
-				
-			}
+			hdgf_cal[i][j] = new TH1F( hname.data(), htitle.data(), ebins, emin, emax );
+			histlist->Add(hdgf_cal[i][j]);
 
 		} // j - channels
 		
@@ -483,21 +395,11 @@ void MiniballConverter::MakeHists() {
 			
 			htitle = "Raw ADC spectra for module " + std::to_string(i);
 			htitle += ", channel " + std::to_string(j);
-			
 			htitle += ";Charge value;Counts";
 			
-			if( output_file->GetListOfKeys()->Contains( hname.data() ) )
-				hadc_qshort[i][j] = (TH1F*)output_file->Get( hname.data() );
-			
-			else {
-				
-				hadc_qshort[i][j] = new TH1F( hname.data(), htitle.data(),
-											 8192, 0, 8192 );
-				
-				hadc_qshort[i][j]->SetDirectory( output_file->GetDirectory( dirname.data() ) );
-				
-			}
-			
+			hadc_qshort[i][j] = new TH1F( hname.data(), htitle.data(), 8192, 0, 8192 );
+			histlist->Add(hadc_qshort[i][j]);
+
 			// Calibrated energy
 			hname = "adc_" + std::to_string(i);
 			hname += "_" + std::to_string(j);
@@ -505,7 +407,6 @@ void MiniballConverter::MakeHists() {
 			
 			htitle = "Calibrated ADC spectra for module " + std::to_string(i);
 			htitle += ", channel " + std::to_string(j);
-			
 			htitle += ";Energy (keV);Counts per 0.5 keV";
 			
 			// Assume particle spectrum
@@ -513,18 +414,8 @@ void MiniballConverter::MakeHists() {
 			float emin = -1e3;
 			float emax = 1.2e6 + emin; // 1.2 GeV range
 			
-			if( output_file->GetListOfKeys()->Contains( hname.data() ) )
-				hadc_cal[i][j] = (TH1F*)output_file->Get( hname.data() );
-			
-			else {
-				
-				hadc_cal[i][j] = new TH1F( hname.data(), htitle.data(),
-											   ebins, emin, emax );
-				
-				hadc_cal[i][j]->SetDirectory( output_file->GetDirectory( dirname.data() ) );
-				
-			}
-			
+			hadc_cal[i][j] = new TH1F( hname.data(), htitle.data(), ebins, emin, emax );
+			histlist->Add(hadc_cal[i][j]);
 
 		} // j - channels
 		
@@ -533,6 +424,7 @@ void MiniballConverter::MakeHists() {
 	
 	// Hit time plot
 	hhit_time = new TH1F( "hhit_time", "Hit time distribution", 3200, -16000, 16000 );
+	histlist->Add(hhit_time);
 
 	// Write once
 	output_file->Write();
@@ -542,52 +434,18 @@ void MiniballConverter::MakeHists() {
 }
 
 // Reset histograms in the DataSpy
-void MiniballConverter::ResetHist( TObject *obj ) {
-
-	if( obj == nullptr ) return;
-
-	if( obj->InheritsFrom( "TH2" ) )
-		( (TH2*)obj )->Reset("ICESM");
-	else if( obj->InheritsFrom( "TH1" ) )
-		( (TH1*)obj )->Reset("ICESM");
-
-	return;
-
-}
-
-// Reset histograms in the DataSpy
 void MiniballConverter::ResetHists(){
 
-	TKey *key1, *key2, *key3;
-	TIter keyList1( gDirectory->GetListOfKeys() );
-	while( ( key1 = (TKey*)keyList1() ) ){ // level 1
+	// Loop over the hist list
+	TIter next( histlist->MakeIterator() );
+	while( TObject *obj = next() ) {
 
-		if( key1->ReadObj()->InheritsFrom("TDirectory") ){
+		if( obj->InheritsFrom( "TH2" ) )
+			( (TH2*)obj )->Reset("ICESM");
+		else if( obj->InheritsFrom( "TH1" ) )
+			( (TH1*)obj )->Reset("ICESM");
 
-			TIter keyList2( ( (TDirectory*)key1->ReadObj() )->GetListOfKeys() );
-			while( ( key2 = (TKey*)keyList2() ) ){ // level 2
-
-				if( key2->ReadObj()->InheritsFrom("TDirectory") ){
-
-					TIter keyList3( ( (TDirectory*)key2->ReadObj() )->GetListOfKeys() );
-					while( ( key3 = (TKey*)keyList3() ) ) // level 3
-						ResetHist( key3->ReadObj() );
-
-				}
-
-				else
-					ResetHist( key2->ReadObj() );
-
-			} // level 2
-
-		}
-
-		else
-			ResetHist( key1->ReadObj() );
-
-	} // level 1
-
-	return;
+	}
 
 }
 

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -44,7 +44,7 @@ MiniballConverter::MiniballConverter( std::shared_ptr<MiniballSettings> myset ) 
 	_prog_ = false;
 
 	// Histogrammer options
-	TH1::AddDirectory(kFALSE);
+	//TH1::AddDirectory(kFALSE);
 
 }
 

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -309,7 +309,6 @@ void MiniballConverter::MakeHists() {
 			histlist->Add(hfebex_resume[i][j]);
 
 			// External sync trigger vs timestamp
-			output_file->cd( maindirname.data() );
 			hname = "hfebex_sync_" + std::to_string(i);
 			hname += "_" + std::to_string(j);
 			htitle = "Profile of external sync trigger ts versus hit_id";

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -422,6 +422,7 @@ void MiniballConverter::MakeHists() {
 	
 	
 	// Hit time plot
+	output_file->cd( maindirname.data() );
 	hhit_time = new TH1F( "hhit_time", "Hit time distribution", 3200, -16000, 16000 );
 	histlist->Add(hhit_time);
 

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -42,7 +42,10 @@ MiniballConverter::MiniballConverter( std::shared_ptr<MiniballSettings> myset ) 
 	
 	// No progress bar by default
 	_prog_ = false;
-	
+
+	// Histogrammer options
+	TH1::AddDirectory(kFALSE);
+
 }
 
 void MiniballConverter::NewBuffer(){

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -64,6 +64,8 @@ void MiniballConverter::StartFile(){
 		// Start counters at zero
 		for( unsigned int j = 0; j < set->GetNumberOfFebexBoards(); ++j ) {
 					
+			first_data[i] = true;
+
 			ctr_febex_hit[i][j] = 0;	// hits on each module
 			ctr_febex_pause[i][j] = 0;
 			ctr_febex_resume[i][j] = 0;

--- a/src/Converter.cc
+++ b/src/Converter.cc
@@ -534,41 +534,61 @@ void MiniballConverter::MakeHists() {
 	// Hit time plot
 	hhit_time = new TH1F( "hhit_time", "Hit time distribution", 3200, -16000, 16000 );
 
+	// Write once
+	output_file->Write();
+
 	return;
 	
 }
 
-void MiniballConverter::ResetHists() {
+// Reset histograms in the DataSpy
+void MiniballConverter::ResetHist( TObject *obj ) {
 
-	// Loop over FEBEX SFPs
-	for( unsigned int i = 0; i < set->GetNumberOfFebexSfps(); ++i ) {
+	if( obj == nullptr ) return;
 
-		// Loop over each FEBEX board
-		for( unsigned int j = 0; j < set->GetNumberOfFebexBoards(); ++j ) {
-			
-			// Loop over channels of each FEBEX board
-			for( unsigned int k = 0; k < set->GetNumberOfFebexChannels(); ++k ) {
-				
-				hfebex_qshort[i][j][k]->Reset( "ICEMS" );
-				hfebex_qint[i][j][k]->Reset( "ICEMS" );
-				hfebex_cal[i][j][k]->Reset( "ICEMS" );
-				hfebex_mwd[i][j][k]->Reset( "ICEMS" );
-				
-			} // k - channel
+	if( obj->InheritsFrom( "TH2" ) )
+		( (TH2*)obj )->Reset("ICESM");
+	else if( obj->InheritsFrom( "TH1" ) )
+		( (TH1*)obj )->Reset("ICESM");
 
-			hfebex_hit[i][j]->Reset( "ICEMS" );
-			hfebex_pause[i][j]->Reset( "ICEMS" );
-			hfebex_resume[i][j]->Reset( "ICEMS" );
-			hfebex_sync[i][j]->Reset( "ICEMS" );
-
-		} // j - board
-		
-	} // i - SFP
-	
-	hhit_time->Reset( "ICEMS" );
-	
 	return;
-	
+
+}
+
+// Reset histograms in the DataSpy
+void MiniballConverter::ResetHists(){
+
+	TKey *key1, *key2, *key3;
+	TIter keyList1( gDirectory->GetListOfKeys() );
+	while( ( key1 = (TKey*)keyList1() ) ){ // level 1
+
+		if( key1->ReadObj()->InheritsFrom("TDirectory") ){
+
+			TIter keyList2( ( (TDirectory*)key1->ReadObj() )->GetListOfKeys() );
+			while( ( key2 = (TKey*)keyList2() ) ){ // level 2
+
+				if( key2->ReadObj()->InheritsFrom("TDirectory") ){
+
+					TIter keyList3( ( (TDirectory*)key2->ReadObj() )->GetListOfKeys() );
+					while( ( key3 = (TKey*)keyList3() ) ) // level 3
+						ResetHist( key3->ReadObj() );
+
+				}
+
+				else
+					ResetHist( key2->ReadObj() );
+
+			} // level 2
+
+		}
+
+		else
+			ResetHist( key1->ReadObj() );
+
+	} // level 1
+
+	return;
+
 }
 
 void MiniballConverter::BuildMbsIndex(){

--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -496,7 +496,7 @@ void MiniballEventBuilder::MakeEventHists(){
 	hists_ready = true;
 
 	// Write once
-	output_file->Write();
+	//output_file->Write();
 
 	return;
 	
@@ -507,10 +507,10 @@ void MiniballEventBuilder::ResetHist( TObject *obj ) {
 
 	if( obj == nullptr ) return;
 
-	if( obj->InheritsFrom( "TH1" ) )
-		( (TH1*)obj )->Reset("ICESM");
-	else if( obj->InheritsFrom( "TH2" ) )
+	if( obj->InheritsFrom( "TH2" ) )
 		( (TH2*)obj )->Reset("ICESM");
+	else if( obj->InheritsFrom( "TH1" ) )
+		( (TH1*)obj )->Reset("ICESM");
 
 	return;
 
@@ -520,7 +520,7 @@ void MiniballEventBuilder::ResetHist( TObject *obj ) {
 void MiniballEventBuilder::ResetHists(){
 
 	TKey *key1, *key2, *key3;
-	TIter keyList1( output_file->GetListOfKeys() );
+	TIter keyList1( gDirectory->GetListOfKeys() );
 	while( ( key1 = (TKey*)keyList1() ) ){ // level 1
 
 		if( key1->ReadObj()->InheritsFrom("TDirectory") ){

--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -211,6 +211,7 @@ void MiniballEventBuilder::SetOutput( std::string output_file_name ) {
 	output_tree = new TTree( "evt_tree", "evt_tree" );
 	output_tree->Branch( "MiniballEvts", "MiniballEvts", write_evts.get() );
 	output_tree->SetAutoFlush();
+	gROOT->GetListOfFiles()->Remove(output_file);
 
 	// Create log file.
 	std::string log_file_name = output_file_name.substr( 0, output_file_name.find_last_of(".") );

--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -2352,12 +2352,6 @@ unsigned long MiniballEventBuilder::BuildEvents() {
 	std::cout << ss_log.str();
 	if( log_file.is_open() && flag_input_file ) log_file << ss_log.str();
 
-	std::cout << "Writing output file...\r";
-	std::cout.flush();
-	output_file->Write( nullptr, TObject::kOverwrite );
-	
-	std::cout << "Writing output file... Done!" << std::endl << std::endl;
-
 	return n_entries;
 	
 }

--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -495,6 +495,9 @@ void MiniballEventBuilder::MakeEventHists(){
 	// flag to denote that hists are ready (used for spy)
 	hists_ready = true;
 
+	// Write once
+	output_file->Write();
+
 	return;
 	
 }
@@ -508,8 +511,6 @@ void MiniballEventBuilder::ResetHist( TObject *obj ) {
 		( (TH1*)obj )->Reset("ICESM");
 	else if( obj->InheritsFrom( "TH2" ) )
 		( (TH2*)obj )->Reset("ICESM");
-	else if( obj->InheritsFrom( "TProfile" ) )
-		( (TProfile*)obj )->Reset("ICESM");
 
 	return;
 
@@ -522,12 +523,12 @@ void MiniballEventBuilder::ResetHists(){
 	TIter keyList1( output_file->GetListOfKeys() );
 	while( ( key1 = (TKey*)keyList1() ) ){ // level 1
 
-		if( key1->InheritsFrom( "TDirectory" ) ){
+		if( key1->ReadObj()->InheritsFrom("TDirectory") ){
 
 			TIter keyList2( ( (TDirectory*)key1->ReadObj() )->GetListOfKeys() );
 			while( ( key2 = (TKey*)keyList2() ) ){ // level 2
 
-				if( key1->InheritsFrom( "TDirectory" ) ){
+				if( key2->ReadObj()->InheritsFrom("TDirectory") ){
 
 					TIter keyList3( ( (TDirectory*)key2->ReadObj() )->GetListOfKeys() );
 					while( ( key3 = (TKey*)keyList3() ) ) // level 3

--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -64,7 +64,10 @@ MiniballEventBuilder::MiniballEventBuilder( std::shared_ptr<MiniballSettings> my
 			febex_time_ch[i][j].resize( set->GetNumberOfFebexChannels(), 0 );
 			
 	}
-		
+
+	// Histogrammer options
+	TH1::AddDirectory(kFALSE);
+
 }
 
 void MiniballEventBuilder::StartFile(){

--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -500,15 +500,15 @@ void MiniballEventBuilder::MakeEventHists(){
 }
 
 // Reset histograms in the DataSpy
-void MiniballEventBuilder::ResetHist( TObject *obj, std::string cls ) {
+void MiniballEventBuilder::ResetHist( TObject *obj ) {
 
 	if( obj == nullptr ) return;
 
-	if( cls == "TH1" )
+	if( obj->InheritsFrom( "TH1" ) )
 		( (TH1*)obj )->Reset("ICESM");
-	else if( cls ==  "TH2" )
+	else if( obj->InheritsFrom( "TH2" ) )
 		( (TH2*)obj )->Reset("ICESM");
-	else if( cls ==  "TProfile" )
+	else if( obj->InheritsFrom( "TProfile" ) )
 		( (TProfile*)obj )->Reset("ICESM");
 
 	return;
@@ -522,28 +522,28 @@ void MiniballEventBuilder::ResetHists(){
 	TIter keyList1( output_file->GetListOfKeys() );
 	while( ( key1 = (TKey*)keyList1() ) ){ // level 1
 
-		if( std::strcmp( key1->GetClassName(), "TDirectory" ) == 0 ){
+		if( key1->InheritsFrom( "TDirectory" ) ){
 
 			TIter keyList2( ( (TDirectory*)key1->ReadObj() )->GetListOfKeys() );
 			while( ( key2 = (TKey*)keyList2() ) ){ // level 2
 
-				if( std::strcmp( key2->GetClassName(), "TDirectory" ) == 0 ){
+				if( key1->InheritsFrom( "TDirectory" ) ){
 
 					TIter keyList3( ( (TDirectory*)key2->ReadObj() )->GetListOfKeys() );
 					while( ( key3 = (TKey*)keyList3() ) ) // level 3
-						ResetHist( key3->ReadObj(), key3->GetClassName() );
+						ResetHist( key3->ReadObj() );
 
 				}
 
 				else
-					ResetHist( key2->ReadObj(), key2->GetClassName() );
+					ResetHist( key2->ReadObj() );
 
 			} // level 2
 
 		}
 
 		else
-			ResetHist( key1->ReadObj(), key1->GetClassName() );
+			ResetHist( key1->ReadObj() );
 
 	} // level 1
 

--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -68,6 +68,9 @@ MiniballEventBuilder::MiniballEventBuilder( std::shared_ptr<MiniballSettings> my
 	// Histogrammer options
 	//TH1::AddDirectory(kFALSE);
 
+	// Intialise the hist list
+	histlist = std::make_unique<TList>();
+
 }
 
 void MiniballEventBuilder::StartFile(){
@@ -286,6 +289,8 @@ void MiniballEventBuilder::MakeEventHists(){
 
 	tdiff = new TH1F( "tdiff", "Time difference to first trigger;#Delta t [ns]", 1e3, -10, 1e5 );
 	tdiff_clean = new TH1F( "tdiff_clean", "Time difference to first trigger without noise;#Delta t [ns]", 1e3, -10, 1e5 );
+	histlist->Add(tdiff);
+	histlist->Add(tdiff_clean);
 
 	pulser_freq = new TProfile( "pulser_freq", "Frequency of pulser in FEBEX DAQ as a function of time;time [ns];f [Hz]", 10.8e4, 0, 10.8e12 );
 	pulser_period = new TH1F( "pulser_period", "Period of pulser in FEBEX DAQ;T [ns]", 10e3, 0, 10e9 );
@@ -299,6 +304,15 @@ void MiniballEventBuilder::MakeEventHists(){
 	t1_period = new TH1F( "t1_period", "Period of T1 events (p+ on ISOLDE target);T [ns]", 10e3, 0, 10e9 );
 	sc_freq = new TProfile( "sc_freq", "Frequency of SuperCycle events as a function of time;time [ns];f [Hz]", 10.8e4, 0, 10.8e12 );
 	sc_period = new TH1F( "sc_period", "Period of SuperCycle events;T [ns]", 10e3, 0, 10e9 );
+	histlist->Add(pulser_freq);
+	histlist->Add(pulser_period);
+	histlist->Add(pulser_tdiff);
+	histlist->Add(ebis_freq);
+	histlist->Add(ebis_period);
+	histlist->Add(t1_freq);
+	histlist->Add(t1_period);
+	histlist->Add(sc_freq);
+	histlist->Add(sc_period);
 
 	// ------------------- //
 	// Miniball histograms //
@@ -310,6 +324,8 @@ void MiniballEventBuilder::MakeEventHists(){
 	
 	mb_td_core_seg  = new TH1F( "mb_td_core_seg",  "Time difference between core and segment in same crystal;#Delta t [ns]", 499, -2495, 2495 );
 	mb_td_core_core = new TH1F( "mb_td_core_core", "Time difference between two cores in same cluster;#Delta t [ns]", 499, -2495, 2495 );
+	histlist->Add(mb_td_core_seg);
+	histlist->Add(mb_td_core_core);
 
 	mb_en_core_seg.resize( set->GetNumberOfMiniballClusters() );
 	mb_en_core_seg_ebis_on.resize( set->GetNumberOfMiniballClusters() );
@@ -326,20 +342,22 @@ void MiniballEventBuilder::MakeEventHists(){
 
 		for( unsigned int j = 0; j < set->GetNumberOfMiniballCrystals(); ++j ) {
 
-				hname  = "mb_en_core_seg_" + std::to_string(i) + "_";
-				hname += std::to_string(j);
-				htitle  = "Gamma-ray spectrum from cluster " + std::to_string(i);
-				htitle += " core " + std::to_string(j) + ", gated by segment ";
-				htitle += " (multiplicity = 1 only);segment ID;Energy (keV)";
-				mb_en_core_seg[i][j] = new TH2F( hname.data(), htitle.data(), 7, -0.5, 6.5, 4096, -0.5, 4095.5 );
-				
-				hname  = "mb_en_core_seg_" + std::to_string(i) + "_";
-				hname += std::to_string(j) + "_ebis_on";
-				htitle  = "Gamma-ray spectrum from cluster " + std::to_string(i);
-				htitle += " core " + std::to_string(j) + ", gated by segment ";
-				htitle += " (multiplicity = 1 only) gated by EBIS time (1.5 ms);segment ID;Energy (keV)";
-				mb_en_core_seg_ebis_on[i][j] = new TH2F( hname.data(), htitle.data(), 7, -0.5, 6.5, 4096, -0.5, 4095.5 );
-			
+			hname  = "mb_en_core_seg_" + std::to_string(i) + "_";
+			hname += std::to_string(j);
+			htitle  = "Gamma-ray spectrum from cluster " + std::to_string(i);
+			htitle += " core " + std::to_string(j) + ", gated by segment ";
+			htitle += " (multiplicity = 1 only);segment ID;Energy (keV)";
+			mb_en_core_seg[i][j] = new TH2F( hname.data(), htitle.data(), 7, -0.5, 6.5, 4096, -0.5, 4095.5 );
+			histlist->Add(mb_en_core_seg[i][j]);
+
+			hname  = "mb_en_core_seg_" + std::to_string(i) + "_";
+			hname += std::to_string(j) + "_ebis_on";
+			htitle  = "Gamma-ray spectrum from cluster " + std::to_string(i);
+			htitle += " core " + std::to_string(j) + ", gated by segment ";
+			htitle += " (multiplicity = 1 only) gated by EBIS time (1.5 ms);segment ID;Energy (keV)";
+			mb_en_core_seg_ebis_on[i][j] = new TH2F( hname.data(), htitle.data(), 7, -0.5, 6.5, 4096, -0.5, 4095.5 );
+			histlist->Add(mb_en_core_seg_ebis_on[i][j]);
+
 		} // j
 		
 	} // i
@@ -390,7 +408,8 @@ void MiniballEventBuilder::MakeEventHists(){
 			cd_pen_id[i][j] = new TH2F( hname.data(), htitle.data(),
 									   set->GetNumberOfCDPStrips(), -0.5, set->GetNumberOfCDPStrips() - 0.5,
 									   4000, 0, 2000e3 );
-			
+			histlist->Add(cd_pen_id[i][j]);
+
 			hname  = "cd_nen_id_" + std::to_string(i) + "_" + std::to_string(j);
 			htitle  = "CD n-side energy for detector " + std::to_string(i);
 			htitle += ", sector " + std::to_string(j);
@@ -398,77 +417,88 @@ void MiniballEventBuilder::MakeEventHists(){
 			cd_nen_id[i][j] = new TH2F( hname.data(), htitle.data(),
 									   set->GetNumberOfCDNStrips(), -0.5, set->GetNumberOfCDNStrips() - 0.5,
 									   4000, 0, 2000e3 );
-			
+			histlist->Add(cd_nen_id[i][j]);
+
 			hname  = "cd_pn_1v1_" + std::to_string(i) + "_" + std::to_string(j);
 			htitle  = "CD p-side vs n-side energy, multiplicity 1v1";
 			htitle += "for detector " + std::to_string(i);
 			htitle += ", sector " + std::to_string(j);
 			htitle += ";p-side Energy (keV);n-side Energy (keV);Counts";
 			cd_pn_1v1[i][j] = new TH2F( hname.data(), htitle.data(), 4000, 0, 200e3, 400, 0, 200e3 );
-			
+			histlist->Add(cd_pn_1v1[i][j]);
+
 			hname  = "cd_pn_1v2_" + std::to_string(i) + "_" + std::to_string(j);
 			htitle  = "CD p-side vs n-side energy, multiplicity 1v2";
 			htitle += "for detector " + std::to_string(i);
 			htitle += ", sector " + std::to_string(j);
 			htitle += ";p-side Energy (keV);n-side Energy (keV);Counts";
 			cd_pn_1v2[i][j] = new TH2F( hname.data(), htitle.data(), 4000, 0, 200e3, 400, 0, 200e3 );
-			
+			histlist->Add(cd_pn_1v2[i][j]);
+
 			hname  = "cd_pn_2v1_" + std::to_string(i) + "_" + std::to_string(j);
 			htitle  = "CD p-side vs n-side energy, multiplicity 2v1";
 			htitle += "for detector " + std::to_string(i);
 			htitle += ", sector " + std::to_string(j);
 			htitle += ";p-side Energy (keV);n-side Energy (keV);Counts";
 			cd_pn_2v1[i][j] = new TH2F( hname.data(), htitle.data(), 4000, 0, 200e3, 400, 0, 200e3 );
-			
+			histlist->Add(cd_pn_2v1[i][j]);
+
 			hname  = "cd_pn_2v2_" + std::to_string(i) + "_" + std::to_string(j);
 			htitle  = "CD p-side vs n-side energy, multiplicity 2v2";
 			htitle += "for detector " + std::to_string(i);
 			htitle += ", sector " + std::to_string(j);
 			htitle += ";p-side Energy (keV);n-side Energy (keV);Counts";
 			cd_pn_2v2[i][j] = new TH2F( hname.data(), htitle.data(), 4000, 0, 200e3, 400, 0, 200e3 );
-			
+			histlist->Add(cd_pn_2v2[i][j]);
+
 			hname  = "cd_pn_td_" + std::to_string(i) + "_" + std::to_string(j);
 			htitle  = "CD p-side vs n-side time difference ";
 			htitle += "for detector " + std::to_string(i);
 			htitle += ", sector " + std::to_string(j);
 			htitle += ";time difference (ns);Counts per 10 ns";
 			cd_pn_td[i][j] = new TH1F( hname.data(), htitle.data(), 800, -4e3, 4e3 );
-			
+			histlist->Add(cd_pn_td[i][j]);
+
 			hname  = "cd_pp_td_" + std::to_string(i) + "_" + std::to_string(j);
 			htitle  = "CD p-side vs p-side time difference ";
 			htitle += "for detector " + std::to_string(i);
 			htitle += ", sector " + std::to_string(j);
 			htitle += ";time difference (ns);Counts per 10 ns";
 			cd_pp_td[i][j] = new TH1F( hname.data(), htitle.data(), 800, -4e3, 4e3 );
-			
+			histlist->Add(cd_pp_td[i][j]);
+
 			hname  = "cd_nn_td_" + std::to_string(i) + "_" + std::to_string(j);
 			htitle  = "CD n-side vs n-side time difference ";
 			htitle += "for detector " + std::to_string(i);
 			htitle += ", sector " + std::to_string(j);
 			htitle += ";time difference (ns);Counts per 10 ns";
 			cd_nn_td[i][j] = new TH1F( hname.data(), htitle.data(), 800, -4e3, 4e3 );
-			
+			histlist->Add(cd_nn_td[i][j]);
+
 			hname  = "cd_ppad_td_" + std::to_string(i) + "_" + std::to_string(j);
 			htitle  = "CD p-side vs pad time difference ";
 			htitle += "for detector " + std::to_string(i);
 			htitle += ", sector " + std::to_string(j);
 			htitle += ";time difference (ns);Counts per 10 ns";
 			cd_ppad_td[i][j] = new TH1F( hname.data(), htitle.data(), 800, -4e3, 4e3 );
-			
+			histlist->Add(cd_ppad_td[i][j]);
+
 			hname  = "cd_pn_mult_" + std::to_string(i) + "_" + std::to_string(j);
 			htitle  = "CD p-side vs n-side multiplicity ";
 			htitle += "for detector " + std::to_string(i);
 			htitle += ", sector " + std::to_string(j);
 			htitle += ";p-side multiplicity;n-side multiplicity";
 			cd_pn_mult[i][j] = new TH2F( hname.data(), htitle.data(), 10, -0.5, 9.5, 10, -0.5, 9.5 );
-			
+			histlist->Add(cd_pn_mult[i][j]);
+
 			hname  = "cd_ppad_mult_" + std::to_string(i) + "_" + std::to_string(j);
 			htitle  = "CD vs Pad multiplicity ";
 			htitle += "for detector " + std::to_string(i);
 			htitle += ", sector " + std::to_string(j);
 			htitle += ";CD multiplicity;Pad multiplicity";
 			cd_ppad_mult[i][j] = new TH2F( hname.data(), htitle.data(), 10, -0.5, 9.5, 10, -0.5, 9.5 );
-			
+			histlist->Add(cd_ppad_mult[i][j]);
+
 		} // j
 		
 		hname  = "pad_en_" + std::to_string(i);
@@ -477,7 +507,8 @@ void MiniballEventBuilder::MakeEventHists(){
 		pad_en_id[i] = new TH2F( hname.data(), htitle.data(),
 				set->GetNumberOfCDSectors(), -0.5, set->GetNumberOfCDSectors() - 0.5,
 								8000, 0, 200e3 );
-		
+		histlist->Add(pad_en_id[i]);
+
 	} // i
 	
 	
@@ -493,6 +524,10 @@ void MiniballEventBuilder::MakeEventHists(){
 	ic_dE = new TH1F( "ic_dE", "Ionisation chamber;Energy in first layer (Gas) (arb. units);Counts", 4096, 0, 10000 );
 	ic_E = new TH1F( "ic_E", "Ionisation chamber;Energy in final layer (Si) (arb. units);Counts", 4096, 0, 10000 );
 	ic_dE_E = new TH2F( "ic_dE_E", "Ionisation chamber;Rest energy, E (arb. units);Energy Loss, dE (arb. units);Counts", 4096, 0, 10000, 4096, 0, 10000 );
+	histlist->Add(ic_td);
+	histlist->Add(ic_dE);
+	histlist->Add(ic_E);
+	histlist->Add(ic_dE_E);
 
 
 	// flag to denote that hists are ready (used for spy)
@@ -503,50 +538,18 @@ void MiniballEventBuilder::MakeEventHists(){
 }
 
 // Reset histograms in the DataSpy
-void MiniballEventBuilder::ResetHist( TObject *obj ) {
-
-	if( obj == nullptr ) return;
-
-	if( obj->InheritsFrom( "TH2" ) )
-		( (TH2*)obj )->Reset("ICESM");
-	else if( obj->InheritsFrom( "TH1" ) )
-		( (TH1*)obj )->Reset("ICESM");
-
-	return;
-
-}
-
-// Reset histograms in the DataSpy
 void MiniballEventBuilder::ResetHists(){
 
-	TKey *key1, *key2, *key3;
-	TIter keyList1( gDirectory->GetListOfKeys() );
-	while( ( key1 = (TKey*)keyList1() ) ){ // level 1
+	// Loop over the hist list
+	TIter next( histlist->MakeIterator() );
+	while( TObject *obj = next() ) {
 
-		if( key1->ReadObj()->InheritsFrom("TDirectory") ){
+		if( obj->InheritsFrom( "TH2" ) )
+			( (TH2*)obj )->Reset("ICESM");
+		else if( obj->InheritsFrom( "TH1" ) )
+			( (TH1*)obj )->Reset("ICESM");
 
-			TIter keyList2( ( (TDirectory*)key1->ReadObj() )->GetListOfKeys() );
-			while( ( key2 = (TKey*)keyList2() ) ){ // level 2
-
-				if( key2->ReadObj()->InheritsFrom("TDirectory") ){
-
-					TIter keyList3( ( (TDirectory*)key2->ReadObj() )->GetListOfKeys() );
-					while( ( key3 = (TKey*)keyList3() ) ) // level 3
-						ResetHist( key3->ReadObj() );
-
-				}
-
-				else
-					ResetHist( key2->ReadObj() );
-
-			} // level 2
-
-		}
-
-		else
-			ResetHist( key1->ReadObj() );
-
-	} // level 1
+	}
 
 	return;
 
@@ -1435,7 +1438,6 @@ unsigned long MiniballEventBuilder::BuildEvents() {
 	if( input_tree->LoadTree(0) < 0 ){
 		
 		std::cout << " Event Building: nothing to do" << std::endl;
-		output_file->Write( nullptr, TObject::kOverwrite );
 		return 0;
 		
 	}

--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -211,8 +211,7 @@ void MiniballEventBuilder::SetOutput( std::string output_file_name ) {
 	output_tree = new TTree( "evt_tree", "evt_tree" );
 	output_tree->Branch( "MiniballEvts", "MiniballEvts", write_evts.get() );
 	output_tree->SetAutoFlush();
-	gROOT->GetListOfFiles()->Remove(output_file);
-
+	
 	// Create log file.
 	std::string log_file_name = output_file_name.substr( 0, output_file_name.find_last_of(".") );
 	log_file_name += ".log";

--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -66,7 +66,7 @@ MiniballEventBuilder::MiniballEventBuilder( std::shared_ptr<MiniballSettings> my
 	}
 
 	// Histogrammer options
-	TH1::AddDirectory(kFALSE);
+	//TH1::AddDirectory(kFALSE);
 
 }
 
@@ -211,7 +211,7 @@ void MiniballEventBuilder::SetOutput( std::string output_file_name ) {
 	output_tree = new TTree( "evt_tree", "evt_tree" );
 	output_tree->Branch( "MiniballEvts", "MiniballEvts", write_evts.get() );
 	output_tree->SetAutoFlush();
-	
+
 	// Create log file.
 	std::string log_file_name = output_file_name.substr( 0, output_file_name.find_last_of(".") );
 	log_file_name += ".log";

--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -496,7 +496,7 @@ void MiniballEventBuilder::MakeEventHists(){
 	hists_ready = true;
 
 	// Write once
-	//output_file->Write();
+	output_file->Write();
 
 	return;
 	

--- a/src/EventBuilder.cc
+++ b/src/EventBuilder.cc
@@ -219,7 +219,10 @@ void MiniballEventBuilder::SetOutput( std::string output_file_name ) {
 
 	// Hisograms in separate function
 	MakeEventHists();
-	
+
+	// Write once at the start
+	output_file->Write();
+
 }
 
 void MiniballEventBuilder::Initialise(){
@@ -494,9 +497,6 @@ void MiniballEventBuilder::MakeEventHists(){
 
 	// flag to denote that hists are ready (used for spy)
 	hists_ready = true;
-
-	// Write once
-	output_file->Write();
 
 	return;
 	

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -23,7 +23,14 @@ MiniballHistogrammer::MiniballHistogrammer( std::shared_ptr<MiniballReaction> my
 	PBIN = react->HistParticleBins();
 	PMIN = react->HistParticleMin();
 	PMAX = react->HistParticleMax();
-	
+
+	// Make the histograms track the sum of the weights for correctly
+	// performing the error propagation when subtracting
+	TH1::SetDefaultSumw2(kTRUE);
+
+	// Histogrammer options
+	TH1::AddDirectory(kFALSE);
+
 }
 
 void MiniballHistogrammer::MakeHists() {

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -1679,13 +1679,6 @@ void MiniballHistogrammer::MakeHists() {
 		
 	} // ion-chamber on
 
-
-	// flag to denote that hists are ready (used for spy)
-	hists_ready = true;
-
-	// Write hists once at the start
-	output_file->Write();
-
 	return;
 	
 }

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -1687,6 +1687,30 @@ void MiniballHistogrammer::MakeHists() {
 	
 }
 
+void MiniballHistogrammer::PlotDefaultHists() {
+
+	// Check that we're ready
+	if( !hists_ready ) return;
+
+	// Make the canvas
+	c1 = std::make_unique<TCanvas>("c1","Monitor hists");
+	c1->Divide(2,2);
+
+	// Plot things
+	c1->cd(1);
+	gE_singles->Draw("hist");
+	c1->cd(2);
+	c1->GetPad(2)->SetLogz()
+	pE_theta->Draw("colz");
+	c1->cd(3);
+	ebis_td_particle->Draw();
+	c1->cd(4);
+	ebis_td_gamma->Draw();
+
+	return;
+
+}
+
 void MiniballHistogrammer::SetSpyHists( std::vector<std::vector<std::string>> hists, short layout[2] ) {
 
 	// Copy the input hists and layouts

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -3240,9 +3240,9 @@ unsigned long MiniballHistogrammer::FillHists() {
 		
 	} // all events
 	
-	output_file->Write( nullptr, TObject::kOverwrite );
+	//output_file->Write( nullptr, TObject::kOverwrite );
 	//output_file->Purge(2);
-	
+
 	return n_entries;
 	
 }

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -1706,9 +1706,9 @@ void MiniballHistogrammer::PlotDefaultHists() {
 	c1->GetPad(2)->SetLogz();
 	pE_theta->Draw("colz");
 	c1->cd(3);
-	ebis_td_particle->Draw();
+	ebis_td_gamma->Draw("hist");
 	c1->cd(4);
-	ebis_td_gamma->Draw();
+	ebis_td_particle->Draw("hist");
 
 	return;
 
@@ -1744,8 +1744,8 @@ void MiniballHistogrammer::PlotPhysicsHists() {
 	}
 	else maxhists = spyhists.size();
 
-	// Clear and divide canvas
-	cspy->Clear("D");
+	// Make the canvas
+	c2 = std::make_unique<TCanvas>("c2","User hists");
 	if( maxhists > 1 && spylayout[0] > 0 && spylayout[1] > 0 )
 		cspy->Divide( spylayout[0], spylayout[1] );
 
@@ -1753,7 +1753,7 @@ void MiniballHistogrammer::PlotPhysicsHists() {
 	for( unsigned int i = 0; i < maxhists; i++ ){
 
 		// Go to corresponding canvas
-		cspy->cd(i+1);
+		c2->cd(i+1);
 
 		// Get this histogram of the right type
 		if( spyhists[i][1] == "TH1" )

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -29,7 +29,7 @@ MiniballHistogrammer::MiniballHistogrammer( std::shared_ptr<MiniballReaction> my
 	TH1::SetDefaultSumw2(kTRUE);
 
 	// Histogrammer options
-	TH1::AddDirectory(kFALSE);
+	//TH1::AddDirectory(kFALSE);
 
 }
 
@@ -3241,7 +3241,7 @@ unsigned long MiniballHistogrammer::FillHists() {
 	} // all events
 	
 	output_file->Write( nullptr, TObject::kOverwrite );
-	output_file->Purge(2);
+	//output_file->Purge(2);
 	
 	return n_entries;
 	

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -2017,13 +2017,19 @@ void MiniballHistogrammer::PlotDefaultHists() {
 
 	// Plot things
 	c1->cd(1);
-	if( gE_singles != nullptr )
-		gE_singles->Draw("hist");
+	if( gamma_particle_td != nullptr )
+		gamma_particle_td->Draw("hist");
 
 	c1->cd(2);
-	c1->GetPad(2)->SetLogz();
-	if( pE_theta != nullptr )
-		pE_theta->Draw("colz");
+	if( gE_singles_vs_crystal != nullptr ){
+		c1->GetPad(2)->SetLogz();
+		gE_singles_vs_crystal->GetYaxis()->SetRangeUser(1430,1490);
+		gE_singles_vs_crystal->Draw("colz");
+	}
+	else if( gE_singles != nullptr ){
+		gE_singles->GetXaxis()->SetRangeUser(1430,1490);
+		gE_singles->Draw("hist");
+	}
 
 	c1->cd(3);
 	if( ebis_td_gamma != nullptr )
@@ -3602,7 +3608,7 @@ void MiniballHistogrammer::SetInputFile( std::vector<std::string> input_file_nam
 	input_tree->SetBranchAddress( "MiniballEvts", &read_evts );
 
 	return;
-	
+
 }
 
 void MiniballHistogrammer::SetInputFile( std::string input_file_name ) {

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -1749,15 +1749,15 @@ void MiniballHistogrammer::PlotPhysicsHists() {
 
 
 // Reset histograms in the DataSpy
-void MiniballHistogrammer::ResetHist( TObject *obj, std::string cls ) {
+void MiniballHistogrammer::ResetHist( TObject *obj ) {
 
 	if( obj == nullptr ) return;
 
-	if( cls == "TH1" )
+	if( obj->InheritsFrom( "TH1" ) )
 		( (TH1*)obj )->Reset("ICESM");
-	else if( cls ==  "TH2" )
+	else if( obj->InheritsFrom( "TH2" ) )
 		( (TH2*)obj )->Reset("ICESM");
-	else if( cls ==  "TProfile" )
+	else if( obj->InheritsFrom( "TProfile" ) )
 		( (TProfile*)obj )->Reset("ICESM");
 
 	return;
@@ -1771,28 +1771,28 @@ void MiniballHistogrammer::ResetHists(){
 	TIter keyList1( output_file->GetListOfKeys() );
 	while( ( key1 = (TKey*)keyList1() ) ){ // level 1
 
-		if( std::strcmp( key1->GetClassName(), "TDirectory" ) == 0 ){
+		if( key1->InheritsFrom( "TDirectory" ) ){
 
 			TIter keyList2( ( (TDirectory*)key1->ReadObj() )->GetListOfKeys() );
 			while( ( key2 = (TKey*)keyList2() ) ){ // level 2
 
-				if( std::strcmp( key2->GetClassName(), "TDirectory" ) == 0 ){
+				if( key1->InheritsFrom( "TDirectory" ) ){
 
 					TIter keyList3( ( (TDirectory*)key2->ReadObj() )->GetListOfKeys() );
 					while( ( key3 = (TKey*)keyList3() ) ) // level 3
-						ResetHist( key3->ReadObj(), key3->GetClassName() );
+						ResetHist( key3->ReadObj() );
 
 				}
 
 				else
-					ResetHist( key2->ReadObj(), key2->GetClassName() );
+					ResetHist( key2->ReadObj() );
 
 			} // level 2
 
 		}
 
 		else
-			ResetHist( key1->ReadObj(), key1->GetClassName() );
+			ResetHist( key1->ReadObj() );
 
 	} // level 1
 

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -1750,8 +1750,8 @@ void MiniballHistogrammer::PlotPhysicsHists() {
 		c2->Divide( spylayout[0], spylayout[1] );
 
 	// User defined histograms
-	std::vector<std::unique_ptr<TH1F>>> ptr_th1;
-	std::vector<std::unique_ptr<TH2F>>> ptr_th2;
+	TH1F *ptr_th1;
+	TH2F *ptr_th2;
 	for( unsigned int i = 0; i < maxhists; i++ ){
 
 		// Go to corresponding canvas
@@ -1762,17 +1762,17 @@ void MiniballHistogrammer::PlotPhysicsHists() {
 		// Get this histogram of the right type
 		if( spyhists[i][1] == "TH1" || spyhists[i][1] == "TH1F" || spyhists[i][1] == "TH1D" ) {
 
-			ptr_th1.push_back( static_cast<TH1*>( gDirectory->Get( spyhists[i][0].data() ) ) );
-			if( ptr_th1.back().get() != nullptr )
-				ptr_th1.back()->Draw( spyhists[i][2].data() );
+			ptr_th1 = (TH1F*)gDirectory->Get( spyhists[i][0].data() );
+			if( ptr_th1 != nullptr )
+				ptr_th1->Draw( spyhists[i][2].data() );
 
 		}
 
 		else if( spyhists[i][1] == "TH2" || spyhists[i][1] == "TH2F" || spyhists[i][1] == "TH2D" ) {
 
-			ptr_th2.push_back( static_cast<TH2*>( gDirectory->Get( spyhists[i][0].data() ) ) );
-			if( ptr_th2.back().get() != nullptr )
-				ptr_th2.back()->Draw( spyhists[i][2].data() );
+			ptr_th2 = (TH2F*)gDirectory->Get( spyhists[i][0].data() );
+			if( ptr_th2 != nullptr )
+				ptr_th2->Draw( spyhists[i][2].data() );
 
 		}
 
@@ -1781,7 +1781,7 @@ void MiniballHistogrammer::PlotPhysicsHists() {
 	}
 
 	// Write once
-	output_file->Write();
+	//output_file->Write();
 
 	return;
 

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -1,13 +1,13 @@
 #include "Histogrammer.hh"
 
 MiniballHistogrammer::MiniballHistogrammer( std::shared_ptr<MiniballReaction> myreact, std::shared_ptr<MiniballSettings> myset ){
-	
+
 	react = myreact;
 	set = myset;
 
 	// Progress bar starts as false
 	_prog_ = false;
-	
+
 	// Calculate histogram limits
 	int window_ticks = ( set->GetEventWindow() + 10 ) / 10;
 	TMAX = (float)window_ticks * 10.0 + 5.0;
@@ -389,14 +389,14 @@ void MiniballHistogrammer::MakeHists() {
 
 	// Sector-by-sector particle plots
 	if( react->HistBySector() ) {
-		
+
 		pE_theta_sec.resize( set->GetNumberOfCDSectors() );
 		pE_theta_coinc_sec.resize( set->GetNumberOfCDSectors() );
 		pE_theta_ejectile_sec.resize( set->GetNumberOfCDSectors() );
 		pE_theta_recoil_sec.resize( set->GetNumberOfCDSectors() );
-		
+
 		for( unsigned int i = 0; i < set->GetNumberOfCDSectors(); ++i ) {
-			
+
 			hname = "pE_theta_sec" + std::to_string(i);
 			htitle = "Particle energy singles for sector " + std::to_string(i);
 			htitle += ";Angle [deg];Energy [keV];Counts";
@@ -422,10 +422,10 @@ void MiniballHistogrammer::MakeHists() {
 			histlist->Add(pE_theta_recoil_sec[i]);
 
 		} // loop over sectors
-		
+
 	} // by sector
-	
-	
+
+
 	pE_dE.resize( set->GetNumberOfCDDetectors() );
 	pE_dE_coinc.resize( set->GetNumberOfCDDetectors() );
 	pE_dE_cut.resize( set->GetNumberOfCDDetectors() );
@@ -433,11 +433,11 @@ void MiniballHistogrammer::MakeHists() {
 	pE_dE_coinc_sec.resize( set->GetNumberOfCDDetectors() );
 	pE_dE_cut_sec.resize( set->GetNumberOfCDDetectors() );
 	for( unsigned int i = 0; i < set->GetNumberOfCDDetectors(); ++i ) {
-		
+
 		pE_dE_sec[i].resize( set->GetNumberOfCDSectors() );
 		pE_dE_coinc_sec[i].resize( set->GetNumberOfCDSectors() );
 		pE_dE_cut_sec[i].resize( set->GetNumberOfCDSectors() );
-		
+
 		hname = "pE_dE" + std::to_string(i);
 		htitle = "Particle energy total versus energy loss for CD " + std::to_string(i);
 		htitle += ";Energy total [keV];Energy loss [keV];Counts";
@@ -460,9 +460,9 @@ void MiniballHistogrammer::MakeHists() {
 
 		// Sector-by-sector particle plots
 		if( react->HistBySector() ) {
-			
+
 			for( unsigned int j = 0; j < set->GetNumberOfCDSectors(); ++j ) {
-				
+
 				hname = "pE_dE_" + std::to_string(i) + "_" + std::to_string(j);
 				htitle = "Particle energy total versus energy loss for CD " + std::to_string(i);
 				htitle += ", sector " + std::to_string(j);
@@ -485,11 +485,11 @@ void MiniballHistogrammer::MakeHists() {
 				histlist->Add(pE_dE_cut_sec[i][j]);
 
 			}
-			
+
 		} // by sector
-		
+
 	}
-	
+
 	hname = "pBeta_theta_ejectile";
 	htitle = "Reconstructed ejectile velocity;Angle [deg];#beta [c];Counts";
 	pBeta_theta_ejectile = new TProfile( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data() );
@@ -1560,12 +1560,12 @@ void MiniballHistogrammer::MakeHists() {
 		unsigned int nsegs = set->GetNumberOfMiniballClusters();
 		nsegs *= set->GetNumberOfMiniballCrystals();
 		nsegs *= set->GetNumberOfMiniballSegments();
-		
+
 		gE_vs_phi_dc_ejectile.resize( nsegs );
 		gE_vs_phi_dc_recoil.resize( nsegs );
 
 		for ( unsigned int i = 0; i < nsegs; i++ ) {
-			
+
 			hname = "gE_vs_phi_dc_ejectile_seg";
 			hname += std::to_string(i);
 			htitle = "Gamma-ray energy versus segment phi angle, Doppler corrected for the ejectile with random subtraction;";
@@ -1581,16 +1581,16 @@ void MiniballHistogrammer::MakeHists() {
 			histlist->Add(gE_vs_phi_dc_recoil[i]);
 
 		}
-		
+
 	}
-	
+
 	//  Electron-particle coincidences
 	if( react->HistElectron() ) {
-		
+
 		dirname = "ElectronParticleCoincidences";
 		output_file->mkdir( dirname.data() );
 		output_file->cd( dirname.data() );
-		
+
 		hname = "eE_prompt";
 		htitle = "Electron energy in prompt coincide with any particle;Energy [keV];Counts per keV";
 		eE_prompt = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
@@ -1659,7 +1659,7 @@ void MiniballHistogrammer::MakeHists() {
 
 		// 1p and 2p gamma-ray histograms
 		if( react->HistByMultiplicity() ){
-			
+
 			hname = "eE_1p_ejectile_dc_none";
 			htitle = "Electron energy, gated on the ejectile, 1-particle only with random subtraction;";
 			htitle += "Energy [keV];Counts per keV";
@@ -1754,7 +1754,7 @@ void MiniballHistogrammer::MakeHists() {
 
 		// 1p and 2p gamma-ray histograms
 		if( react->HistByMultiplicity() ){
-			
+
 			hname = "eE_vs_theta_1p_ejectile_dc_none";
 			htitle = "Electron energy, gated on the ejectile, 1-particle only with random subtraction;";
 			htitle += "Theta [deg];Energy [keV];Counts per keV per strip";
@@ -1810,7 +1810,7 @@ void MiniballHistogrammer::MakeHists() {
 			histlist->Add(eE_vs_theta_2p_dc_recoil);
 
 		}
-		
+
 		hname = "eE_costheta_ejectile";
 		htitle = "Electron energy versus cos(#theta) of angle between ejectile and electron;";
 		htitle += "Energy [keV];cos(#theta_pe)";
@@ -1938,16 +1938,16 @@ void MiniballHistogrammer::MakeHists() {
 			histlist->Add(eaE_recoil_dc_recoil);
 
 		}
-		
+
 	} // electrons on
 
 	// Beam dump histograms
 	if( react->HistBeamDump() ) {
-		
+
 		dirname = "BeamDump";
 		output_file->mkdir( dirname.data() );
 		output_file->cd( dirname.data() );
-		
+
 		hname = "bdE_singles";
 		htitle = "Beam-dump gamma-ray energy singles;Energy [keV];Counts per 0.5 keV";
 		bdE_singles = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
@@ -1966,7 +1966,7 @@ void MiniballHistogrammer::MakeHists() {
 
 		bdE_singles_det.resize( set->GetNumberOfBeamDumpDetectors() );
 		for( unsigned int i = 0; i < set->GetNumberOfBeamDumpDetectors(); ++i ){
-			
+
 			hname = "bdE_singles_det" + std::to_string(i);
 			htitle  = "Beam-dump gamma-ray energy singles in detector ";
 			htitle += std::to_string(i);
@@ -1975,16 +1975,16 @@ void MiniballHistogrammer::MakeHists() {
 			histlist->Add(bdE_singles_det[i]);
 
 		}
-		
+
 	} // beam dump on
-	
+
 	// Ionisation chamber histograms
 	if( react->HistIonChamber() ) {
-		
+
 		dirname = "IonChamber";
 		output_file->mkdir( dirname.data() );
 		output_file->cd( dirname.data() );
-		
+
 		hname = "ic_dE";
 		htitle = "Ionisation chamber;Energy loss in dE layers (Gas) (arb. units);Counts";
 		ic_dE = new TH1F( hname.data(), htitle.data(), 4096, 0, 10000 );
@@ -2003,7 +2003,7 @@ void MiniballHistogrammer::MakeHists() {
 	} // ion-chamber on
 
 	return;
-	
+
 }
 
 void MiniballHistogrammer::PlotDefaultHists() {
@@ -2037,7 +2037,7 @@ void MiniballHistogrammer::PlotDefaultHists() {
 	c1->GetPad(5)->SetLogz();
 	if( gamma_theta_phi_map != nullptr )
 		gamma_theta_phi_map->Draw("colz");
-	
+
 	c1->cd(6);
 	c1->GetPad(6)->SetLogz();
 	if( particle_xy_map_forward != nullptr )
@@ -2149,11 +2149,11 @@ void MiniballHistogrammer::FillParticleGammaHists( std::shared_ptr<GammaRayEvt> 
 		weight = -1.0 * react->GetParticleGammaFillRatio();
 	}
 	else return; // outside of either window, quit now
-	
+
 	// Plot the prompt and random gamma spectra
 	if( prompt ) gE_prompt->Fill( g->GetEnergy() );
 	else gE_random->Fill( g->GetEnergy() );
-	
+
 	// Same again but explicitly 1 particle events
 	if( prompt && ( react->IsEjectileDetected() != react->IsRecoilDetected() ) )
 		gE_prompt_1p->Fill( g->GetEnergy() );
@@ -2162,7 +2162,7 @@ void MiniballHistogrammer::FillParticleGammaHists( std::shared_ptr<GammaRayEvt> 
 
 	// Ejectile-gated spectra
 	if( react->IsEjectileDetected() ) {
-		
+
 		gE_vs_costheta_ejectile_dc_none->Fill( g->GetEnergy(), react->CosTheta( g, true ), weight );
 		gE_vs_costheta2_ejectile_dc_none->Fill( g->GetEnergy(), react->CosTheta( g, false ), weight );
 		gE_vs_costheta_ejectile_dc_ejectile->Fill( react->DopplerCorrection( g, true ), react->CosTheta( g, true ), weight );
@@ -2178,60 +2178,60 @@ void MiniballHistogrammer::FillParticleGammaHists( std::shared_ptr<GammaRayEvt> 
 
 		// Check if it is 1-particle only
 		if( !react->IsRecoilDetected() && react->HistByMultiplicity() ){
-			
+
 			gE_1p_ejectile_dc_none->Fill( g->GetEnergy(), weight );
 			gE_1p_ejectile_dc_ejectile->Fill( react->DopplerCorrection( g, true ), weight );
 			gE_1p_ejectile_dc_recoil->Fill( react->DopplerCorrection( g, false ), weight );
-			
+
 			gE_vs_theta_1p_ejectile_dc_none->Fill( react->GetEjectile()->GetTheta() * TMath::RadToDeg(), g->GetEnergy(), weight );
 			gE_vs_theta_1p_ejectile_dc_ejectile->Fill( react->GetEjectile()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, true ), weight );
 			gE_vs_theta_1p_ejectile_dc_recoil->Fill( react->GetEjectile()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, false ), weight );
-			
+
 
 		}
-		
+
 		// T1 impact time
 		if( react->HistByT1() ) {
-			
+
 			gE_ejectile_dc_none_t1->Fill( g->GetTime() - read_evts->GetT1(), g->GetEnergy(), weight );
 			gE_ejectile_dc_ejectile_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, true ), weight );
 			gE_ejectile_dc_recoil_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, false ), weight );
-			
+
 			// Check if it is 1-particle only
 			if( !react->IsRecoilDetected() && react->HistByMultiplicity() ){
-				
+
 				gE_1p_ejectile_dc_none_t1->Fill( g->GetTime() - read_evts->GetT1(), g->GetEnergy(), weight );
 				gE_1p_ejectile_dc_ejectile_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, true ), weight );
 				gE_1p_ejectile_dc_recoil_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, false ), weight );
 
 			}
-			
+
 		}
-		
+
 		// Per crystal Doppler-corrected spectra
 		if( react->HistByCrystal() ) {
-			
+
 			int cry = g->GetCrystal() + set->GetNumberOfMiniballCrystals() * g->GetCluster();
 			gE_vs_crystal_ejectile_dc_none->Fill( cry, g->GetEnergy(), weight );
 			gE_vs_crystal_ejectile_dc_ejectile->Fill( cry, react->DopplerCorrection( g, true ), weight );
 			gE_vs_crystal_ejectile_dc_recoil->Fill( cry, react->DopplerCorrection( g, false ), weight );
-			
+
 			// Check if it is 1-particle only
 			if( !react->IsRecoilDetected() && react->HistByMultiplicity() ){
-				
+
 				gE_vs_crystal_1p_ejectile_dc_none->Fill( cry, g->GetEnergy(), weight );
 				gE_vs_crystal_1p_ejectile_dc_ejectile->Fill( cry, react->DopplerCorrection( g, true ), weight );
 				gE_vs_crystal_1p_ejectile_dc_recoil->Fill( cry, react->DopplerCorrection( g, false ), weight );
 
 			}
-			
+
 		}
-		
+
 	}
 
 	// Recoil-gated spectra
 	if( react->IsRecoilDetected() || react->IsTransferDetected() ) {
-		
+
 		gE_vs_costheta_recoil_dc_none->Fill( g->GetEnergy(), react->CosTheta( g, false ), weight );
 		gE_vs_costheta2_recoil_dc_none->Fill( g->GetEnergy(), react->CosTheta( g, true ), weight );
 		gE_vs_costheta_recoil_dc_ejectile->Fill( react->DopplerCorrection( g, true ), react->CosTheta( g, true ), weight );
@@ -2240,118 +2240,118 @@ void MiniballHistogrammer::FillParticleGammaHists( std::shared_ptr<GammaRayEvt> 
 		gE_recoil_dc_none->Fill( g->GetEnergy(), weight );
 		gE_recoil_dc_ejectile->Fill( react->DopplerCorrection( g, true ), weight );
 		gE_recoil_dc_recoil->Fill( react->DopplerCorrection( g, false ), weight );
-				
+
 		gE_vs_theta_recoil_dc_none->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), g->GetEnergy(), weight );
 		gE_vs_theta_recoil_dc_ejectile->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, true ), weight );
 		gE_vs_theta_recoil_dc_recoil->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, false ), weight );
 
 		// Check if it is 1-particle only
 		if( !react->IsEjectileDetected() && react->HistByMultiplicity() ){
-			
+
 			gE_1p_recoil_dc_none->Fill( g->GetEnergy(), weight );
 			gE_1p_recoil_dc_ejectile->Fill( react->DopplerCorrection( g, true ), weight );
 			gE_1p_recoil_dc_recoil->Fill( react->DopplerCorrection( g, false ), weight );
-			
+
 			gE_vs_theta_1p_recoil_dc_none->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), g->GetEnergy(), weight );
 			gE_vs_theta_1p_recoil_dc_ejectile->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, true ), weight );
 			gE_vs_theta_1p_recoil_dc_recoil->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, false ), weight );
 
 		}
-		
+
 		// T1 impact time
 		if( react->HistByT1() ) {
-			
+
 			gE_recoil_dc_none_t1->Fill( g->GetTime() - read_evts->GetT1(), g->GetEnergy(), weight );
 			gE_recoil_dc_ejectile_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, true ), weight );
 			gE_recoil_dc_recoil_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, false ), weight );
-			
+
 			// Check if it is 1-particle only
 			if( !react->IsEjectileDetected() && react->HistByMultiplicity() ){
-				
+
 				gE_1p_recoil_dc_none_t1->Fill( g->GetTime() - read_evts->GetT1(), g->GetEnergy(), weight );
 				gE_1p_recoil_dc_ejectile_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, true ), weight );
 				gE_1p_recoil_dc_recoil_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, false ), weight );
-				
+
 			}
-			
+
 		}
 
 		// Per crystal Doppler-corrected spectra
 		if( react->HistByCrystal() ) {
-			
+
 			int cry = g->GetCrystal() + set->GetNumberOfMiniballCrystals() * g->GetCluster();
 			gE_vs_crystal_recoil_dc_none->Fill( cry, g->GetEnergy(), weight );
 			gE_vs_crystal_recoil_dc_ejectile->Fill( cry, react->DopplerCorrection( g, true ), weight );
 			gE_vs_crystal_recoil_dc_recoil->Fill( cry, react->DopplerCorrection( g, false ), weight );
-			
+
 			// Check if it is 1-particle only
 			if( !react->IsEjectileDetected() && react->HistByMultiplicity() ){
-				
+
 				gE_vs_crystal_1p_recoil_dc_none->Fill( cry, g->GetEnergy(), weight );
 				gE_vs_crystal_1p_recoil_dc_ejectile->Fill( cry, react->DopplerCorrection( g, true ), weight );
 				gE_vs_crystal_1p_recoil_dc_recoil->Fill( cry, react->DopplerCorrection( g, false ), weight );
 
 			}
-			
+
 		}
 
 	}
-	
+
 	// Two-particle spectra
 	if( react->IsEjectileDetected() && react->IsRecoilDetected() ){
-		
+
 		// Prompt and random spectra
 		if( prompt ) gE_prompt_2p->Fill( g->GetEnergy() );
 		else gE_random_2p->Fill( g->GetEnergy() );
 
 		// Check if we need to plot by multplicity
 		if( react->HistByMultiplicity() ){
-			
+
 			gE_2p_dc_none->Fill( g->GetEnergy(), weight );
 			gE_2p_dc_ejectile->Fill( react->DopplerCorrection( g, true ), weight );
 			gE_2p_dc_recoil->Fill( react->DopplerCorrection( g, false ), weight );
-			
+
 			gE_vs_theta_2p_dc_none->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), g->GetEnergy(), weight );
 			gE_vs_theta_2p_dc_ejectile->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, true ), weight );
 			gE_vs_theta_2p_dc_recoil->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, false ), weight );
-			
+
 			// T1 impact time
 			if( react->HistByT1() ) {
-				
+
 				gE_2p_dc_none_t1->Fill( g->GetTime() - read_evts->GetT1(), g->GetEnergy(), weight );
 				gE_2p_dc_ejectile_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, true ), weight );
 				gE_2p_dc_recoil_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, false ), weight );
-				
+
 			}
-			
+
 			// Per crystal Doppler-corrected spectra
 			if( react->HistByCrystal() ) {
-				
+
 				int cry = g->GetCrystal() + set->GetNumberOfMiniballCrystals() * g->GetCluster();
 				gE_vs_crystal_2p_dc_none->Fill( cry, g->GetEnergy(), weight );
 				gE_vs_crystal_2p_dc_ejectile->Fill( cry, react->DopplerCorrection( g, true ), weight );
 				gE_vs_crystal_2p_dc_recoil->Fill( cry, react->DopplerCorrection( g, false ), weight );
-				
+
 			}
-			
+
 		}
 
 	}
-	
+
 	// Segment-phi determination
 	if( react->HistSegmentPhi() ) {
-		
+
 		for( unsigned int i = 0; i < 360; i ++ ) {
-			
+
 			double gphi_deg = (double)i;
 			double gphi = gphi_deg * TMath::DegToRad();
 			double gtheta = react->GetGammaTheta(g);
-			
+
 			unsigned short segID = g->GetCluster();
 			segID *= set->GetNumberOfMiniballCrystals() * set->GetNumberOfMiniballSegments();
 			segID += set->GetNumberOfMiniballSegments() * g->GetCrystal();
 			segID += g->GetSegment();
-	
+
 			// Ejectile DC
 			double dc_gen = react->DopplerCorrection( g->GetEnergy(), gtheta, gphi, true );
 			gE_vs_phi_dc_ejectile[segID]->Fill( gphi_deg, dc_gen, weight );
@@ -2361,9 +2361,9 @@ void MiniballHistogrammer::FillParticleGammaHists( std::shared_ptr<GammaRayEvt> 
 			gE_vs_phi_dc_recoil[segID]->Fill( gphi_deg, dc_gen, weight );
 
 		}
-		
+
 	}
-	
+
 	return;
 
 }
@@ -2382,20 +2382,20 @@ void MiniballHistogrammer::FillParticleGammaHists( std::shared_ptr<GammaRayAddba
 		weight = -1.0 * react->GetParticleGammaFillRatio();
 	}
 	else return; // outside of either window, quit now
-	
+
 	// Plot the prompt and random gamma spectra
 	if( prompt ) aE_prompt->Fill( g->GetEnergy() );
 	else aE_random->Fill( g->GetEnergy() );
-	
+
 	// Same again but explicitly 1 particle events
 	if( prompt && ( react->IsEjectileDetected() != react->IsRecoilDetected() ) )
 		aE_prompt_1p->Fill( g->GetEnergy() );
 	else if( react->IsEjectileDetected() != react->IsRecoilDetected() )
 		aE_random_1p->Fill( g->GetEnergy() );
-	
+
 	// Ejectile-gated spectra
 	if( react->IsEjectileDetected() ) {
-		
+
 		aE_vs_costheta_ejectile_dc_none->Fill( g->GetEnergy(), react->CosTheta( g, true ), weight );
 		aE_vs_costheta2_ejectile_dc_none->Fill( g->GetEnergy(), react->CosTheta( g, false ), weight );
 		aE_vs_costheta_ejectile_dc_ejectile->Fill( react->DopplerCorrection( g, true ), react->CosTheta( g, true ), weight );
@@ -2404,57 +2404,57 @@ void MiniballHistogrammer::FillParticleGammaHists( std::shared_ptr<GammaRayAddba
 		aE_ejectile_dc_none->Fill( g->GetEnergy(), weight );
 		aE_ejectile_dc_ejectile->Fill( react->DopplerCorrection( g, true ), weight );
 		aE_ejectile_dc_recoil->Fill( react->DopplerCorrection( g, false ), weight );
-		
+
 		aE_vs_theta_ejectile_dc_none->Fill( react->GetEjectile()->GetTheta() * TMath::RadToDeg(), g->GetEnergy(), weight );
 		aE_vs_theta_ejectile_dc_ejectile->Fill( react->GetEjectile()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, true ), weight );
 		aE_vs_theta_ejectile_dc_recoil->Fill( react->GetEjectile()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, false ), weight );
 
 		// Check if it is 1-particle only
 		if( !react->IsRecoilDetected() && react->HistByMultiplicity() ){
-			
+
 			aE_1p_ejectile_dc_none->Fill( g->GetEnergy(), weight );
 			aE_1p_ejectile_dc_ejectile->Fill( react->DopplerCorrection( g, true ), weight );
 			aE_1p_ejectile_dc_recoil->Fill( react->DopplerCorrection( g, false ), weight );
-			
+
 			aE_vs_theta_1p_ejectile_dc_none->Fill( react->GetEjectile()->GetTheta() * TMath::RadToDeg(), g->GetEnergy(), weight );
 			aE_vs_theta_1p_ejectile_dc_ejectile->Fill( react->GetEjectile()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, true ), weight );
 			aE_vs_theta_1p_ejectile_dc_recoil->Fill( react->GetEjectile()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, false ), weight );
 
 		}
-		
+
 		// T1 impact time
 		if( react->HistByT1() ) {
-			
+
 			aE_ejectile_dc_none_t1->Fill( g->GetTime() - read_evts->GetT1(), g->GetEnergy(), weight );
 			aE_ejectile_dc_ejectile_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, true ), weight );
 			aE_ejectile_dc_recoil_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, false ), weight );
-			
+
 			// Check if it is 1-particle only
 			if( !react->IsRecoilDetected() && react->HistByMultiplicity() ){
-				
+
 				aE_1p_ejectile_dc_none_t1->Fill( g->GetTime() - read_evts->GetT1(), g->GetEnergy(), weight );
 				aE_1p_ejectile_dc_ejectile_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, true ), weight );
 				aE_1p_ejectile_dc_recoil_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, false ), weight );
-				
+
 			}
-			
+
 		}
 
 		// Per crystal Doppler-corrected spectra
 		if( react->HistByCrystal() ) {
-			
+
 			int cry = g->GetCrystal() + set->GetNumberOfMiniballCrystals() * g->GetCluster();
 			aE_vs_crystal_ejectile_dc_none->Fill( cry, g->GetEnergy(), weight );
 			aE_vs_crystal_ejectile_dc_ejectile->Fill( cry, react->DopplerCorrection( g, true ), weight );
 			aE_vs_crystal_ejectile_dc_recoil->Fill( cry, react->DopplerCorrection( g, false ), weight );
-			
+
 			// Check if it is 1-particle only
 			if( !react->IsRecoilDetected() && react->HistByMultiplicity() ){
-				
+
 				aE_vs_crystal_1p_ejectile_dc_none->Fill( cry, g->GetEnergy(), weight );
 				aE_vs_crystal_1p_ejectile_dc_ejectile->Fill( cry, react->DopplerCorrection( g, true ), weight );
 				aE_vs_crystal_1p_ejectile_dc_recoil->Fill( cry, react->DopplerCorrection( g, false ), weight );
-				
+
 			}
 
 		}
@@ -2463,7 +2463,7 @@ void MiniballHistogrammer::FillParticleGammaHists( std::shared_ptr<GammaRayAddba
 
 	// Recoil-gated spectra
 	if( react->IsRecoilDetected() || react->IsTransferDetected() ) {
-		
+
 		aE_vs_costheta_recoil_dc_none->Fill( g->GetEnergy(), react->CosTheta( g, false ), weight );
 		aE_vs_costheta2_recoil_dc_none->Fill( g->GetEnergy(), react->CosTheta( g, true ), weight );
 		aE_vs_costheta_recoil_dc_ejectile->Fill( react->DopplerCorrection( g, true ), react->CosTheta( g, true ), weight );
@@ -2472,7 +2472,7 @@ void MiniballHistogrammer::FillParticleGammaHists( std::shared_ptr<GammaRayAddba
 		aE_recoil_dc_none->Fill( g->GetEnergy(), weight );
 		aE_recoil_dc_ejectile->Fill( react->DopplerCorrection( g, true ), weight );
 		aE_recoil_dc_recoil->Fill( react->DopplerCorrection( g, false ), weight );
-		
+
 		aE_vs_theta_recoil_dc_none->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), g->GetEnergy(), weight );
 		aE_vs_theta_recoil_dc_ejectile->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, true ), weight );
 		aE_vs_theta_recoil_dc_recoil->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, false ), weight );
@@ -2483,93 +2483,93 @@ void MiniballHistogrammer::FillParticleGammaHists( std::shared_ptr<GammaRayAddba
 			aE_1p_recoil_dc_none->Fill( g->GetEnergy(), weight );
 			aE_1p_recoil_dc_ejectile->Fill( react->DopplerCorrection( g, true ), weight );
 			aE_1p_recoil_dc_recoil->Fill( react->DopplerCorrection( g, false ), weight );
-			
+
 			aE_vs_theta_1p_recoil_dc_none->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), g->GetEnergy(), weight );
 			aE_vs_theta_1p_recoil_dc_ejectile->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, true ), weight );
 			aE_vs_theta_1p_recoil_dc_recoil->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, false ), weight );
-			
+
 		}
 
 		// T1 impact time
 		if( react->HistByT1() ) {
-			
+
 			aE_recoil_dc_none_t1->Fill( g->GetTime() - read_evts->GetT1(), g->GetEnergy(), weight );
 			aE_recoil_dc_ejectile_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, true ), weight );
 			aE_recoil_dc_recoil_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, false ), weight );
-			
+
 			// Check if it is 1-particle only
 			if( !react->IsEjectileDetected() && react->HistByMultiplicity() ){
-				
+
 				aE_1p_recoil_dc_none_t1->Fill( g->GetTime() - read_evts->GetT1(), g->GetEnergy(), weight );
 				aE_1p_recoil_dc_ejectile_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, true ), weight );
 				aE_1p_recoil_dc_recoil_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, false ), weight );
-				
+
 			}
 
 		}
 
 		// Per crystal Doppler-corrected spectra
 		if( react->HistByCrystal() ) {
-			
+
 			int cry = g->GetCrystal() + set->GetNumberOfMiniballCrystals() * g->GetCluster();
 			aE_vs_crystal_recoil_dc_none->Fill( cry, g->GetEnergy(), weight );
 			aE_vs_crystal_recoil_dc_ejectile->Fill( cry, react->DopplerCorrection( g, true ), weight );
 			aE_vs_crystal_recoil_dc_recoil->Fill( cry, react->DopplerCorrection( g, false ), weight );
-			
+
 			// Check if it is 1-particle only
 			if( !react->IsEjectileDetected() && react->HistByMultiplicity() ){
-				
+
 				aE_vs_crystal_1p_recoil_dc_none->Fill( cry, g->GetEnergy(), weight );
 				aE_vs_crystal_1p_recoil_dc_ejectile->Fill( cry, react->DopplerCorrection( g, true ), weight );
 				aE_vs_crystal_1p_recoil_dc_recoil->Fill( cry, react->DopplerCorrection( g, false ), weight );
-				
+
 			}
 
 		}
 
 	}
-	
+
 	// Two-particle spectra
 	if( react->IsEjectileDetected() && react->IsRecoilDetected() ){
-		
+
 		// Prompt and random spectra
 		if( prompt ) aE_prompt_2p->Fill( g->GetEnergy() );
 		else aE_random_2p->Fill( g->GetEnergy() );
 
 		// Check if we need to plot by multplicity
 		if( react->HistByMultiplicity() ){
-			
+
 			aE_2p_dc_none->Fill( g->GetEnergy(), weight );
 			aE_2p_dc_ejectile->Fill( react->DopplerCorrection( g, true ), weight );
 			aE_2p_dc_recoil->Fill( react->DopplerCorrection( g, false ), weight );
-			
+
 			aE_vs_theta_2p_dc_none->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), g->GetEnergy(), weight );
 			aE_vs_theta_2p_dc_ejectile->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, true ), weight );
 			aE_vs_theta_2p_dc_recoil->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( g, false ), weight );
-			
+
 			// T1 impact time
 			if( react->HistByT1() ) {
-				
+
 				aE_2p_dc_none_t1->Fill( g->GetTime() - read_evts->GetT1(), g->GetEnergy(), weight );
 				aE_2p_dc_ejectile_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, true ), weight );
 				aE_2p_dc_recoil_t1->Fill( g->GetTime() - read_evts->GetT1(), react->DopplerCorrection( g, false ), weight );
-				
+
 			}
-			
+
 			// Per crystal Doppler-corrected spectra
 			if( react->HistByCrystal() ) {
-				
+
 				int cry = g->GetCrystal() + set->GetNumberOfMiniballCrystals() * g->GetCluster();
 				aE_vs_crystal_2p_dc_none->Fill( cry, g->GetEnergy(), weight );
 				aE_vs_crystal_2p_dc_ejectile->Fill( cry, react->DopplerCorrection( g, true ), weight );
 				aE_vs_crystal_2p_dc_recoil->Fill( cry, react->DopplerCorrection( g, false ), weight );
-				
+
 			}
-			
+
 		}
 
 	}
-	
+
 	return;
 
 }
@@ -2588,11 +2588,11 @@ void MiniballHistogrammer::FillParticleElectronHists( std::shared_ptr<SpedeEvt> 
 		weight = -1.0 * react->GetParticleElectronFillRatio();
 	}
 	else return; // outside of either window, quit now
-	
+
 	// Plot the prompt and random gamma spectra
 	if( prompt ) eE_prompt->Fill( e->GetEnergy() );
 	else eE_random->Fill( e->GetEnergy() );
-	
+
 	// Same again but explicitly 1 particle events
 	if( prompt && ( react->IsEjectileDetected() != react->IsRecoilDetected() ) )
 		eE_prompt_1p->Fill( e->GetEnergy() );
@@ -2601,9 +2601,9 @@ void MiniballHistogrammer::FillParticleElectronHists( std::shared_ptr<SpedeEvt> 
 
 	// Ejectile-gated spectra
 	if( react->IsEjectileDetected() ) {
-		
+
 		eE_costheta_ejectile->Fill( e->GetEnergy(), react->CosTheta( e, true ), weight );
-		
+
 		eE_ejectile_dc_none->Fill( e->GetEnergy(), weight );
 		eE_ejectile_dc_ejectile->Fill( react->DopplerCorrection( e, true ), weight );
 		eE_ejectile_dc_recoil->Fill( react->DopplerCorrection( e, false ), weight );
@@ -2611,18 +2611,18 @@ void MiniballHistogrammer::FillParticleElectronHists( std::shared_ptr<SpedeEvt> 
 		eE_vs_theta_ejectile_dc_none->Fill( react->GetEjectile()->GetTheta() * TMath::RadToDeg(), e->GetEnergy(), weight );
 		eE_vs_theta_ejectile_dc_ejectile->Fill( react->GetEjectile()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( e, true ), weight );
 		eE_vs_theta_ejectile_dc_recoil->Fill( react->GetEjectile()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( e, false ), weight );
-    
+
 		// Check if it is 1-particle only
 		if( !react->IsRecoilDetected() && react->HistByMultiplicity() ){
-			
+
 			eE_1p_ejectile_dc_none->Fill( e->GetEnergy(), weight );
 			eE_1p_ejectile_dc_ejectile->Fill( react->DopplerCorrection( e, true ), weight );
 			eE_1p_ejectile_dc_recoil->Fill( react->DopplerCorrection( e, false ), weight );
-			
+
 			eE_vs_theta_1p_ejectile_dc_none->Fill( react->GetEjectile()->GetTheta() * TMath::RadToDeg(), e->GetEnergy(), weight );
 			eE_vs_theta_1p_ejectile_dc_ejectile->Fill( react->GetEjectile()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( e, true ), weight );
 			eE_vs_theta_1p_ejectile_dc_recoil->Fill( react->GetEjectile()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( e, false ), weight );
-			
+
 		}
 
 		eE_vs_ejectile_dc_none_segment->Fill( e->GetEnergy(), e->GetSegment(), weight );
@@ -2633,59 +2633,59 @@ void MiniballHistogrammer::FillParticleElectronHists( std::shared_ptr<SpedeEvt> 
 
 	// Recoil-gated spectra
 	if( react->IsRecoilDetected() || react->IsTransferDetected() ) {
-		
+
 		eE_costheta_recoil->Fill( e->GetEnergy(), react->CosTheta( e, false ), weight );
-		
+
 		eE_recoil_dc_none->Fill( e->GetEnergy(), weight );
 		eE_recoil_dc_ejectile->Fill( react->DopplerCorrection( e, true ), weight );
 		eE_recoil_dc_recoil->Fill( react->DopplerCorrection( e, false ), weight );
-		
+
 		eE_vs_theta_recoil_dc_none->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), e->GetEnergy(), weight );
 		eE_vs_theta_recoil_dc_ejectile->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( e, true ), weight );
 		eE_vs_theta_recoil_dc_recoil->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( e, false ), weight );
-		
+
 		// Check if it is 1-particle only
 		if( !react->IsEjectileDetected() && react->HistByMultiplicity() ){
-			
+
 			eE_1p_recoil_dc_none->Fill( e->GetEnergy(), weight );
 			eE_1p_recoil_dc_ejectile->Fill( react->DopplerCorrection( e, true ), weight );
 			eE_1p_recoil_dc_recoil->Fill( react->DopplerCorrection( e, false ), weight );
-			
+
 			eE_vs_theta_1p_recoil_dc_none->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), e->GetEnergy(), weight );
 			eE_vs_theta_1p_recoil_dc_ejectile->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( e, true ), weight );
 			eE_vs_theta_1p_recoil_dc_recoil->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( e, false ), weight );
-			
+
 
 		}
 
 		eE_vs_recoil_dc_none_segment->Fill( e->GetEnergy(), e->GetSegment(), weight );
 		eE_vs_recoil_dc_ejectile_segment->Fill( react->DopplerCorrection( e, true ), e->GetSegment(), weight );
 		eE_vs_recoil_dc_recoil_segment->Fill( react->DopplerCorrection( e, false ), e->GetSegment(), weight );
-		
+
 	}
-	
+
 	// Two-particle spectra
 	if( react->IsEjectileDetected() && react->IsRecoilDetected() ){
-		
+
 		// Prompt and random spectra
 		if( prompt ) eE_prompt_2p->Fill( e->GetEnergy() );
 		else eE_random_2p->Fill( e->GetEnergy() );
-		
+
 		// Check if we need to plot by multplicity
 		if( react->HistByMultiplicity() ){
-			
+
 			eE_2p_dc_none->Fill( e->GetEnergy(), weight );
 			eE_2p_dc_ejectile->Fill( react->DopplerCorrection( e, true ), weight );
 			eE_2p_dc_recoil->Fill( react->DopplerCorrection( e, false ), weight );
-			
+
 			eE_vs_theta_2p_dc_none->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), e->GetEnergy(), weight );
 			eE_vs_theta_2p_dc_ejectile->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( e, true ), weight );
 			eE_vs_theta_2p_dc_recoil->Fill( react->GetRecoil()->GetTheta() * TMath::RadToDeg(), react->DopplerCorrection( e, false ), weight );
-			
+
 		}
-		
+
 	}
-	
+
 	return;
 
 }
@@ -2705,26 +2705,26 @@ void MiniballHistogrammer::FillParticleGammaGammaHists( std::shared_ptr<GammaRay
 
 	// Ejectile-gated spectra
 	if( react->IsEjectileDetected() ) {
-		
+
 		// Gamma-gamma
 		ggE_ejectile_dc_none->Fill( g1->GetEnergy(), g2->GetEnergy(), weight );
 		ggE_ejectile_dc_ejectile->Fill( react->DopplerCorrection( g1, true ), react->DopplerCorrection( g2, true ), weight );
 		ggE_ejectile_dc_recoil->Fill( react->DopplerCorrection( g1, false ), react->DopplerCorrection( g2, false ), weight );
-		
+
 	}
-	
+
 	// Recoil-gated spectra
 	if( react->IsRecoilDetected() || react->IsTransferDetected() ) {
-		
+
 		// Gamma-gamma
 		ggE_recoil_dc_none->Fill( g1->GetEnergy(), g2->GetEnergy(), weight );
 		ggE_recoil_dc_ejectile->Fill( react->DopplerCorrection( g1, true ), react->DopplerCorrection( g2, true ), weight );
 		ggE_recoil_dc_recoil->Fill( react->DopplerCorrection( g1, false ), react->DopplerCorrection( g2, false ), weight );
 
 	}
-	
+
 	return;
-	
+
 }
 
 // Particle-Gamma-Gamma coincidences with addback
@@ -2742,17 +2742,17 @@ void MiniballHistogrammer::FillParticleGammaGammaHists( std::shared_ptr<GammaRay
 
 	// Ejectile-gated spectra
 	if( react->IsEjectileDetected() ) {
-		
+
 		// Gamma-gamma
 		aaE_ejectile_dc_none->Fill( g1->GetEnergy(), g2->GetEnergy(), weight );
 		aaE_ejectile_dc_ejectile->Fill( react->DopplerCorrection( g1, true ), react->DopplerCorrection( g2, true ), weight );
 		aaE_ejectile_dc_recoil->Fill( react->DopplerCorrection( g1, false ), react->DopplerCorrection( g2, false ), weight );
 
 	}
-	
+
 	// Recoil-gated spectra
 	if( react->IsRecoilDetected() || react->IsTransferDetected() ) {
-		
+
 		// Gamma-gamma
 		aaE_recoil_dc_none->Fill( g1->GetEnergy(), g2->GetEnergy(), weight );
 		aaE_recoil_dc_ejectile->Fill( react->DopplerCorrection( g1, true ), react->DopplerCorrection( g2, true ), weight );
@@ -2761,7 +2761,7 @@ void MiniballHistogrammer::FillParticleGammaGammaHists( std::shared_ptr<GammaRay
 	}
 
 	return;
-	
+
 }
 
 // Particle-Electron-Gamma coincidences without addback
@@ -2779,17 +2779,17 @@ void MiniballHistogrammer::FillParticleElectronGammaHists( std::shared_ptr<Spede
 
 	// Ejectile-gated spectra
 	if( react->IsEjectileDetected() ) {
-		
+
 		// Electon-gamma
 		egE_ejectile_dc_none->Fill( e->GetEnergy(), g->GetEnergy(), weight );
 		egE_ejectile_dc_ejectile->Fill( react->DopplerCorrection( e, true ), react->DopplerCorrection( g, true ), weight );
 		egE_ejectile_dc_recoil->Fill( react->DopplerCorrection( e, false ), react->DopplerCorrection( g, false ), weight );
 
 	}
-	
+
 	// Recoil-gated spectra
 	if( react->IsRecoilDetected() || react->IsTransferDetected() ) {
-		
+
 		// Electon-gamma
 		egE_recoil_dc_none->Fill( e->GetEnergy(), g->GetEnergy(), weight );
 		egE_recoil_dc_ejectile->Fill( react->DopplerCorrection( e, true ), react->DopplerCorrection( g, true ), weight );
@@ -2798,7 +2798,7 @@ void MiniballHistogrammer::FillParticleElectronGammaHists( std::shared_ptr<Spede
 	}
 
 	return;
-	
+
 }
 
 // Particle-Electron-Gamma coincidences with addback
@@ -2816,78 +2816,78 @@ void MiniballHistogrammer::FillParticleElectronGammaHists( std::shared_ptr<Spede
 
 	// Ejectile-gated spectra
 	if( react->IsEjectileDetected() ) {
-		
+
 		// Electon-gamma
 		eaE_ejectile_dc_none->Fill( e->GetEnergy(), g->GetEnergy(), weight );
 		eaE_ejectile_dc_ejectile->Fill( react->DopplerCorrection( e, true ), react->DopplerCorrection( g, true ), weight );
 		eaE_ejectile_dc_recoil->Fill( react->DopplerCorrection( e, false ), react->DopplerCorrection( g, false ), weight );
-		
+
 	}
-	
+
 	// Recoil-gated spectra
 	if( react->IsRecoilDetected() || react->IsTransferDetected() ) {
-		
+
 		// Electon-gamma
 		eaE_recoil_dc_none->Fill( e->GetEnergy(), g->GetEnergy(), weight );
 		eaE_recoil_dc_ejectile->Fill( react->DopplerCorrection( e, true ), react->DopplerCorrection( g, true ), weight );
 		eaE_recoil_dc_recoil->Fill( react->DopplerCorrection( e, false ), react->DopplerCorrection( g, false ), weight );
-		
+
 	}
-	
+
 	return;
-	
+
 }
 
 unsigned long MiniballHistogrammer::FillHists() {
-	
+
 	/// Main function to fill the histograms
 	n_entries = input_tree->GetEntries();
-	
+
 	std::cout << " MiniballHistogrammer: number of entries in event tree = ";
 	std::cout << n_entries << std::endl;
-	
+
 	if( n_entries == 0 ){
-		
+
 		std::cout << " MiniballHistogrammer: Nothing to do..." << std::endl;
 		return n_entries;
-		
+
 	}
 	else {
-		
+
 		std::cout << " MiniballHistogrammer: Start filling histograms" << std::endl;
-		
+
 	}
 
 	// ------------------------------------------------------------------------ //
 	// Main loop over TTree to find events
 	// ------------------------------------------------------------------------ //
 	for( unsigned int i = 0; i < n_entries; ++i ){
-		
+
 		// Current event data
 		input_tree->GetEntry(i);
-		
+
 		// Get laser status
 		unsigned char laser_status = read_evts->GetLaserStatus();
-		
+
 		// Check laser mode
 		unsigned char laser_mode = react->GetLaserMode();
-		
+
 		// Test if we want to plot this event or not
 		if( laser_status != laser_mode && laser_mode != 2 ) continue;
-		
+
 		// Apply the T1 cut if requested by the user
 		if( react->GetT1Cut() && !T1Cut() ) continue;
-		
+
 		// Check if it we are restricting to particle-gamma events
 		int g_e_mult = read_evts->GetGammaRayMultiplicity() + read_evts->GetSpedeMultiplicity();
 		if( ( read_evts->GetParticleMultiplicity() == 0 || g_e_mult == 0 )
 		   && react->EventsParticleGammaOnly() ) continue;
-		
+
 		// ------------------------- //
 		// Loop over particle events //
 		// ------------------------- //
 		for( unsigned int j = 0; j < read_evts->GetParticleMultiplicity(); ++j ){
-			
+
 			// Get particle event
 			particle_evt = read_evts->GetParticleEvt(j);
 
@@ -2901,13 +2901,13 @@ unsigned long MiniballHistogrammer::FillHists() {
 
 			// EBIS time
 			ebis_td_particle->Fill( (double)particle_evt->GetTime() - (double)read_evts->GetEBIS() );
-			
+
 			// Get angles and plot maps
 			float pid = particle_evt->GetStripP() + rand.Rndm() - 0.5; // randomise strip number
 			float nid = particle_evt->GetStripN() + rand.Rndm() - 0.5; // randomise strip number
 			TVector3 pvec = react->GetCDVector( particle_evt->GetDetector(), particle_evt->GetSector(), pid, nid );
 			particle_theta_phi_map->Fill( react->GetParticleTheta( particle_evt ) * TMath::RadToDeg(),
-										  react->GetParticlePhi( particle_evt ) * TMath::RadToDeg() );
+										 react->GetParticlePhi( particle_evt ) * TMath::RadToDeg() );
 			if( react->GetParticleTheta( particle_evt ) < TMath::PiOver2() )
 				particle_xy_map_forward->Fill( pvec.Y(), pvec.X() );
 			else
@@ -2921,18 +2921,18 @@ unsigned long MiniballHistogrammer::FillHists() {
 
 			// Sector-by-sector particle plots
 			if( react->HistBySector() ) {
-				
+
 				pE_dE_sec[particle_evt->GetDetector()][particle_evt->GetSector()]->Fill( particle_evt->GetEnergy(), particle_evt->GetDeltaEnergy() );
 				pE_theta_sec[particle_evt->GetSector()]->Fill( react->GetParticleTheta( particle_evt ) * TMath::RadToDeg(), particle_evt->GetDeltaEnergy() );
-				
+
 			} // by sector
 
 			// Check for coincidence with another particle
 			for( unsigned int k = j+1; k < read_evts->GetParticleMultiplicity(); ++k ){
-				
+
 				// Get second particle event
 				particle_evt2 = read_evts->GetParticleEvt(k);
-				
+
 				// Check if we are demanding CD-Pad coincidences
 				if( react->EventsCdPadCoincidence() && particle_evt2->GetEnergyPad() < 1e-9 )
 					continue;
@@ -2949,25 +2949,25 @@ unsigned long MiniballHistogrammer::FillHists() {
 
 			// Check for coincidence with a gamma-ray
 			for( unsigned int k = 0; k < read_evts->GetGammaRayMultiplicity(); ++k ){
-				
+
 				// Get gamma-ray event
 				gamma_evt = read_evts->GetGammaRayEvt(k);
-				
+
 				// Time differences
 				gamma_particle_td->Fill( (double)particle_evt->GetTime() - (double)gamma_evt->GetTime() );
 				gamma_particle_E_vs_td->Fill( (double)particle_evt->GetTime() - (double)gamma_evt->GetTime(), gamma_evt->GetEnergy() );
 
 				// Time differences by sector
 				if( react->HistBySector() ) {
-					
+
 					gamma_particle_td_sec[particle_evt->GetSector()]->Fill( (double)particle_evt->GetTime() - (double)gamma_evt->GetTime() );
 					gamma_particle_E_vs_td_sec[particle_evt->GetSector()]->Fill( (double)particle_evt->GetTime() - (double)gamma_evt->GetTime(), gamma_evt->GetEnergy() );
-					
+
 				}
-				
+
 				// Check for prompt coincidence
 				if( PromptCoincidence( gamma_evt, particle_evt ) ){
-					
+
 					// Energy vs Angle plot with gamma-ray coincidence
 					pE_theta_coinc->Fill( react->GetParticleTheta( particle_evt ) * TMath::RadToDeg(), particle_evt->GetDeltaEnergy() );
 					pE_dE_coinc[particle_evt->GetDetector()]->Fill( particle_evt->GetEnergy(), particle_evt->GetDeltaEnergy() );
@@ -2978,26 +2978,26 @@ unsigned long MiniballHistogrammer::FillHists() {
 						// Energy vs Angle plot with gamma-ray coincidence
 						pE_theta_coinc_sec[particle_evt->GetSector()]->Fill( react->GetParticleTheta( particle_evt ) * TMath::RadToDeg(), particle_evt->GetDeltaEnergy() );
 						pE_dE_coinc_sec[particle_evt->GetDetector()][particle_evt->GetSector()]->Fill( particle_evt->GetEnergy(), particle_evt->GetDeltaEnergy() );
-						
+
 					} // by sector
-						
+
 				} // if prompt
-				
+
 			} // k: gammas
-			
+
 			// Check for coincidence with an electron
 			for( unsigned int k = 0; k < read_evts->GetSpedeMultiplicity(); ++k ){
-				
+
 				// Get SPEDE event
 				spede_evt = read_evts->GetSpedeEvt(k);
-				
+
 				// Time differences
 				electron_particle_td->Fill( (double)particle_evt->GetTime() - (double)spede_evt->GetTime() );
-								
+
 			} // k: electrons
-			
+
 		} // j: particles
-		
+
 		// Annoyingly, we need to do another loop to check the kinematics
 		// TODO: make this more efficient than looping twice?
 		// TODO: It needs to be improved to allow multiple particles in transfer
@@ -3006,7 +3006,7 @@ unsigned long MiniballHistogrammer::FillHists() {
 
 			// Get particle event
 			particle_evt = read_evts->GetParticleEvt(j);
-			
+
 			// Check if we are demanding CD-Pad coincidences
 			if( react->EventsCdPadCoincidence() && particle_evt->GetEnergyPad() < 1e-9 )
 				continue;
@@ -3020,25 +3020,25 @@ unsigned long MiniballHistogrammer::FillHists() {
 
 			// See if we are doing transfer reactions
 			if( react->GetBeam()->GetIsotope() != react->GetEjectile()->GetIsotope() &&
-				TransferCut( particle_evt ) ) {
-				
+			   TransferCut( particle_evt ) ) {
+
 				react->TransferProduct( particle_evt );
 				react->SetParticleTime( particle_evt->GetTime() );
-				
+
 				pE_dE_cut[particle_evt->GetDetector()]->Fill( particle_evt->GetEnergy(), particle_evt->GetDeltaEnergy() );
-				
+
 				if( react->HistBySector() )
 					pE_dE_cut_sec[particle_evt->GetDetector()][particle_evt->GetSector()]->Fill( particle_evt->GetEnergy(), particle_evt->GetDeltaEnergy() );
 
 				// Got what we came for
 				// TODO: What if we have multiple particles in transfer?
 				break;
-				
+
 			} // transfer event
-			
+
 			// Check for prompt coincidence with another particle
 			for( unsigned int k = j+1; k < read_evts->GetParticleMultiplicity(); ++k ){
-				
+
 				// Get second particle event
 				particle_evt2 = read_evts->GetParticleEvt(k);
 
@@ -3053,13 +3053,13 @@ unsigned long MiniballHistogrammer::FillHists() {
 				// Do a two-particle cut and check that they are coincident
 				// particle_evt (j) is beam and particle_evt2 (k) is target
 				if( TwoParticleCut( particle_evt, particle_evt2 ) ){
-					
+
 					react->IdentifyEjectile( particle_evt );
 					react->IdentifyRecoil( particle_evt2 );
 					if( particle_evt->GetTime() < particle_evt2->GetTime() )
 						react->SetParticleTime( particle_evt->GetTime() );
 					else react->SetParticleTime( particle_evt2->GetTime() );
-					
+
 					pE_theta_ejectile->Fill( react->GetParticleTheta( particle_evt ) * TMath::RadToDeg(), particle_evt->GetDeltaEnergy() );
 					pE_theta_recoil->Fill( react->GetParticleTheta( particle_evt2 ) * TMath::RadToDeg(), particle_evt2->GetDeltaEnergy() );
 					if( react->HistByMultiplicity() ){
@@ -3071,27 +3071,27 @@ unsigned long MiniballHistogrammer::FillHists() {
 
 					// Sector-by-sector particle plots
 					if( react->HistBySector() ) {
-						
+
 						pE_theta_ejectile_sec[particle_evt->GetSector()]->Fill( react->GetParticleTheta( particle_evt ) * TMath::RadToDeg(), particle_evt->GetDeltaEnergy() );
 						pE_theta_recoil_sec[particle_evt->GetSector()]->Fill( react->GetParticleTheta( particle_evt2 ) * TMath::RadToDeg(), particle_evt2->GetDeltaEnergy() );
-						
+
 					} // by sector
-					
+
 					// Got what we came for
 					event_used = true;
 					break;
 
 				} // 2-particle check
-				
+
 				// particle_evt2 (k) is beam and particle_evt (j) is target
 				else if( TwoParticleCut( particle_evt2, particle_evt ) ){
-					
+
 					react->IdentifyEjectile( particle_evt2 );
 					react->IdentifyRecoil( particle_evt );
 					if( particle_evt->GetTime() < particle_evt2->GetTime() )
 						react->SetParticleTime( particle_evt->GetTime() );
 					else react->SetParticleTime( particle_evt2->GetTime() );
-					
+
 					pE_theta_ejectile->Fill( react->GetParticleTheta( particle_evt2 ) * TMath::RadToDeg(), particle_evt2->GetDeltaEnergy() );
 					pE_theta_recoil->Fill( react->GetParticleTheta( particle_evt ) * TMath::RadToDeg(), particle_evt->GetDeltaEnergy() );
 					if( react->HistByMultiplicity() ){
@@ -3103,27 +3103,27 @@ unsigned long MiniballHistogrammer::FillHists() {
 
 					// Sector-by-sector particle plots
 					if( react->HistBySector() ) {
-						
+
 						pE_theta_ejectile_sec[particle_evt->GetSector()]->Fill( react->GetParticleTheta( particle_evt2 ) * TMath::RadToDeg(), particle_evt2->GetDeltaEnergy() );
 						pE_theta_recoil_sec[particle_evt->GetSector()]->Fill( react->GetParticleTheta( particle_evt ) * TMath::RadToDeg(), particle_evt->GetDeltaEnergy() );
 
 					} // by sector
-					
+
 					// Got what we came for
 					event_used = true;
 					break;
 
 				} // 2-particle check
-				
+
 			} // k: second particle
-			
+
 			// If we found a two-particle event, we're done
 			if( event_used ) break;
-			
+
 			// If we got here, there were no transfer events or 2p events
 			// Therefore, we can build a one particle event
 			else if( EjectileCut( particle_evt ) ) {
-				
+
 				react->IdentifyEjectile( particle_evt );
 				react->CalculateRecoil();
 				react->SetParticleTime( particle_evt->GetTime() );
@@ -3135,14 +3135,14 @@ unsigned long MiniballHistogrammer::FillHists() {
 
 				if( react->HistBySector() )
 					pE_theta_ejectile_sec[particle_evt->GetSector()]->Fill( react->GetParticleTheta( particle_evt ) * TMath::RadToDeg(), particle_evt->GetDeltaEnergy() );
-				
+
 				// Got what we came for
 				break;
-				
+
 			} // ejectile event
 
 			else if( RecoilCut( particle_evt ) ) {
-				
+
 				react->IdentifyRecoil( particle_evt );
 				react->CalculateEjectile();
 				react->SetParticleTime( particle_evt->GetTime() );
@@ -3154,15 +3154,15 @@ unsigned long MiniballHistogrammer::FillHists() {
 
 				if( react->HistBySector() )
 					pE_theta_recoil_sec[particle_evt->GetSector()]->Fill( react->GetParticleTheta( particle_evt ) * TMath::RadToDeg(), particle_evt->GetDeltaEnergy() );
-				
+
 				// Got what we came for
 				break;
-				
+
 			} // recoil event
 
 		} // j: particles
-		
-		
+
+
 		// ------------------------------------------ //
 		// Loop over gamma-ray events without addback //
 		// ------------------------------------------ //
@@ -3351,68 +3351,68 @@ unsigned long MiniballHistogrammer::FillHists() {
 		// ---------------------------------- //
 		// If the electron histograms are turned on
 		if( react->HistElectron() ) {
-			
+
 			// Get the first SPEDE event
 			for( unsigned int j = 0; j < read_evts->GetSpedeMultiplicity(); ++j ){
-				
+
 				// Get SPEDE event
 				spede_evt = read_evts->GetSpedeEvt(j);
-				
+
 				// Singles
 				eE_singles->Fill( spede_evt->GetEnergy() );
-				
+
 				// Check for events in the EBIS on-beam window
 				if( OnBeam( spede_evt ) ){
-					
+
 					eE_singles_ebis->Fill( spede_evt->GetEnergy() );
 					eE_singles_ebis_on->Fill( spede_evt->GetEnergy() );
-					
+
 				} // ebis on
-				
+
 				else if( OffBeam( spede_evt ) ){
-					
+
 					eE_singles_ebis->Fill( spede_evt->GetEnergy(), -1.0 * react->GetEBISFillRatio() );
 					eE_singles_ebis_off->Fill( spede_evt->GetEnergy() );
-					
+
 				} // ebis off
-				
+
 				// Particle-electron coincidence spectra
 				FillParticleElectronHists( spede_evt );
-				
+
 				// SPEDE hitmap
 				TVector3 evec = react->GetSpedeVector( spede_evt->GetSegment(), true );
 				electron_xy_map->Fill( evec.Y(), evec.X() );
-				
+
 				// Loop over other SPEDE events
 				for( unsigned int k = j+1; k < read_evts->GetSpedeMultiplicity(); ++k ){
-					
+
 					// Get second SPEDE event
 					spede_evt2 = read_evts->GetSpedeEvt(k);
-					
+
 					// Time differences - symmetrise
 					electron_electron_td->Fill( (double)spede_evt->GetTime() - (double)spede_evt2->GetTime() );
 					electron_electron_td->Fill( (double)spede_evt2->GetTime() - (double)spede_evt->GetTime() );
-					
+
 					// Check for prompt gamma-gamma coincidences
 					if( PromptCoincidence( spede_evt, spede_evt2 ) ) {
-						
+
 						// Fill and symmetrise
 						eE_eE->Fill( spede_evt->GetEnergy(), spede_evt2->GetEnergy() );
 						eE_eE->Fill( spede_evt2->GetEnergy(), spede_evt->GetEnergy() );
-						
+
 						// Apply EBIS condition
 						if( OnBeam( spede_evt ) && OnBeam( spede_evt2 ) ) {
-							
+
 							// Fill and symmetrise
 							eE_eE_ebis_on->Fill( spede_evt->GetEnergy(), spede_evt2->GetEnergy() );
 							eE_eE_ebis_on->Fill( spede_evt2->GetEnergy(), spede_evt->GetEnergy() );
-							
+
 						} // On Beam
-						
+
 					} // if prompt
-					
+
 				} // k: second electron
-				
+
 				// Loop over gamma events
 				// If electron-gamma and gamma without addback histograms are turned on
 				if( react->HistElectronGamma() && react->HistWithoutAddback() ) {
@@ -3459,169 +3459,169 @@ unsigned long MiniballHistogrammer::FillHists() {
 
 					// Loop over gamma addback events
 					for( unsigned int k = 0; k < read_evts->GetGammaRayAddbackMultiplicity(); ++k ){
-						
+
 						// Get gamma-ray event
 						gamma_ab_evt = read_evts->GetGammaRayAddbackEvt(k);
-						
+
 						// Check for prompt gamma-electron coincidences
 						if( PromptCoincidence( gamma_ab_evt, spede_evt ) ) {
-							
+
 							// Fill
 							aE_eE->Fill( gamma_ab_evt->GetEnergy(), spede_evt->GetEnergy() );
-							
+
 							// Apply EBIS condition
 							if( OnBeam( gamma_ab_evt ) && OnBeam( spede_evt ) ) {
-								
+
 								// Fill
 								aE_eE_ebis_on->Fill( gamma_ab_evt->GetEnergy(), spede_evt->GetEnergy() );
-								
+
 							} // On Beam
-							
+
 							// Particle-electron-gamma coincidence spectra
 							FillParticleElectronGammaHists( spede_evt, gamma_ab_evt );
-							
+
 						} // if prompt
-						
+
 					} // k: gamma with addback
-					
+
 				} // electron-gamma user option
-				
+
 			} // j: SPEDE electrons
-			
+
 		} // if electron hists turned on
-		
-		
+
+
 		// -------------------------- //
 		// Loop over beam dump events //
 		// -------------------------- //
 		// If beam-dump histograms are turned on
 		if( react->HistBeamDump() ) {
-			
+
 			// Do loop over first beam-dump event
 			for( unsigned int j = 0; j < read_evts->GetBeamDumpMultiplicity(); ++j ){
-				
+
 				// Get beam-dump event
 				bd_evt = read_evts->GetBeamDumpEvt(j);
-				
+
 				// Singles spectra
 				bdE_singles->Fill( bd_evt->GetEnergy() );
 				bdE_singles_det[bd_evt->GetDetector()]->Fill( bd_evt->GetEnergy() );
-				
+
 				// Check for coincidences in case we have multiple beam dump detectors
 				for( unsigned int k = j+1; k < read_evts->GetBeamDumpMultiplicity(); ++k ){
-					
+
 					// Get second beam dump event
 					bd_evt2 = read_evts->GetBeamDumpEvt(k);
-					
+
 					// Fill time differences symmetrically
 					bd_bd_td->Fill( (double)bd_evt->GetTime() - (double)bd_evt2->GetTime() );
 					bd_bd_td->Fill( (double)bd_evt2->GetTime() - (double)bd_evt->GetTime() );
-					
+
 					// Check for prompt coincidence
 					if( PromptCoincidence( bd_evt, bd_evt2 ) ) {
-						
+
 						// Fill energies symmetrically
 						bdE_bdE->Fill( bd_evt->GetEnergy(), bd_evt2->GetEnergy() );
 						bdE_bdE->Fill( bd_evt2->GetEnergy(), bd_evt->GetEnergy() );
-						
+
 					} // if prompt
-					
+
 				} // k: second beam dump
-				
+
 			} // j: beam dump
-			
+
 		} // beam-dump user histograms on
-		
-		
+
+
 		// ---------------------------- //
 		// Loop over ion chamber events //
 		// ---------------------------- //
 		// If ionisation chamber histograms are turned on
 		if( react->HistIonChamber() ) {
-			
+
 			// Loop over ion chamber events
 			for( unsigned int j = 0; j < read_evts->GetIonChamberMultiplicity(); ++j ){
-				
+
 				// Get ion chamber event
 				ic_evt = read_evts->GetIonChamberEvt(j);
-				
+
 				// Single spectra
 				ic_dE->Fill( ic_evt->GetEnergyLoss() );
 				ic_E->Fill( ic_evt->GetEnergyRest() );
-				
+
 				// 2D plot
 				ic_dE_E->Fill( ic_evt->GetEnergyLoss(), ic_evt->GetEnergyRest() );
-				
+
 			} // j: ion chamber
-			
+
 		} // if ion chamber hists are on
-		
+
 		// Progress bar
 		bool update_progress = false;
 		if( n_entries < 200 )
 			update_progress = true;
 		else if( i % (n_entries/100) == 0 || i+1 == n_entries )
 			update_progress = true;
-		
+
 		if( update_progress ) {
 
 			// Percent complete
 			float percent = (float)(i+1)*100.0/(float)n_entries;
-			
+
 			// Progress bar in GUI
 			if( _prog_ ){
-				
+
 				prog->SetPosition( percent );
 				gSystem->ProcessEvents();
-				
+
 			}
-		
+
 			// Progress bar in terminal
 			std::cout << " " << std::setw(6) << std::setprecision(4);
 			std::cout << percent << "%    \r";
 			std::cout.flush();
 
 		}
-		
-		
+
+
 	} // all events
-	
+
 	return n_entries;
-	
+
 }
 
 void MiniballHistogrammer::SetInputFile( std::vector<std::string> input_file_names ) {
-	
+
 	/// Overloaded function for a single file or multiple files
 	input_tree = new TChain( "evt_tree" );
 	for( unsigned int i = 0; i < input_file_names.size(); i++ ) {
-		
+
 		input_tree->Add( input_file_names[i].data() );
-		
+
 	}
 	input_tree->SetBranchAddress( "MiniballEvts", &read_evts );
-	
+
 	return;
 	
 }
 
 void MiniballHistogrammer::SetInputFile( std::string input_file_name ) {
-	
+
 	/// Overloaded function for a single file or multiple files
 	input_tree = new TChain( "evt_tree" );
 	input_tree->Add( input_file_name.data() );
 	input_tree->SetBranchAddress( "MiniballEvts", &read_evts );
-	
+
 	return;
-	
+
 }
 
 void MiniballHistogrammer::SetInputTree( TTree *user_tree ){
-	
+
 	// Find the tree and set branch addresses
 	input_tree = (TChain*)user_tree;
 	input_tree->SetBranchAddress( "MiniballEvts", &read_evts );
-	
+
 	return;
-	
+
 }

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -1801,7 +1801,7 @@ void MiniballHistogrammer::ResetHists(){
 			TIter keyList2( ( (TDirectory*)key1->ReadObj() )->GetListOfKeys() );
 			while( ( key2 = (TKey*)keyList2() ) ){ // level 2
 
-				if( key1->ReadObj()->InheritsFrom("TDirectory") ){
+				if( key2->ReadObj()->InheritsFrom("TDirectory") ){
 
 					TIter keyList3( ( (TDirectory*)key2->ReadObj() )->GetListOfKeys() );
 					while( ( key3 = (TKey*)keyList3() ) ) // level 3

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -2017,20 +2017,31 @@ void MiniballHistogrammer::PlotDefaultHists() {
 
 	// Plot things
 	c1->cd(1);
-	gE_singles->Draw("hist");
+	if( gE_singles != nullptr )
+		gE_singles->Draw("hist");
+
 	c1->cd(2);
 	c1->GetPad(2)->SetLogz();
-	pE_theta->Draw("colz");
+	if( pE_theta != nullptr )
+		pE_theta->Draw("colz");
+
 	c1->cd(3);
-	ebis_td_gamma->Draw("hist");
+	if( ebis_td_gamma != nullptr )
+		ebis_td_gamma->Draw("hist");
+
 	c1->cd(4);
-	ebis_td_particle->Draw("hist");
+	if( ebis_td_particle != nullptr )
+		ebis_td_particle->Draw("hist");
+
 	c1->cd(5);
 	c1->GetPad(5)->SetLogz();
-	gamma_theta_phi_map->Draw("colz");
+	if( gamma_theta_phi_map != nullptr )
+		gamma_theta_phi_map->Draw("colz");
+	
 	c1->cd(6);
 	c1->GetPad(6)->SetLogz();
-	particle_xy_map_forward->Draw("colz");
+	if( particle_xy_map_forward != nullptr )
+		particle_xy_map_forward->Draw("colz");
 
 	return;
 

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -2079,8 +2079,6 @@ void MiniballHistogrammer::PlotPhysicsHists() {
 		// Go to corresponding canvas
 		c2->cd(i+1);
 
-		std::cout << spyhists[i][0] << "\t" <<  spyhists[i][1] << "\t" <<  spyhists[i][2] << std::endl;
-
 		// Get this histogram of the right type
 		if( spyhists[i][1] == "TH1" || spyhists[i][1] == "TH1F" || spyhists[i][1] == "TH1D" ) {
 

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -28,8 +28,8 @@ MiniballHistogrammer::MiniballHistogrammer( std::shared_ptr<MiniballReaction> my
 	// performing the error propagation when subtracting
 	TH1::SetDefaultSumw2(kTRUE);
 
-	// Histogrammer options
-	//TH1::AddDirectory(kFALSE);
+	// Intialise the hist list
+	histlist = std::make_unique<TList>();
 
 }
 
@@ -46,16 +46,21 @@ void MiniballHistogrammer::MakeHists() {
 
 	ebis_td_gamma = new TH1F( "ebis_td_gamma", "Gamma-ray time with respect to EBIS;#Deltat;Counts per 20 #mus", 5.5e3, -0.1e8, 1e8  );
 	ebis_td_particle = new TH1F( "ebis_td_particle", "Particle time with respect to EBIS;#Deltat;Counts per 20 #mus", 5.5e3, -0.1e8, 1e8  );
+	histlist->Add(ebis_td_gamma);
+	histlist->Add(ebis_td_particle);
 
 	hname = "gamma_particle_td";
 	htitle = "Gamma-ray - Particle time difference;#Deltat;Counts";
 	gamma_particle_td = new TH1F( hname.data(), htitle.data(),
 								 TBIN, TMIN, TMAX );
+	histlist->Add(gamma_particle_td);
+
 
 	hname = "gamma_particle_E_vs_td";
 	htitle = "Gamma-ray - Particle time difference versus gamma-ray energy;#Deltat;Gamma-ray energy (keV);Counts";
 	gamma_particle_E_vs_td = new TH2F( hname.data(), htitle.data(),
 									  TBIN, TMIN, TMAX, GBIN/4., 0., 2000. );
+	histlist->Add(gamma_particle_E_vs_td);
 
 	// Sector-by-sector particle plots
 	if( react->HistBySector() ) {
@@ -70,12 +75,14 @@ void MiniballHistogrammer::MakeHists() {
 			htitle += std::to_string(i) + ";#Deltat;Counts";
 			gamma_particle_td_sec[i] = new TH1F( hname.data(), htitle.data(),
 												TBIN, TMIN, TMAX );
+			histlist->Add(gamma_particle_td_sec[i]);
 
 			hname = "gamma_particle_E_vs_td_sec" + std::to_string(i);
 			htitle = "Gamma-ray - Particle time difference versus gamma-ray energy for CD sector ";
 			htitle += std::to_string(i) + ";#Deltat;Gamma-ray energy (keV);Counts";
 			gamma_particle_E_vs_td_sec[i] = new TH2F( hname.data(), htitle.data(),
 													 TBIN, TMIN, TMAX, GBIN/4., 0., 2000. );
+			histlist->Add(gamma_particle_E_vs_td_sec[i]);
 
 		}
 
@@ -85,26 +92,31 @@ void MiniballHistogrammer::MakeHists() {
 	htitle = "Gamma-ray - Gamma-ray time difference;#Deltat [ns];Counts";
 	gamma_gamma_td = new TH1F( hname.data(), htitle.data(),
 							  TBIN, TMIN, TMAX );
+	histlist->Add(gamma_gamma_td);
 
 	hname = "gamma_electron_td";
 	htitle = "Gamma-ray - Electron time difference;#Deltat [ns];Counts per 10 ns";
 	gamma_electron_td = new TH1F( hname.data(), htitle.data(),
 								 TBIN, TMIN, TMAX );
+	histlist->Add(gamma_electron_td);
 
 	hname = "electron_electron_td";
 	htitle = "Electron - Electron time difference;#Deltat [ns];Counts per 10 ns";
 	electron_electron_td = new TH1F( hname.data(), htitle.data(),
 									TBIN, TMIN, TMAX );
+	histlist->Add(electron_electron_td);
 
 	hname = "electron_particle_td";
 	htitle = "Electron - Particle time difference;#Deltat [ns];Counts per 10 ns";
 	electron_particle_td = new TH1F( hname.data(), htitle.data(),
 									TBIN, TMIN, TMAX );
+	histlist->Add(electron_particle_td);
 
 	hname = "particle_particle_td";
 	htitle = "Particle - Particle time difference;#Deltat [ns];Counts per 10 ns";
 	particle_particle_td = new TH1F( hname.data(), htitle.data(),
 									TBIN, TMIN, TMAX );
+	histlist->Add(particle_particle_td);
 
 	// Gamma-ray singles histograms
 	dirname = "GammaRaySingles";
@@ -114,85 +126,104 @@ void MiniballHistogrammer::MakeHists() {
 	hname = "gE_singles";
 	htitle = "Gamma-ray energy singles;Energy [keV];Counts per 0.5 keV";
 	gE_singles = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+	histlist->Add(gE_singles);
 
 	if( react->HistByCrystal() ) {
 
 		hname = "gE_singles_vs_crystal";
 		htitle = "Gamma-ray energy singles versus crystal ID;Crystal ID;Energy [keV];Counts per 0.5 keV";
 		gE_singles_vs_crystal = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
+		histlist->Add(gE_singles_vs_crystal);
 
 	}
 
 	hname = "gE_singles_ebis";
 	htitle = "Gamma-ray energy singles EBIS on-off;Energy [keV];Counts per 0.5 keV";
 	gE_singles_ebis = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+	histlist->Add(gE_singles_ebis);
 
 	hname = "gE_singles_ebis_on";
 	htitle = "Gamma-ray energy singles EBIS on;Energy [keV];Counts per 0.5 keV";
 	gE_singles_ebis_on = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+	histlist->Add(gE_singles_ebis_on);
 
 	hname = "gE_singles_ebis_off";
 	htitle = "Gamma-ray energy singles EBIS off;Energy [keV];Counts per 0.5 keV";
 	gE_singles_ebis_off = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+	histlist->Add(gE_singles_ebis_off);
 
 	hname = "gE_singles_dc";
 	htitle = "Gamma-ray energy singles, Doppler corrected for unscattered beam;Energy [keV];Counts per 0.5 keV";
 	gE_singles_dc = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+	histlist->Add(gE_singles_dc);
 
 	hname = "gE_singles_dc_ebis";
 	htitle = "Gamma-ray energy singles, Doppler corrected for unscattered beam, EBIS on-off;Energy [keV];Counts per 0.5 keV";
 	gE_singles_dc_ebis = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+	histlist->Add(gE_singles_dc_ebis);
 
 	hname = "aE_singles";
 	htitle = "Gamma-ray energy with addback singles;Energy [keV];Counts per 0.5 keV";
 	aE_singles = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+	histlist->Add(aE_singles);
 
 	if( react->HistByCrystal() ) {
 
 		hname = "aE_singles_vs_crystal";
 		htitle = "Gamma-ray energy with addback singles versus crystal ID;Crystal ID;Energy [keV];Counts per 0.5 keV";
 		aE_singles_vs_crystal = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
+		histlist->Add(aE_singles_vs_crystal);
 
 	}
 	hname = "aE_singles_ebis";
 	htitle = "Gamma-ray energy with addback singles EBIS on-off;Energy [keV];Counts per 0.5 keV";
 	aE_singles_ebis = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+	histlist->Add(aE_singles_ebis);
 
 	hname = "aE_singles_ebis_on";
 	htitle = "Gamma-ray energy with addback singles EBIS on;Energy [keV];Counts per 0.5 keV";
 	aE_singles_ebis_on = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+	histlist->Add(aE_singles_ebis_on);
 
 	hname = "aE_singles_ebis_off";
 	htitle = "Gamma-ray energy with addback singles EBIS off;Energy [keV];Counts per 0.5 keV";
 	aE_singles_ebis_off = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+	histlist->Add(aE_singles_ebis_off);
 
 	hname = "aE_singles_dc";
 	htitle = "Gamma-ray energy with addback singles, Doppler corrected for unscattered beam;Energy [keV];Counts per 0.5 keV";
 	aE_singles_dc = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+	histlist->Add(aE_singles_dc);
 
 	hname = "aE_singles_dc_ebis";
 	htitle = "Gamma-ray energy with addback singles, Doppler corrected for unscattered beam, EBIS on-off;Energy [keV];Counts per 0.5 keV";
 	aE_singles_dc_ebis = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+	histlist->Add(aE_singles_dc_ebis);
 
 	hname = "gamma_xy_map_forward";
 	htitle = "Gamma-ray X-Y hit map (forward: z > 0);y (horizontal) [mm];x (vertical) [mm];Counts";
 	gamma_xy_map_forward = new TH2F( hname.data(), htitle.data(), 201, -201., 201., 201, -201., 201. );
+	histlist->Add(gamma_xy_map_forward);
 
 	hname = "gamma_xy_map_backward";
 	htitle = "Gamma-ray X-Y hit map (backwards: z < 0);y (horizontal) [mm];x (vertical) [mm];Counts";
 	gamma_xy_map_backward = new TH2F( hname.data(), htitle.data(), 201, -201., 201., 201, -201., 201. );
+	histlist->Add(gamma_xy_map_backward);
 
 	hname = "gamma_xz_map_left";
 	htitle = "Gamma-ray X-Z hit map (left: y < 0);z (horizontal) [mm];x (vertical) [mm];Counts";
 	gamma_xz_map_left = new TH2F( hname.data(), htitle.data(), 201, -201., 201., 201, -201., 201. );
+	histlist->Add(gamma_xz_map_left);
 
 	hname = "gamma_xz_map_right";
 	htitle = "Gamma-ray X-Z hit map (right: y > 0);z (horizontal) [mm];x (vertical) [mm];Counts";
 	gamma_xz_map_right = new TH2F( hname.data(), htitle.data(), 201, -201., 201., 201, -201., 201. );
+	histlist->Add(gamma_xz_map_right);
 
 	hname = "gamma_theta_phi_map";
 	htitle = "Gamma-ray #theta-#phi hit map;#theta [degrees];#phi [degrees];Counts";
 	gamma_theta_phi_map = new TH2F( hname.data(), htitle.data(), 180, 0., 180., 360, 0., 360. );
+	histlist->Add(gamma_theta_phi_map);
 
 	// Gamma-ray coincidence histograms
 	dirname = "CoincidenceMatrices";
@@ -205,18 +236,22 @@ void MiniballHistogrammer::MakeHists() {
 		hname = "gE_gE";
 		htitle = "Gamma-ray coincidence matrix;Energy [keV];Energy [keV];Counts per 0.5 keV";
 		gE_gE = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
+		histlist->Add(gE_gE);
 
 		hname = "gE_gE_ebis_on";
 		htitle = "Gamma-ray coincidence matrix EBIS on;Energy [keV];Energy [keV];Counts per 0.5 keV";
 		gE_gE_ebis_on = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
+		histlist->Add(gE_gE_ebis_on);
 
 		hname = "aE_aE";
 		htitle = "Gamma-ray addback coincidence matrix;Energy [keV];Energy [keV];Counts per 0.5 keV";
 		aE_aE = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
+		histlist->Add(aE_aE);
 
 		hname = "aE_aE_ebis_on";
 		htitle = "Gamma-ray addback coincidence matrix EBIS on;Energy [keV];Energy [keV];Counts per 0.5 keV";
 		aE_aE_ebis_on = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
+		histlist->Add(aE_aE_ebis_on);
 
 	} // gamma-gamma on
 
@@ -226,10 +261,12 @@ void MiniballHistogrammer::MakeHists() {
 		hname = "eE_eE";
 		htitle = "Electron coincidence matrix;Energy [keV];Energy [keV];Counts per keV";
 		eE_eE = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, EBIN, EMIN, EMAX );
+		histlist->Add(eE_eE);
 
 		hname = "eE_eE_ebis_on";
 		htitle = "Electron coincidence matrix EBIS on;Energy [keV];Energy [keV];Counts per keV";
 		eE_eE_ebis_on = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, EBIN, EMIN, EMAX );
+		histlist->Add(eE_eE_ebis_on);
 
 		// If electron-gamma histograms are turned on
 		if( react->HistElectronGamma() ) {
@@ -237,18 +274,22 @@ void MiniballHistogrammer::MakeHists() {
 			hname = "gE_eE";
 			htitle = "Gamma-ray and electron coincidence matrix;#gamma-ray energy [keV];e^{-} energy [keV];Counts per 0.5 keV";
 			gE_eE = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, EBIN, EMIN, EMAX );
+			histlist->Add(gE_eE);
 
 			hname = "gE_eE_ebis_on";
 			htitle = "Gamma-ray and electron coincidence matrix EBIS on;#gamma-ray energy [keV];e^{-} energy [keV];Counts per 0.5 keV";
 			gE_eE_ebis_on = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, EBIN, EMIN, EMAX );
+			histlist->Add(gE_eE_ebis_on);
 
 			hname = "aE_eE";
 			htitle = "Gamma-ray addback and electron coincidence matrix;#gamma-ray energy [keV];e^{-} energy [keV];Counts per 0.5 keV";
 			aE_eE = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, EBIN, EMIN, EMAX );
+			histlist->Add(aE_eE);
 
 			hname = "aE_eE_ebis_on";
 			htitle = "Gamma-ray addback and electron coincidence matrix EBIS on;#gamma-ray energy [keV];e^{-} energy [keV];Counts per 0.5 keV";
 			aE_eE_ebis_on = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, EBIN, EMIN, EMAX );
+			histlist->Add(aE_eE_ebis_on);
 
 		} // electron-gamma on
 
@@ -260,22 +301,27 @@ void MiniballHistogrammer::MakeHists() {
 		hname = "eE_singles";
 		htitle = "Electron energy singles;Energy [keV];Counts keV";
 		eE_singles = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
+		histlist->Add(eE_singles);
 
 		hname = "eE_singles_ebis";
 		htitle = "Electron energy singles EBIS on-off;Energy [keV];Counts keV";
 		eE_singles_ebis = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
+		histlist->Add(eE_singles_ebis);
 
 		hname = "eE_singles_ebis_on";
 		htitle = "Electron energy singles EBIS on;Energy [keV];Counts keV";
 		eE_singles_ebis_on = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
+		histlist->Add(eE_singles_ebis_on);
 
 		hname = "eE_singles_ebis_off";
 		htitle = "Electron energy singles EBIS off;Energy [keV];Counts keV";
 		eE_singles_ebis_off = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
+		histlist->Add(eE_singles_ebis_off);
 
 		hname = "electron_xy_map";
 		htitle = "Electron X-Y hit map (#theta < 90);y (horizontal) [mm];x (vertical) [mm];Counts per mm^2";
 		electron_xy_map = new TH2F( hname.data(), htitle.data(), 361, -45.125, 45.125, 361, -45.125, 45.125 );
+		histlist->Add(electron_xy_map);
 
 	} // electrons on
 
@@ -287,18 +333,22 @@ void MiniballHistogrammer::MakeHists() {
 	hname = "pE_theta";
 	htitle = "Particle energy singles;Angle [deg];Energy [keV];Counts";
 	pE_theta = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), PBIN, PMIN, PMAX );
+	histlist->Add(pE_theta);
 
 	hname = "pE_theta_coinc";
 	htitle = "Particle energy in coincidence with a gamma ray;Angle [deg];Energy [keV];Counts";
 	pE_theta_coinc = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), PBIN, PMIN, PMAX );
+	histlist->Add(pE_theta_coinc);
 
 	hname = "pE_theta_ejectile";
 	htitle = "Particle energy singles, gated on ejectile;Angle [deg];Energy [keV];Counts";
 	pE_theta_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), PBIN, PMIN, PMAX );
+	histlist->Add(pE_theta_ejectile);
 
 	hname = "pE_theta_recoil";
 	htitle = "Particle energy singles, gated on recoil;Angle [deg];Energy [keV];Counts";
 	pE_theta_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), PBIN, PMIN, PMAX );
+	histlist->Add(pE_theta_recoil);
 
 	// 1p and 2p particle histograms
 	if( react->HistByMultiplicity() ){
@@ -306,18 +356,22 @@ void MiniballHistogrammer::MakeHists() {
 		hname = "pE_theta_1p_ejectile";
 		htitle = "Particle energy singles, gated on ejectile without matching recoil;Angle [deg];Energy [keV];Counts";
 		pE_theta_1p_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), PBIN, PMIN, PMAX );
+		histlist->Add(pE_theta_1p_ejectile);
 
 		hname = "pE_theta_1p_recoil";
 		htitle = "Particle energy singles, gated on recoil without matching ejectile;Angle [deg];Energy [keV];Counts";
 		pE_theta_1p_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), PBIN, PMIN, PMAX );
+		histlist->Add(pE_theta_1p_recoil);
 
 		hname = "pE_theta_2p_ejectile";
 		htitle = "Particle energy singles, gated on ejectile with 2-particle condition;Angle [deg];Energy [keV];Counts";
 		pE_theta_2p_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), PBIN, PMIN, PMAX );
+		histlist->Add(pE_theta_2p_ejectile);
 
 		hname = "pE_theta_2p_recoil";
 		htitle = "Particle energy singles, gated on recoil with 2-particle condition;Angle [deg];Energy [keV];Counts";
 		pE_theta_2p_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), PBIN, PMIN, PMAX );
+		histlist->Add(pE_theta_2p_recoil);
 
 	}
 
@@ -335,22 +389,26 @@ void MiniballHistogrammer::MakeHists() {
 			htitle = "Particle energy singles for sector " + std::to_string(i);
 			htitle += ";Angle [deg];Energy [keV];Counts";
 			pE_theta_sec[i] = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), PBIN, PMIN, PMAX );
-			
+			histlist->Add(pE_theta_sec[i]);
+
 			hname = "pE_theta_coinc_sec" + std::to_string(i);
 			htitle = "Particle energy in coincidence with a gamma ray for sector " + std::to_string(i);
 			htitle += ";Angle [deg];Energy [keV];Counts";
 			pE_theta_coinc_sec[i] = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), PBIN, PMIN, PMAX );
-			
+			histlist->Add(pE_theta_coinc_sec[i]);
+
 			hname = "pE_theta_ejectile_sec" + std::to_string(i);
 			htitle = "Particle energy singles, gated on ejectile for sector " + std::to_string(i);
 			htitle += ";Angle [deg];Energy [keV];Counts";
 			pE_theta_ejectile_sec[i] = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), PBIN, PMIN, PMAX );
-			
+			histlist->Add(pE_theta_ejectile_sec[i]);
+
 			hname = "pE_theta_recoil_sec" + std::to_string(i);
 			htitle = "Particle energy singles, gated on recoil for sector " + std::to_string(i);
 			htitle += ";Angle [deg];Energy [keV];Counts";
 			pE_theta_recoil_sec[i] = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), PBIN, PMIN, PMAX );
-			
+			histlist->Add(pE_theta_recoil_sec[i]);
+
 		} // loop over sectors
 		
 	} // by sector
@@ -372,19 +430,22 @@ void MiniballHistogrammer::MakeHists() {
 		htitle = "Particle energy total versus energy loss for CD " + std::to_string(i);
 		htitle += ";Energy total [keV];Energy loss [keV];Counts";
 		pE_dE[i] = new TH2F( hname.data(), htitle.data(), PBIN, PMIN, PMAX, PBIN, PMIN, PMAX );
-		
+		histlist->Add(pE_dE[i]);
+
 		hname = "pE_dE_" + std::to_string(i) + "_coinc";
 		htitle = "Particle energy total versus energy loss for CD " + std::to_string(i);
 		htitle += ", coincident with a gamma-ray";
 		htitle += ";Energy total [keV];Energy loss [keV];Counts";
 		pE_dE_coinc[i] = new TH2F( hname.data(), htitle.data(), PBIN, PMIN, PMAX, PBIN, PMIN, PMAX );
-		
+		histlist->Add(pE_dE_coinc[i]);
+
 		hname = "pE_dE_" + std::to_string(i) + "_cut";
 		htitle = "Particle energy total versus energy loss for CD " + std::to_string(i);
 		htitle += ", after transfer cut applied";
 		htitle += ";Energy total [keV];Energy loss [keV];Counts";
 		pE_dE_cut[i] = new TH2F( hname.data(), htitle.data(), PBIN, PMIN, PMAX, PBIN, PMIN, PMAX );
-		
+		histlist->Add(pE_dE_cut[i]);
+
 		// Sector-by-sector particle plots
 		if( react->HistBySector() ) {
 			
@@ -395,19 +456,22 @@ void MiniballHistogrammer::MakeHists() {
 				htitle += ", sector " + std::to_string(j);
 				htitle += ";Energy total [keV];Energy loss [keV];Counts";
 				pE_dE_sec[i][j] = new TH2F( hname.data(), htitle.data(), PBIN, PMIN, PMAX, PBIN, PMIN, PMAX );
-				
+				histlist->Add(pE_dE_sec[i][j]);
+
 				hname = "pE_dE_" + std::to_string(i) + "_" + std::to_string(j) + "_coinc";
 				htitle = "Particle energy total versus energy loss for CD " + std::to_string(i);
 				htitle += ", sector " + std::to_string(j) + ", coincident with a gamma-ray";
 				htitle += ";Energy total [keV];Energy loss [keV];Counts";
 				pE_dE_coinc_sec[i][j] = new TH2F( hname.data(), htitle.data(), PBIN, PMIN, PMAX, PBIN, PMIN, PMAX );
-				
+				histlist->Add(pE_dE_coinc_sec[i][j]);
+
 				hname = "pE_dE_" + std::to_string(i) + "_" + std::to_string(j) + "_cut";
 				htitle = "Particle energy total versus energy loss for CD " + std::to_string(i);
 				htitle += ", sector " + std::to_string(j) + ", after transfer cut applied";
 				htitle += ";Energy total [keV];Energy loss [keV];Counts";
 				pE_dE_cut_sec[i][j] = new TH2F( hname.data(), htitle.data(), PBIN, PMIN, PMAX, PBIN, PMIN, PMAX );
-				
+				histlist->Add(pE_dE_cut_sec[i][j]);
+
 			}
 			
 		} // by sector
@@ -417,23 +481,28 @@ void MiniballHistogrammer::MakeHists() {
 	hname = "pBeta_theta_ejectile";
 	htitle = "Reconstructed ejectile velocity;Angle [deg];#beta [c];Counts";
 	pBeta_theta_ejectile = new TProfile( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data() );
-	
+	histlist->Add(pBeta_theta_ejectile);
+
 	hname = "pBeta_theta_recoil";
 	htitle = "Reconstructed recoil velocity;Angle [deg];#beta [c];Counts";
 	pBeta_theta_recoil = new TProfile( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data() );
-	
+	histlist->Add(pBeta_theta_recoil);
+
 	hname = "particle_xy_map_forward";
 	htitle = "Particle X-Y hit map (#theta < 90);y (horizontal) [mm];x (vertical) [mm];Counts per mm^2";
 	particle_xy_map_forward = new TH2F( hname.data(), htitle.data(), 361, -45.125, 45.125, 361, -45.125, 45.125 );
-	
+	histlist->Add(particle_xy_map_forward);
+
 	hname = "particle_xy_map_backward";
 	htitle = "Particle X-Y hit map (#theta > 90);y (horizontal) [mm];x (vertical);Counts per mm^2";
 	particle_xy_map_backward = new TH2F( hname.data(), htitle.data(), 361, -45.125, 45.125, 361, -45.125, 45.125 );
-	
+	histlist->Add(particle_xy_map_backward);
+
 	hname = "particle_theta_phi_map";
 	htitle = "Particle #theta-#phi hit map;#theta [deg];#phi [deg];Counts";
 	particle_theta_phi_map = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), 180, -181, 181 );
-	
+	histlist->Add(particle_theta_phi_map);
+
 	// Gamma-particle coincidences without addback
 	dirname = "GammaRayParticleCoincidences";
 	output_file->mkdir( dirname.data() );
@@ -442,57 +511,69 @@ void MiniballHistogrammer::MakeHists() {
 	hname = "gE_prompt";
 	htitle = "Gamma-ray energy in prompt coincide with any particle;Energy [keV];Counts per 0.5 keV";
 	gE_prompt = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	
+	histlist->Add(gE_prompt);
+
 	hname = "gE_prompt_1p";
 	htitle = "Gamma-ray energy in prompt coincide with just 1 particle;Energy [keV];Counts per 0.5 keV";
 	gE_prompt_1p = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	
+	histlist->Add(gE_prompt_1p);
+
 	hname = "gE_prompt_2p";
 	htitle = "Gamma-ray energy in prompt coincide with 2 particles;Energy [keV];Counts per 0.5 keV";
 	gE_prompt_2p = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	
+	histlist->Add(gE_prompt_2p);
+
 	hname = "gE_random";
 	htitle = "Gamma-ray energy in random coincide with any particle;Energy [keV];Counts per 0.5 keV";
 	gE_random = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	
+	histlist->Add(gE_random);
+
 	hname = "gE_random_1p";
 	htitle = "Gamma-ray energy in random coincide with just 1 particle;Energy [keV];Counts per 0.5 keV";
 	gE_random_1p = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	
+	histlist->Add(gE_random_1p);
+
 	hname = "gE_random_2p";
 	htitle = "Gamma-ray energy in random coincide with 2 particles;Energy [keV];Counts per 0.5 keV";
 	gE_random_2p = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	
+	histlist->Add(gE_random_2p);
+
 	hname = "gE_ejectile_dc_none";
 	htitle = "Gamma-ray energy, gated on the ejectile with random subtraction;";
 	htitle += "Energy [keV];Counts per 0.5 keV";
 	gE_ejectile_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	
+	histlist->Add(gE_ejectile_dc_none);
+
 	hname = "gE_ejectile_dc_ejectile";
 	htitle = "Gamma-ray energy, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
 	htitle += "Energy [keV];Counts per 0.5 keV";
 	gE_ejectile_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	
+	histlist->Add(gE_ejectile_dc_ejectile);
+
 	hname = "gE_ejectile_dc_recoil";
 	htitle = "Gamma-ray energy, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
 	htitle += "Energy [keV];Counts per 0.5 keV";
 	gE_ejectile_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	
+	histlist->Add(gE_ejectile_dc_recoil);
+
 	hname = "gE_recoil_dc_none";
 	htitle = "Gamma-ray energy, gated on the recoil with random subtraction;";
 	htitle += "Energy [keV];Counts per 0.5 keV";
 	gE_recoil_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	
+	histlist->Add(gE_recoil_dc_none);
+
 	hname = "gE_recoil_dc_ejectile";
 	htitle = "Gamma-ray energy, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
 	htitle += "Energy [keV];Counts per 0.5 keV";
 	gE_recoil_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	
+	histlist->Add(gE_recoil_dc_ejectile);
+
 	hname = "gE_recoil_dc_recoil";
 	htitle = "Gamma-ray energy, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
 	htitle += "Energy [keV];Counts per 0.5 keV";
 	gE_recoil_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	
+	histlist->Add(gE_recoil_dc_recoil);
+
 	// 1p and 2p gamma-ray histograms
 	if( react->HistByMultiplicity() ){
 		
@@ -500,111 +581,134 @@ void MiniballHistogrammer::MakeHists() {
 		htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only with random subtraction;";
 		htitle += "Energy [keV];Counts per 0.5 keV";
 		gE_1p_ejectile_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(gE_1p_ejectile_dc_none);
+
 		hname = "gE_1p_ejectile_dc_ejectile";
 		htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "Energy [keV];Counts per 0.5 keV";
 		gE_1p_ejectile_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(gE_1p_ejectile_dc_ejectile);
+
 		hname = "gE_1p_ejectile_dc_recoil";
 		htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
 		htitle += "Energy [keV];Counts per 0.5 keV";
 		gE_1p_ejectile_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(gE_1p_ejectile_dc_recoil);
+
 		hname = "gE_1p_recoil_dc_none";
 		htitle = "Gamma-ray energy, gated on the recoil, 1-particle only with random subtraction;";
 		htitle += "Energy [keV];Counts per 0.5 keV";
 		gE_1p_recoil_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(gE_1p_recoil_dc_none);
+
 		hname = "gE_1p_recoil_dc_ejectile";
 		htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "Energy [keV];Counts per 0.5 keV";
 		gE_1p_recoil_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(gE_1p_recoil_dc_ejectile);
+
 		hname = "gE_1p_recoil_dc_recoil";
 		htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
 		htitle += "Energy [keV];Counts per 0.5 keV";
 		gE_1p_recoil_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(gE_1p_recoil_dc_recoil);
+
 		hname = "gE_2p_dc_none";
 		htitle = "Gamma-ray energy, in coincidence with ejectile and recoil with random subtraction;";
 		htitle += "Energy [keV];Counts per 0.5 keV";
 		gE_2p_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(gE_2p_dc_none);
+
 		hname = "gE_2p_dc_ejectile";
 		htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "Energy [keV];Counts per 0.5 keV";
 		gE_2p_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(gE_2p_dc_ejectile);
+
 		hname = "gE_2p_dc_recoil";
 		htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
 		htitle += "Energy [keV];Counts per 0.5 keV";
 		gE_2p_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(gE_2p_dc_recoil);
+
 	}
 	
 	hname = "gE_vs_costheta_ejectile_dc_none";
 	htitle = "Gamma-ray energy versus cos(#theta) of angle between ejectile and gamma-ray, gated on the ejectile;Energy [keV];cos(#theta_p#gamma)";
 	gE_vs_costheta_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+	histlist->Add(gE_vs_costheta_ejectile_dc_none);
 
 	hname = "gE_vs_costheta2_ejectile_dc_none";
 	htitle = "Gamma-ray energy versus cos(#theta) of angle between recoil and gamma-ray, gated on the ejectile;Energy [keV];cos(#theta_p#gamma)";
 	gE_vs_costheta2_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+	histlist->Add(gE_vs_costheta2_ejectile_dc_none);
 
 	hname = "gE_vs_costheta_ejectile_dc_ejectile";
 	htitle = "Gamma-ray energy versus cos(#theta) of angle between ejectile and gamma-ray, gated on the ejectile, Doppler corrected for the ejectile;Energy [keV];cos(#theta_p#gamma)";
 	gE_vs_costheta_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+	histlist->Add(gE_vs_costheta_ejectile_dc_ejectile);
 
 	hname = "gE_vs_costheta_ejectile_dc_recoil";
 	htitle = "Gamma-ray energy versus cos(#theta) of angle between recoil and gamma-ray, gated on the ejectile, Doppler corrected for the recoil;Energy [keV];cos(#theta_p#gamma)";
 	gE_vs_costheta_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+	histlist->Add(gE_vs_costheta_ejectile_dc_recoil);
 
 	hname = "gE_vs_costheta_recoil_dc_none";
 	htitle = "Gamma-ray energy versus cos(#theta) of angle between recoil and gamma-ray, gated on the recoil, no Doppler correction;Energy [keV];cos(#theta_p#gamma)";
 	gE_vs_costheta_recoil_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+	histlist->Add(gE_vs_costheta_recoil_dc_none);
 
 	hname = "gE_vs_costheta2_recoil_dc_none";
 	htitle = "Gamma-ray energy versus cos(#theta) of angle between ejectile and gamma-ray, gated on the recoil, no Doppler correction;Energy [keV];cos(#theta_p#gamma)";
 	gE_vs_costheta2_recoil_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+	histlist->Add(gE_vs_costheta2_recoil_dc_none);
 
 	hname = "gE_vs_costheta_recoil_dc_ejectile";
 	htitle = "Gamma-ray energy versus cos(#theta) of angle between ejectile and gamma-ray, gated on the recoil, Doppler corrected for the ejectile;Energy [keV];cos(#theta_p#gamma)";
 	gE_vs_costheta_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+	histlist->Add(gE_vs_costheta_recoil_dc_ejectile);
 
 	hname = "gE_vs_costheta_recoil_dc_recoil";
 	htitle = "Gamma-ray energy versus cos(#theta) of angle between recoil and gamma-ray, gated on the recoil, Doppler corrected for the recoil;Energy [keV];cos(#theta_p#gamma)";
 	gE_vs_costheta_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+	histlist->Add(gE_vs_costheta_recoil_dc_recoil);
 
 	hname = "gE_vs_theta_ejectile_dc_none";
 	htitle = "Gamma-ray energy, gated on the ejectile with random subtraction;";
 	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 	gE_vs_theta_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-	
+	histlist->Add(gE_vs_theta_ejectile_dc_none);
+
 	hname = "gE_vs_theta_ejectile_dc_ejectile";
 	htitle = "Gamma-ray energy, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
 	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 	gE_vs_theta_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-	
+	histlist->Add(gE_vs_theta_ejectile_dc_ejectile);
+
 	hname = "gE_vs_theta_ejectile_dc_recoil";
 	htitle = "Gamma-ray energy, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
 	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 	gE_vs_theta_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-	
+	histlist->Add(gE_vs_theta_ejectile_dc_recoil);
+
 	hname = "gE_vs_theta_recoil_dc_none";
 	htitle = "Gamma-ray energy, gated on the recoil with random subtraction;";
 	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 	gE_vs_theta_recoil_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-	
+	histlist->Add(gE_vs_theta_recoil_dc_none);
+
 	hname = "gE_vs_theta_recoil_dc_ejectile";
 	htitle = "Gamma-ray energy, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
 	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 	gE_vs_theta_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-	
+	histlist->Add(gE_vs_theta_recoil_dc_ejectile);
+
 	hname = "gE_vs_theta_recoil_dc_recoil";
 	htitle = "Gamma-ray energy, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
 	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 	gE_vs_theta_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-	
+	histlist->Add(gE_vs_theta_recoil_dc_recoil);
+
 	// 1p and 2p gamma-ray histograms
 	if( react->HistByMultiplicity() ){
 		
@@ -612,47 +716,56 @@ void MiniballHistogrammer::MakeHists() {
 		htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only with random subtraction;";
 		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 		gE_vs_theta_1p_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(gE_vs_theta_1p_ejectile_dc_none);
+
 		hname = "gE_vs_theta_1p_ejectile_dc_ejectile";
 		htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 		gE_vs_theta_1p_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(gE_vs_theta_1p_ejectile_dc_ejectile);
+
 		hname = "gE_vs_theta_1p_ejectile_dc_recoil";
 		htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
 		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 		gE_vs_theta_1p_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(gE_vs_theta_1p_ejectile_dc_recoil);
+
 		hname = "gE_vs_theta_1p_recoil_dc_none";
 		htitle = "Gamma-ray energy, gated on the recoil, 1-particle only with random subtraction;";
 		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 		gE_vs_theta_1p_recoil_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(gE_vs_theta_1p_recoil_dc_none);
+
 		hname = "gE_vs_theta_1p_recoil_dc_ejectile";
 		htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 		gE_vs_theta_1p_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(gE_vs_theta_1p_recoil_dc_ejectile);
+
 		hname = "gE_vs_theta_1p_recoil_dc_recoil";
 		htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
 		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 		gE_vs_theta_1p_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(gE_vs_theta_1p_recoil_dc_recoil);
+
 		hname = "gE_vs_theta_2p_dc_none";
 		htitle = "Gamma-ray energy, in coincidence with ejectile and recoil with random subtraction;";
 		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 		gE_vs_theta_2p_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(gE_vs_theta_2p_dc_none);
+
 		hname = "gE_vs_theta_2p_dc_ejectile";
 		htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 		gE_vs_theta_2p_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(gE_vs_theta_2p_dc_ejectile);
+
 		hname = "gE_vs_theta_2p_dc_recoil";
 		htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
 		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 		gE_vs_theta_2p_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(gE_vs_theta_2p_dc_recoil);
+
 	}
 
 	// Per crystal Doppler-corrected spectra
@@ -662,32 +775,38 @@ void MiniballHistogrammer::MakeHists() {
 		htitle = "Gamma-ray energy, gated on the ejectile with random subtraction;";
 		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 		gE_vs_crystal_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-		
+		histlist->Add(gE_vs_crystal_ejectile_dc_none);
+
 		hname = "gE_vs_crystal_ejectile_dc_ejectile";
 		htitle = "Gamma-ray energy, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 		gE_vs_crystal_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-		
+		histlist->Add(gE_vs_crystal_ejectile_dc_ejectile);
+
 		hname = "gE_vs_crystal_ejectile_dc_recoil";
 		htitle = "Gamma-ray energy, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
 		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 		gE_vs_crystal_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-		
+		histlist->Add(gE_vs_crystal_ejectile_dc_recoil);
+
 		hname = "gE_vs_crystal_recoil_dc_none";
 		htitle = "Gamma-ray energy, gated on the recoil with random subtraction;";
 		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 		gE_vs_crystal_recoil_dc_none = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-		
+		histlist->Add(gE_vs_crystal_recoil_dc_none);
+
 		hname = "gE_vs_crystal_recoil_dc_ejectile";
 		htitle = "Gamma-ray energy, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 		gE_vs_crystal_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-		
+		histlist->Add(gE_vs_crystal_recoil_dc_ejectile);
+
 		hname = "gE_vs_crystal_recoil_dc_recoil";
 		htitle = "Gamma-ray energy, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
 		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 		gE_vs_crystal_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-		
+		histlist->Add(gE_vs_crystal_recoil_dc_recoil);
+
 		// 1p and 2p gamma-ray histograms
 		if( react->HistByMultiplicity() ){
 			
@@ -695,47 +814,56 @@ void MiniballHistogrammer::MakeHists() {
 			htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only with random subtraction;";
 			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 			gE_vs_crystal_1p_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-			
+			histlist->Add(gE_vs_crystal_1p_ejectile_dc_none);
+
 			hname = "gE_vs_crystal_1p_ejectile_dc_ejectile";
 			htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
 			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 			gE_vs_crystal_1p_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-			
+			histlist->Add(gE_vs_crystal_1p_ejectile_dc_ejectile);
+
 			hname = "gE_vs_crystal_1p_ejectile_dc_recoil";
 			htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
 			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 			gE_vs_crystal_1p_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-			
+			histlist->Add(gE_vs_crystal_1p_ejectile_dc_recoil);
+
 			hname = "gE_vs_crystal_1p_recoil_dc_none";
 			htitle = "Gamma-ray energy, gated on the recoil, 1-particle only with random subtraction;";
 			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 			gE_vs_crystal_1p_recoil_dc_none = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-			
+			histlist->Add(gE_vs_crystal_1p_recoil_dc_none);
+
 			hname = "gE_vs_crystal_1p_recoil_dc_ejectile";
 			htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
 			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 			gE_vs_crystal_1p_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-			
+			histlist->Add(gE_vs_crystal_1p_recoil_dc_ejectile);
+
 			hname = "gE_vs_crystal_1p_recoil_dc_recoil";
 			htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
 			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 			gE_vs_crystal_1p_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-			
+			histlist->Add(gE_vs_crystal_1p_recoil_dc_recoil);
+
 			hname = "gE_vs_crystal_2p_dc_none";
 			htitle = "Gamma-ray energy, in coincidence with ejectile and recoil with random subtraction;";
 			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 			gE_vs_crystal_2p_dc_none = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-			
+			histlist->Add(gE_vs_crystal_2p_dc_none);
+
 			hname = "gE_vs_crystal_2p_dc_ejectile";
 			htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
 			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 			gE_vs_crystal_2p_dc_ejectile = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-			
+			histlist->Add(gE_vs_crystal_2p_dc_ejectile);
+
 			hname = "gE_vs_crystal_2p_dc_recoil";
 			htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
 			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 			gE_vs_crystal_2p_dc_recoil = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-			
+			histlist->Add(gE_vs_crystal_2p_dc_recoil);
+
 		}
 		
 	} // by crystal
@@ -747,32 +875,38 @@ void MiniballHistogrammer::MakeHists() {
 		htitle = "Gamma-ray energy, gated on the ejectile, with random subtraction;";
 		htitle += "T1 time [ns];Energy [keV];Counts per keV";
 		gE_ejectile_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(gE_ejectile_dc_none_t1);
+
 		hname = "gE_ejectile_dc_ejectile_t1";
 		htitle = "Gamma-ray energy, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "T1 time [ns];Energy [keV];Counts per keV";
 		gE_ejectile_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(gE_ejectile_dc_ejectile_t1);
+
 		hname = "gE_ejectile_dc_recoil_t1";
 		htitle = "Gamma-ray energy, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
 		htitle += "T1 time [ns];Energy [keV];Counts per keV";
 		gE_ejectile_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(gE_ejectile_dc_recoil_t1);
+
 		hname = "gE_recoil_dc_none_t1";
 		htitle = "Gamma-ray energy, gated on the recoil, with random subtraction;";
 		htitle += "T1 time [ns];Energy [keV];Counts per keV";
 		gE_recoil_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(gE_recoil_dc_none_t1);
+
 		hname = "gE_recoil_dc_ejectile_t1";
 		htitle = "Gamma-ray energy, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "T1 time [ns];Energy [keV];Counts per keV";
 		gE_recoil_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(gE_recoil_dc_ejectile_t1);
+
 		hname = "gE_recoil_dc_recoil_t1";
 		htitle = "Gamma-ray energy, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
 		htitle += "T1 time [ns];Energy [keV];Counts per eV";
 		gE_recoil_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(gE_recoil_dc_recoil_t1);
+
 		// 1p and 2p gamma-ray histograms
 		if( react->HistByMultiplicity() ){
 			
@@ -780,47 +914,56 @@ void MiniballHistogrammer::MakeHists() {
 			htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, with random subtraction;";
 			htitle += "T1 time [ns];Energy [keV];Counts per keV";
 			gE_1p_ejectile_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			
+			histlist->Add(gE_1p_ejectile_dc_none_t1);
+
 			hname = "gE_1p_ejectile_dc_ejectile_t1";
 			htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
 			htitle += "T1 time [ns];Energy [keV];Counts per keV";
 			gE_1p_ejectile_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			
+			histlist->Add(gE_1p_ejectile_dc_ejectile_t1);
+
 			hname = "gE_1p_ejectile_dc_recoil_t1";
 			htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
 			htitle += "T1 time [ns];Energy [keV];Counts per keV";
 			gE_1p_ejectile_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			
+			histlist->Add(gE_1p_ejectile_dc_recoil_t1);
+
 			hname = "gE_1p_recoil_dc_none_t1";
 			htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, with random subtraction;";
 			htitle += "T1 time [ns];Energy [keV];Counts per keV";
 			gE_1p_recoil_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			
+			histlist->Add(gE_1p_recoil_dc_none_t1);
+
 			hname = "gE_1p_recoil_dc_ejectile_t1";
 			htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
 			htitle += "T1 time [ns];Energy [keV];Counts per keV";
 			gE_1p_recoil_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			
+			histlist->Add(gE_1p_recoil_dc_ejectile_t1);
+
 			hname = "gE_1p_recoil_dc_recoil_t1";
 			htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
 			htitle += "T1 time [ns];Energy [keV];Counts per eV";
 			gE_1p_recoil_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+			histlist->Add(gE_1p_recoil_dc_recoil_t1);
 
 			hname = "gE_2p_dc_none_t1";
 			htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil with random subtraction;";
 			htitle += "Energy [keV];Counts per keV";
 			gE_2p_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			
+			histlist->Add(gE_2p_dc_none_t1);
+
 			hname = "gE_2p_dc_ejectile_t1";
 			htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
 			htitle += "Energy [keV];Counts per keV";
 			gE_2p_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			
+			histlist->Add(gE_2p_dc_ejectile_t1);
+
 			hname = "gE_2p_dc_recoil_t1";
 			htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
 			htitle += "Energy [keV];Counts per keV";
 			gE_2p_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			
+			histlist->Add(gE_2p_dc_recoil_t1);
+
 		}
 		
 	}
@@ -831,32 +974,38 @@ void MiniballHistogrammer::MakeHists() {
 		htitle = "Gamma-gamma matrix, gated on the ejectile with random subtraction;";
 		htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
 		ggE_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(ggE_ejectile_dc_none);
+
 		hname = "ggE_ejectile_dc_ejectile";
 		htitle = "Gamma-gamma matrix, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
 		ggE_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(ggE_ejectile_dc_ejectile);
+
 		hname = "ggE_ejectile_dc_recoil";
 		htitle = "Gamma-gamma matrix, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
 		htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
 		ggE_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(ggE_ejectile_dc_recoil);
+
 		hname = "ggE_recoil_dc_none";
 		htitle = "Gamma-gamma matrix, gated on the recoil with random subtraction;";
 		htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
 		ggE_recoil_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(ggE_recoil_dc_none);
+
 		hname = "ggE_recoil_dc_ejectile";
 		htitle = "Gamma-gamma matrix, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
 		ggE_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(ggE_recoil_dc_ejectile);
+
 		hname = "ggE_recoil_dc_recoil";
 		htitle = "Gamma-gamma matrix, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
 		htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
 		ggE_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(ggE_recoil_dc_recoil);
+
 	}
 	
 	// Gamma-particle coincidences with addback
@@ -867,56 +1016,68 @@ void MiniballHistogrammer::MakeHists() {
 	hname = "aE_prompt";
 	htitle = "Gamma-ray energy with addback in prompt coincide with any particle;Energy [keV];Counts per 0.5 keV";
 	aE_prompt = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+	histlist->Add(aE_prompt);
 
 	hname = "aE_prompt_1p";
 	htitle = "Gamma-ray energy with addback in prompt coincide with just 1 particle;Energy [keV];Counts per 0.5 keV";
 	aE_prompt_1p = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+	histlist->Add(aE_prompt_1p);
 
 	hname = "aE_prompt_2p";
 	htitle = "Gamma-ray energy with addback in prompt coincide with 2 particles;Energy [keV];Counts per 0.5 keV";
 	aE_prompt_2p = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+	histlist->Add(aE_prompt_2p);
 
 	hname = "aE_random";
 	htitle = "Gamma-ray energy with addback in random coincide with any particle;Energy [keV];Counts per 0.5 keV";
 	aE_random = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+	histlist->Add(aE_random);
 
 	hname = "aE_random_1p";
 	htitle = "Gamma-ray energy with addback in random coincide with just 1 particle;Energy [keV];Counts per 0.5 keV";
 	aE_random_1p = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+	histlist->Add(aE_random_1p);
 
 	hname = "aE_random_2p";
 	htitle = "Gamma-ray energy with addback in random coincide with 2 particles;Energy [keV];Counts per 0.5 keV";
 	aE_random_2p = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+	histlist->Add(aE_random_2p);
 
 	hname = "aE_ejectile_dc_none";
 	htitle = "Gamma-ray energy with addback, gated on the ejectile with random subtraction;";
 	htitle += "Energy [keV];Counts per 0.5 keV";
 	aE_ejectile_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+	histlist->Add(aE_ejectile_dc_none);
 
 	hname = "aE_ejectile_dc_ejectile";
 	htitle = "Gamma-ray energy with addback, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
 	htitle += "Energy [keV];Counts per 0.5 keV";
 	aE_ejectile_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+	histlist->Add(aE_ejectile_dc_ejectile);
 
 	hname = "aE_ejectile_dc_recoil";
 	htitle = "Gamma-ray energy with addback, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
 	htitle += "Energy [keV];Counts per 0.5 keV";
 	aE_ejectile_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+	histlist->Add(aE_ejectile_dc_recoil);
 
 	hname = "aE_recoil_dc_none";
 	htitle = "Gamma-ray energy with addback, gated on the recoil with random subtraction;";
 	htitle += "Energy [keV];Counts per 0.5 keV";
 	aE_recoil_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+	histlist->Add(aE_recoil_dc_none);
 
 	hname = "aE_recoil_dc_ejectile";
 	htitle = "Gamma-ray energy with addback, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
 	htitle += "Energy [keV];Counts per 0.5 keV";
 	aE_recoil_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+	histlist->Add(aE_recoil_dc_ejectile);
 
 	hname = "aE_recoil_dc_recoil";
 	htitle = "Gamma-ray energy with addback, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
 	htitle += "Energy [keV];Counts per 0.5 keV";
 	aE_recoil_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+	histlist->Add(aE_recoil_dc_recoil);
 
 	// 1p and 2p gamma-ray histograms
 	if( react->HistByMultiplicity() ){
@@ -925,111 +1086,134 @@ void MiniballHistogrammer::MakeHists() {
 		htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only with random subtraction;";
 		htitle += "Energy [keV];Counts per 0.5 keV";
 		aE_1p_ejectile_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(aE_1p_ejectile_dc_none);
+
 		hname = "aE_1p_ejectile_dc_ejectile";
 		htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "Energy [keV];Counts per 0.5 keV";
 		aE_1p_ejectile_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(aE_1p_ejectile_dc_ejectile);
+
 		hname = "aE_1p_ejectile_dc_recoil";
 		htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
 		htitle += "Energy [keV];Counts per 0.5 keV";
 		aE_1p_ejectile_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(aE_1p_ejectile_dc_recoil);
+
 		hname = "aE_1p_recoil_dc_none";
 		htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only with random subtraction;";
 		htitle += "Energy [keV];Counts per 0.5 keV";
 		aE_1p_recoil_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(aE_1p_recoil_dc_none);
+
 		hname = "aE_1p_recoil_dc_ejectile";
 		htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "Energy [keV];Counts per 0.5 keV";
 		aE_1p_recoil_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(aE_1p_recoil_dc_ejectile);
+
 		hname = "aE_1p_recoil_dc_recoil";
 		htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
 		htitle += "Energy [keV];Counts per 0.5 keV";
 		aE_1p_recoil_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(aE_1p_recoil_dc_recoil);
+
 		hname = "aE_2p_dc_none";
 		htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil with random subtraction;";
 		htitle += "Energy [keV];Counts per 0.5 keV";
 		aE_2p_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(aE_2p_dc_none);
+
 		hname = "aE_2p_dc_ejectile";
 		htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "Energy [keV];Counts per 0.5 keV";
 		aE_2p_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(aE_2p_dc_ejectile);
+
 		hname = "aE_2p_dc_recoil";
 		htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
 		htitle += "Energy [keV];Counts per 0.5 keV";
 		aE_2p_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(aE_2p_dc_recoil);
+
 	}
 
 	hname = "aE_vs_costheta_ejectile_dc_none";
 	htitle = "Gamma-ray energy with addback versus cos(#theta) of angle between ejectile and gamma-ray, gated on the ejectile;Energy [keV];cos(#theta_p#gamma)";
 	aE_vs_costheta_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+	histlist->Add(aE_vs_costheta_ejectile_dc_none);
 
 	hname = "aE_vs_costheta2_ejectile_dc_none";
 	htitle = "Gamma-ray energy with addback versus cos(#theta) of angle between recoil and gamma-ray, gated on the ejectile;Energy [keV];cos(#theta_p#gamma)";
 	aE_vs_costheta2_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+	histlist->Add(aE_vs_costheta2_ejectile_dc_none);
 
 	hname = "aE_vs_costheta_ejectile_dc_ejectile";
 	htitle = "Gamma-ray energy with addback versus cos(#theta) of angle between ejectile and gamma-ray, gated on the ejectile, Doppler corrected for the ejectile;Energy [keV];cos(#theta_p#gamma)";
 	aE_vs_costheta_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+	histlist->Add(aE_vs_costheta_ejectile_dc_ejectile);
 
 	hname = "aE_vs_costheta_ejectile_dc_recoil";
 	htitle = "Gamma-ray energy with addback versus cos(#theta) of angle between recoil and gamma-ray, gated on the ejectile, Doppler corrected for the recoil;Energy [keV];cos(#theta_p#gamma)";
 	aE_vs_costheta_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+	histlist->Add(aE_vs_costheta_ejectile_dc_recoil);
 
 	hname = "aE_vs_costheta_recoil_dc_none";
 	htitle = "Gamma-ray energy with addback versus cos(#theta) of angle between recoil and gamma-ray, gated on the recoil, no Doppler correction;Energy [keV];cos(#theta_p#gamma)";
 	aE_vs_costheta_recoil_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+	histlist->Add(aE_vs_costheta_recoil_dc_none);
 
 	hname = "aE_vs_costheta2_recoil_dc_none";
 	htitle = "Gamma-ray energy with addback versus cos(#theta) of angle between ejectile and gamma-ray, gated on the recoil, no Doppler correction;Energy [keV];cos(#theta_p#gamma)";
 	aE_vs_costheta2_recoil_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+	histlist->Add(aE_vs_costheta2_recoil_dc_none);
 
 	hname = "aE_vs_costheta_recoil_dc_ejectile";
 	htitle = "Gamma-ray energy with addback versus cos(#theta) of angle between ejectile and gamma-ray, gated on the recoil, Doppler corrected for the ejectile;Energy [keV];cos(#theta_p#gamma)";
 	aE_vs_costheta_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+	histlist->Add(aE_vs_costheta_recoil_dc_ejectile);
 
 	hname = "aE_vs_costheta_recoil_dc_recoil";
 	htitle = "Gamma-ray energy with addback versus cos(#theta) of angle between recoil and gamma-ray, gated on the recoil, Doppler corrected for the recoil;Energy [keV];cos(#theta_p#gamma)";
 	aE_vs_costheta_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+	histlist->Add(aE_vs_costheta_recoil_dc_recoil);
 
 	hname = "aE_vs_theta_ejectile_dc_none";
 	htitle = "Gamma-ray energy with addback, gated on the ejectile with random subtraction;";
 	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 	aE_vs_theta_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-	
+	histlist->Add(aE_vs_theta_ejectile_dc_none);
+
 	hname = "aE_vs_theta_ejectile_dc_ejectile";
 	htitle = "Gamma-ray energy with addback, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
 	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 	aE_vs_theta_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-	
+	histlist->Add(aE_vs_theta_ejectile_dc_ejectile);
+
 	hname = "aE_vs_theta_ejectile_dc_recoil";
 	htitle = "Gamma-ray energy with addback, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
 	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 	aE_vs_theta_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-	
+	histlist->Add(aE_vs_theta_ejectile_dc_recoil);
+
 	hname = "aE_vs_theta_recoil_dc_none";
 	htitle = "Gamma-ray energy with addback, gated on the recoil with random subtraction;";
 	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 	aE_vs_theta_recoil_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-	
+	histlist->Add(aE_vs_theta_recoil_dc_none);
+
 	hname = "aE_vs_theta_recoil_dc_ejectile";
 	htitle = "Gamma-ray energy with addback, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
 	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 	aE_vs_theta_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-	
+	histlist->Add(aE_vs_theta_recoil_dc_ejectile);
+
 	hname = "aE_vs_theta_recoil_dc_recoil";
 	htitle = "Gamma-ray energy with addback, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
 	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 	aE_vs_theta_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-	
+	histlist->Add(aE_vs_theta_recoil_dc_recoil);
+
 	// 1p and 2p gamma-ray histograms
 	if( react->HistByMultiplicity() ){
 		
@@ -1037,47 +1221,56 @@ void MiniballHistogrammer::MakeHists() {
 		htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only with random subtraction;";
 		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 		aE_vs_theta_1p_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(aE_vs_theta_1p_ejectile_dc_none);
+
 		hname = "aE_vs_theta_1p_ejectile_dc_ejectile";
 		htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 		aE_vs_theta_1p_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(aE_vs_theta_1p_ejectile_dc_ejectile);
+
 		hname = "aE_vs_theta_1p_ejectile_dc_recoil";
 		htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
 		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 		aE_vs_theta_1p_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(aE_vs_theta_1p_ejectile_dc_recoil);
+
 		hname = "aE_vs_theta_1p_recoil_dc_none";
 		htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only with random subtraction;";
 		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 		aE_vs_theta_1p_recoil_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(aE_vs_theta_1p_recoil_dc_none);
+
 		hname = "aE_vs_theta_1p_recoil_dc_ejectile";
 		htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 		aE_vs_theta_1p_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(aE_vs_theta_1p_recoil_dc_ejectile);
+
 		hname = "aE_vs_theta_1p_recoil_dc_recoil";
 		htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
 		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 		aE_vs_theta_1p_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(aE_vs_theta_1p_recoil_dc_recoil);
+
 		hname = "aE_vs_theta_2p_dc_none";
 		htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil with random subtraction;";
 		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 		aE_vs_theta_2p_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(aE_vs_theta_2p_dc_none);
+
 		hname = "aE_vs_theta_2p_dc_ejectile";
 		htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 		aE_vs_theta_2p_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(aE_vs_theta_2p_dc_ejectile);
+
 		hname = "aE_vs_theta_2p_dc_recoil";
 		htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
 		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
 		aE_vs_theta_2p_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(aE_vs_theta_2p_dc_recoil);
+
 	}
 	
 	// Per crystal Doppler-corrected spectra
@@ -1088,37 +1281,43 @@ void MiniballHistogrammer::MakeHists() {
 		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 		aE_vs_crystal_ejectile_dc_none = new TH2F( hname.data(), htitle.data(),
 					set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-		
+		histlist->Add(aE_vs_crystal_ejectile_dc_none);
+
 		hname = "aE_vs_crystal_ejectile_dc_ejectile";
 		htitle = "Gamma-ray energy with addback, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 		aE_vs_crystal_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), 
 													  set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-		
+		histlist->Add(aE_vs_crystal_ejectile_dc_ejectile);
+
 		hname = "aE_vs_crystal_ejectile_dc_recoil";
 		htitle = "Gamma-ray energy with addback, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
 		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 		aE_vs_crystal_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), 
 													set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-		
+		histlist->Add(aE_vs_crystal_ejectile_dc_recoil);
+
 		hname = "aE_vs_crystal_recoil_dc_none";
 		htitle = "Gamma-ray energy with addback, gated on the recoil with random subtraction;";
 		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 		aE_vs_crystal_recoil_dc_none = new TH2F( hname.data(), htitle.data(), 
 												set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-		
+		histlist->Add(aE_vs_crystal_recoil_dc_none);
+
 		hname = "aE_vs_crystal_recoil_dc_ejectile";
 		htitle = "Gamma-ray energy with addback, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 		aE_vs_crystal_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), 
 													set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-		
+		histlist->Add(aE_vs_crystal_recoil_dc_ejectile);
+
 		hname = "aE_vs_crystal_recoil_dc_recoil";
 		htitle = "Gamma-ray energy with addback, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
 		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 		aE_vs_crystal_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), 
 												  set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-		
+		histlist->Add(aE_vs_crystal_recoil_dc_recoil);
+
 		// 1p and 2p gamma-ray histograms
 		if( react->HistByMultiplicity() ){
 			
@@ -1127,55 +1326,64 @@ void MiniballHistogrammer::MakeHists() {
 			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 			aE_vs_crystal_1p_ejectile_dc_none = new TH2F( hname.data(), htitle.data(),
 													  set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-			
+			histlist->Add(aE_vs_crystal_1p_ejectile_dc_none);
+
 			hname = "aE_vs_crystal_1p_ejectile_dc_ejectile";
 			htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
 			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 			aE_vs_crystal_1p_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(),
 														  set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-			
+			histlist->Add(aE_vs_crystal_1p_ejectile_dc_ejectile);
+
 			hname = "aE_vs_crystal_1p_ejectile_dc_recoil";
 			htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
 			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 			aE_vs_crystal_1p_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(),
 														set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-			
+			histlist->Add(aE_vs_crystal_1p_ejectile_dc_recoil);
+
 			hname = "aE_vs_crystal_1p_recoil_dc_none";
 			htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only with random subtraction;";
 			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 			aE_vs_crystal_1p_recoil_dc_none = new TH2F( hname.data(), htitle.data(),
 													set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-			
+			histlist->Add(aE_vs_crystal_1p_recoil_dc_none);
+
 			hname = "aE_vs_crystal_1p_recoil_dc_ejectile";
 			htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
 			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 			aE_vs_crystal_1p_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(),
 														set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-			
+			histlist->Add(aE_vs_crystal_1p_recoil_dc_ejectile);
+
 			hname = "aE_vs_crystal_1p_recoil_dc_recoil";
 			htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
 			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 			aE_vs_crystal_1p_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(),
 													  set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-			
+			histlist->Add(aE_vs_crystal_1p_recoil_dc_recoil);
+
 			hname = "aE_vs_crystal_2p_dc_none";
 			htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil with random subtraction;";
 			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 			aE_vs_crystal_2p_dc_none = new TH2F( hname.data(), htitle.data(),
 												set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-			
+			histlist->Add(aE_vs_crystal_2p_dc_none);
+
 			hname = "aE_vs_crystal_2p_dc_ejectile";
 			htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
 			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 			aE_vs_crystal_2p_dc_ejectile = new TH2F( hname.data(), htitle.data(),
 													set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-			
+			histlist->Add(aE_vs_crystal_2p_dc_ejectile);
+
 			hname = "aE_vs_crystal_2p_dc_recoil";
 			htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
 			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
 			aE_vs_crystal_2p_dc_recoil = new TH2F( hname.data(), htitle.data(),
 												  set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-			
+			histlist->Add(aE_vs_crystal_2p_dc_recoil);
+
 		}
 		
 	} // by crystal
@@ -1187,31 +1395,37 @@ void MiniballHistogrammer::MakeHists() {
 		htitle = "Gamma-ray energy with addback, gated on the ejectile, with random subtraction;";
 		htitle += "T1 time [ns];Energy [keV];Counts per keV";
 		aE_ejectile_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(aE_ejectile_dc_none_t1);
+
 		hname = "aE_ejectile_dc_ejectile_t1";
 		htitle = "Gamma-ray energy with addback, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "T1 time [ns];Energy [keV];Counts per keV";
 		aE_ejectile_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(aE_ejectile_dc_ejectile_t1);
+
 		hname = "aE_ejectile_dc_recoil_t1";
 		htitle = "Gamma-ray energy with addback, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
 		htitle += "T1 time [ns];Energy [keV];Counts per keV";
 		aE_ejectile_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(aE_ejectile_dc_recoil_t1);
+
 		hname = "aE_recoil_dc_none_t1";
 		htitle = "Gamma-ray energy with addback, gated on the recoil, with random subtraction;";
 		htitle += "T1 time [ns];Energy [keV];Counts per keV";
 		aE_recoil_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(aE_recoil_dc_none_t1);
+
 		hname = "aE_recoil_dc_ejectile_t1";
 		htitle = "Gamma-ray energy with addback, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "T1 time [ns];Energy [keV];Counts per keV";
 		aE_recoil_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(aE_recoil_dc_ejectile_t1);
+
 		hname = "aE_recoil_dc_recoil_t1";
 		htitle = "Gamma-ray energy with addback, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
 		htitle += "T1 time [ns];Energy [keV];Counts per eV";
 		aE_recoil_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+		histlist->Add(aE_recoil_dc_recoil_t1);
 
 		// 1p and 2p gamma-ray histograms
 		if( react->HistByMultiplicity() ){
@@ -1220,47 +1434,56 @@ void MiniballHistogrammer::MakeHists() {
 			htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, with random subtraction;";
 			htitle += "T1 time [ns];Energy [keV];Counts per keV";
 			aE_1p_ejectile_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			
+			histlist->Add(aE_1p_ejectile_dc_none_t1);
+
 			hname = "aE_1p_ejectile_dc_ejectile_t1";
 			htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
 			htitle += "T1 time [ns];Energy [keV];Counts per keV";
 			aE_1p_ejectile_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			
+			histlist->Add(aE_1p_ejectile_dc_ejectile_t1);
+
 			hname = "aE_1p_ejectile_dc_recoil_t1";
 			htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
 			htitle += "T1 time [ns];Energy [keV];Counts per keV";
 			aE_1p_ejectile_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			
+			histlist->Add(aE_1p_ejectile_dc_recoil_t1);
+
 			hname = "aE_1p_recoil_dc_none_t1";
 			htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, with random subtraction;";
 			htitle += "T1 time [ns];Energy [keV];Counts per keV";
 			aE_1p_recoil_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			
+			histlist->Add(aE_1p_recoil_dc_none_t1);
+
 			hname = "aE_1p_recoil_dc_ejectile_t1";
 			htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
 			htitle += "T1 time [ns];Energy [keV];Counts per keV";
 			aE_1p_recoil_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			
+			histlist->Add(aE_1p_recoil_dc_ejectile_t1);
+
 			hname = "aE_1p_recoil_dc_recoil_t1";
 			htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
 			htitle += "T1 time [ns];Energy [keV];Counts per eV";
 			aE_1p_recoil_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			
+			histlist->Add(aE_1p_recoil_dc_recoil_t1);
+
 			hname = "aE_2p_dc_none_t1";
 			htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, with random subtraction;";
 			htitle += "Energy [keV];Counts per keV";
 			aE_2p_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			
+			histlist->Add(aE_2p_dc_none_t1);
+
 			hname = "aE_2p_dc_ejectile_t1";
 			htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
 			htitle += "Energy [keV];Counts per keV";
 			aE_2p_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			
+			histlist->Add(aE_2p_dc_ejectile_t1);
+
 			hname = "aE_2p_dc_recoil_t1";
 			htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
 			htitle += "Energy [keV];Counts per keV";
 			aE_2p_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			
+			histlist->Add(aE_2p_dc_recoil_t1);
+
 		}
 		
 	}
@@ -1272,32 +1495,38 @@ void MiniballHistogrammer::MakeHists() {
 		htitle = "Gamma-gamma matrix with addback, gated on the ejectile with random subtraction;";
 		htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
 		aaE_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(aaE_ejectile_dc_none);
+
 		hname = "aaE_ejectile_dc_ejectile";
 		htitle = "Gamma-gamma matrix with addback, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
 		aaE_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(aaE_ejectile_dc_ejectile);
+
 		hname = "aaE_ejectile_dc_recoil";
 		htitle = "Gamma-gamma matrix with addback, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
 		htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
 		aaE_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(aaE_ejectile_dc_recoil);
+
 		hname = "aaE_recoil_dc_none";
 		htitle = "Gamma-gamma matrix with addback, gated on the recoil with random subtraction;";
 		htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
 		aaE_recoil_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(aaE_recoil_dc_none);
+
 		hname = "aaE_recoil_dc_ejectile";
 		htitle = "Gamma-gamma matrix with addback, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
 		aaE_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(aaE_recoil_dc_ejectile);
+
 		hname = "aaE_recoil_dc_recoil";
 		htitle = "Gamma-gamma matrix with addback, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
 		htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
 		aaE_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(aaE_recoil_dc_recoil);
+
 	}
 	
 	// Segment phi determination
@@ -1321,13 +1550,15 @@ void MiniballHistogrammer::MakeHists() {
 			htitle = "Gamma-ray energy versus segment phi angle, Doppler corrected for the ejectile with random subtraction;";
 			htitle += "Phi angle of segment " + std::to_string(i) + ";Gamma-ray Energy [keV];Counts";
 			gE_vs_phi_dc_ejectile[i] = new TH2F( hname.data(), htitle.data(), 360, -0.5, 359.5, GBIN, GMIN, GMAX );
-			
+			histlist->Add(gE_vs_phi_dc_ejectile[i]);
+
 			hname = "gE_vs_phi_dc_recoil_seg";
 			hname += std::to_string(i);
 			htitle = "Gamma-ray energy versus segment phi angle, Doppler corrected for the recoil with random subtraction;";
 			htitle += "Phi angle of segment " + std::to_string(i) + ";Gamma-ray Energy [keV];Counts";
 			gE_vs_phi_dc_recoil[i] = new TH2F( hname.data(), htitle.data(), 360, -0.5, 359.5, GBIN, GMIN, GMAX );
-			
+			histlist->Add(gE_vs_phi_dc_recoil[i]);
+
 		}
 		
 	}
@@ -1342,57 +1573,69 @@ void MiniballHistogrammer::MakeHists() {
 		hname = "eE_prompt";
 		htitle = "Electron energy in prompt coincide with any particle;Energy [keV];Counts per keV";
 		eE_prompt = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
-		
+		histlist->Add(eE_prompt);
+
 		hname = "eE_prompt_1p";
 		htitle = "Electron energy in prompt coincide with just 1 particle;Energy [keV];Counts per keV";
 		eE_prompt_1p = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
-		
+		histlist->Add(eE_prompt_1p);
+
 		hname = "eE_prompt_2p";
 		htitle = "Electron energy in prompt coincide with 2 particles;Energy [keV];Counts per keV";
 		eE_prompt_2p = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
-		
+		histlist->Add(eE_prompt_2p);
+
 		hname = "eE_random";
 		htitle = "Electron energy in random coincide with any particle;Energy [keV];Counts per keV";
 		eE_random = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
-		
+		histlist->Add(eE_random);
+
 		hname = "eE_random_1p";
 		htitle = "Electron energy in random coincide with just 1 particle;Energy [keV];Counts per keV";
 		eE_random_1p = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
-		
+		histlist->Add(eE_random_1p);
+
 		hname = "eE_random_2p";
 		htitle = "Electron energy in random coincide with 2 particles;Energy [keV];Counts per keV";
 		eE_random_2p = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
-		
+		histlist->Add(eE_random_2p);
+
 		hname = "eE_ejectile_dc_none";
 		htitle = "Electron energy, gated on the ejectile with random subtraction;";
 		htitle += "Energy [keV];Counts per keV";
 		eE_ejectile_dc_none = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
-		
+		histlist->Add(eE_ejectile_dc_none);
+
 		hname = "eE_ejectile_dc_ejectile";
 		htitle = "Electron energy, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "Energy [keV];Counts per keV";
 		eE_ejectile_dc_ejectile = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
-		
+		histlist->Add(eE_ejectile_dc_ejectile);
+
 		hname = "eE_ejectile_dc_recoil";
 		htitle = "Electron energy, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
 		htitle += "Energy [keV];Counts per keV";
 		eE_ejectile_dc_recoil = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
-		
+		histlist->Add(eE_ejectile_dc_recoil);
+
 		hname = "eE_recoil_dc_none";
 		htitle = "Electron energy, gated on the recoil with random subtraction;";
 		htitle += "Energy [keV];Counts per keV";
 		eE_recoil_dc_none = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
-		
+		histlist->Add(eE_recoil_dc_none);
+
 		hname = "eE_recoil_dc_ejectile";
 		htitle = "Electron energy, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "Energy [keV];Counts per keV";
 		eE_recoil_dc_ejectile = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
-		
+		histlist->Add(eE_recoil_dc_ejectile);
+
 		hname = "eE_recoil_dc_recoil";
 		htitle = "Electron energy, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
 		htitle += "Energy [keV];Counts per keV";
 		eE_recoil_dc_recoil = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
-		
+		histlist->Add(eE_recoil_dc_recoil);
+
 		// 1p and 2p gamma-ray histograms
 		if( react->HistByMultiplicity() ){
 			
@@ -1400,79 +1643,94 @@ void MiniballHistogrammer::MakeHists() {
 			htitle = "Electron energy, gated on the ejectile, 1-particle only with random subtraction;";
 			htitle += "Energy [keV];Counts per keV";
 			eE_1p_ejectile_dc_none = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
-			
+			histlist->Add(eE_1p_ejectile_dc_none);
+
 			hname = "eE_1p_ejectile_dc_ejectile";
 			htitle = "Electron energy, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
 			htitle += "Energy [keV];Counts per keV";
 			eE_1p_ejectile_dc_ejectile = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
-			
+			histlist->Add(eE_1p_ejectile_dc_ejectile);
+
 			hname = "eE_1p_ejectile_dc_recoil";
 			htitle = "Electron energy, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
 			htitle += "Energy [keV];Counts per keV";
 			eE_1p_ejectile_dc_recoil = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
-			
+			histlist->Add(eE_1p_ejectile_dc_recoil);
+
 			hname = "eE_1p_recoil_dc_none";
 			htitle = "Electron energy, gated on the recoil, 1-particle only with random subtraction;";
 			htitle += "Energy [keV];Counts per keV";
 			eE_1p_recoil_dc_none = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
-			
+			histlist->Add(eE_1p_recoil_dc_none);
+
 			hname = "eE_1p_recoil_dc_ejectile";
 			htitle = "Electron energy, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
 			htitle += "Energy [keV];Counts per keV";
 			eE_1p_recoil_dc_ejectile = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
-			
+			histlist->Add(eE_1p_recoil_dc_ejectile);
+
 			hname = "eE_1p_recoil_dc_recoil";
 			htitle = "Electron energy, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
 			htitle += "Energy [keV];Counts per keV";
 			eE_1p_recoil_dc_recoil = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
-			
+			histlist->Add(eE_1p_recoil_dc_recoil);
+
 			hname = "eE_2p_dc_none";
 			htitle = "Electron energy, in coincidence with ejectile and recoil with random subtraction;";
 			htitle += "Energy [keV];Counts per keV";
 			eE_2p_dc_none = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
-			
+			histlist->Add(eE_2p_dc_none);
+
 			hname = "eE_2p_dc_ejectile";
 			htitle = "Electron energy, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
 			htitle += "Energy [keV];Counts per keV";
 			eE_2p_dc_ejectile = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
-			
+			histlist->Add(eE_2p_dc_ejectile);
+
 			hname = "eE_2p_dc_recoil";
 			htitle = "Electron energy, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
 			htitle += "Energy [keV];Counts per keV";
 			eE_2p_dc_recoil = new TH1F( hname.data(), htitle.data(), EBIN, EMIN, EMAX );
-			
+			histlist->Add(eE_2p_dc_recoil);
+
 		}
 
 		hname = "eE_vs_theta_ejectile_dc_none";
 		htitle = "Electron energy, gated on the ejectile with random subtraction;";
 		htitle += "Theta [deg];Energy [keV];Counts per keV per strip";
 		eE_vs_theta_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), EBIN, EMIN, EMAX );
-		
+		histlist->Add(eE_vs_theta_ejectile_dc_none);
+
 		hname = "eE_vs_theta_ejectile_dc_ejectile";
 		htitle = "Electron energy, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "Theta [deg];Energy [keV];Counts per keV per strip";
 		eE_vs_theta_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), EBIN, EMIN, EMAX );
-		
+		histlist->Add(eE_vs_theta_ejectile_dc_ejectile);
+
 		hname = "eE_vs_theta_ejectile_dc_recoil";
 		htitle = "Electron energy, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
 		htitle += "Theta [deg];Energy [keV];Counts per keV per strip";
 		eE_vs_theta_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), EBIN, EMIN, EMAX );
-		
+		histlist->Add(eE_vs_theta_ejectile_dc_recoil);
+
 		hname = "eE_vs_theta_recoil_dc_none";
 		htitle = "Electron energy, gated on the recoil with random subtraction;";
 		htitle += "Theta [deg];Energy [keV];Counts per keV per strip";
 		eE_vs_theta_recoil_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), EBIN, EMIN, EMAX );
-		
+		histlist->Add(eE_vs_theta_recoil_dc_none);
+
 		hname = "eE_vs_theta_recoil_dc_ejectile";
 		htitle = "Electron energy, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "Theta [deg];Energy [keV];Counts per keV per strip";
 		eE_vs_theta_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), EBIN, EMIN, EMAX );
-		
+		histlist->Add(eE_vs_theta_recoil_dc_ejectile);
+
 		hname = "eE_vs_theta_recoil_dc_recoil";
 		htitle = "Electron energy, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
 		htitle += "Theta [deg];Energy [keV];Counts per keV per strip";
 		eE_vs_theta_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), EBIN, EMIN, EMAX );
-		
+		histlist->Add(eE_vs_theta_recoil_dc_recoil);
+
 		// 1p and 2p gamma-ray histograms
 		if( react->HistByMultiplicity() ){
 			
@@ -1480,149 +1738,178 @@ void MiniballHistogrammer::MakeHists() {
 			htitle = "Electron energy, gated on the ejectile, 1-particle only with random subtraction;";
 			htitle += "Theta [deg];Energy [keV];Counts per keV per strip";
 			eE_vs_theta_1p_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), EBIN, EMIN, EMAX );
-			
+			histlist->Add(eE_vs_theta_1p_ejectile_dc_none);
+
 			hname = "eE_vs_theta_1p_ejectile_dc_ejectile";
 			htitle = "Electron energy, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
 			htitle += "Theta [deg];Energy [keV];Counts per keV per strip";
 			eE_vs_theta_1p_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), EBIN, EMIN, EMAX );
-			
+			histlist->Add(eE_vs_theta_1p_ejectile_dc_ejectile);
+
 			hname = "eE_vs_theta_1p_ejectile_dc_recoil";
 			htitle = "Electron energy, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
 			htitle += "Theta [deg];Energy [keV];Counts per keV per strip";
 			eE_vs_theta_1p_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), EBIN, EMIN, EMAX );
-			
+			histlist->Add(eE_vs_theta_1p_ejectile_dc_recoil);
+
 			hname = "eE_vs_theta_1p_recoil_dc_none";
 			htitle = "Electron energy, gated on the recoil, 1-particle only with random subtraction;";
 			htitle += "Theta [deg];Energy [keV];Counts per keV per strip";
 			eE_vs_theta_1p_recoil_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), EBIN, EMIN, EMAX );
-			
+			histlist->Add(eE_vs_theta_1p_recoil_dc_none);
+
 			hname = "eE_vs_theta_1p_recoil_dc_ejectile";
 			htitle = "Electron energy, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
 			htitle += "Theta [deg];Energy [keV];Counts per keV per strip";
 			eE_vs_theta_1p_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), EBIN, EMIN, EMAX );
-			
+			histlist->Add(eE_vs_theta_1p_recoil_dc_ejectile);
+
 			hname = "eE_vs_theta_1p_recoil_dc_recoil";
 			htitle = "Electron energy, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
 			htitle += "Theta [deg];Energy [keV];Counts per keV per strip";
 			eE_vs_theta_1p_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), EBIN, EMIN, EMAX );
-			
+			histlist->Add(eE_vs_theta_1p_recoil_dc_recoil);
+
 			hname = "eE_vs_theta_2p_dc_none";
 			htitle = "Electron energy, in coincidence with ejectile and recoil with random subtraction;";
 			htitle += "Theta [deg];Energy [keV];Counts per keV per strip";
 			eE_vs_theta_2p_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), EBIN, EMIN, EMAX );
-			
+			histlist->Add(eE_vs_theta_2p_dc_none);
+
 			hname = "eE_vs_theta_2p_dc_ejectile";
 			htitle = "Electron energy, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
 			htitle += "Theta [deg];Energy [keV];Counts per keV per strip";
 			eE_vs_theta_2p_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), EBIN, EMIN, EMAX );
-			
+			histlist->Add(eE_vs_theta_2p_dc_ejectile);
+
 			hname = "eE_vs_theta_2p_dc_recoil";
 			htitle = "Electron energy, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
 			htitle += "Theta [deg];Energy [keV];Counts per keV per strip";
 			eE_vs_theta_2p_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), EBIN, EMIN, EMAX );
-			
+			histlist->Add(eE_vs_theta_2p_dc_recoil);
+
 		}
 		
 		hname = "eE_costheta_ejectile";
 		htitle = "Electron energy versus cos(#theta) of angle between ejectile and electron;";
 		htitle += "Energy [keV];cos(#theta_pe)";
 		eE_costheta_ejectile = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, 100, -1.0, 1.0 );
-		
+		histlist->Add(eE_costheta_ejectile);
+
 		hname = "eE_costheta_recoil";
 		htitle = "Electron energy versus cos(#theta) of angle between recoil and electron;";
 		htitle += "Energy [keV];cos(#theta_pe)";
 		eE_costheta_recoil = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, 100, -1.0, 1.0 );
-		
+		histlist->Add(eE_costheta_recoil);
+
 		hname = "eE_vs_ejectile_dc_none_segment";
 		htitle = "Electron energy, gated on the ejectile with random subtraction;";
 		htitle += "Energy [keV];Ring;Counts per keV per segment";
 		eE_vs_ejectile_dc_none_segment = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, 24, -0.5, 23.5 );
-		
+		histlist->Add(eE_vs_ejectile_dc_none_segment);
+
 		hname = "eE_vs_ejectile_dc_ejectile_segment";
 		htitle = "Electron energy, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "Energy [keV];Ring;Counts per keV per ring";
 		eE_vs_ejectile_dc_ejectile_segment = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, 24, -0.5, 23.5 );
-		
+		histlist->Add(eE_vs_ejectile_dc_ejectile_segment);
+
 		hname = "eE_vs_ejectile_dc_recoil_segment";
 		htitle = "Electron energy, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
 		htitle += "Energy [keV];Ring;Counts per keV per ring";
 		eE_vs_ejectile_dc_recoil_segment = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, 24, -0.5, 23.5 );
-		
+		histlist->Add(eE_vs_ejectile_dc_recoil_segment);
+
 		hname = "eE_vs_recoil_dc_none_segment";
 		htitle = "Electron energy, gated on the recoil with random subtraction;";
 		htitle += "Energy [keV];Ring;Counts per keV per ring";
 		eE_vs_recoil_dc_none_segment = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, 24, -0.5, 23.5 );
-		
+		histlist->Add(eE_vs_recoil_dc_none_segment);
+
 		hname = "eE_vs_recoil_dc_ejectile_segment";
 		htitle = "Electron energy, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "Energy [keV];Ring;Counts per keV per ring";
 		eE_vs_recoil_dc_ejectile_segment = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, 24, -0.5, 23.5 );
-		
+		histlist->Add(eE_vs_recoil_dc_ejectile_segment);
+
 		hname = "eE_vs_recoil_dc_recoil_segment";
 		htitle = "Electron energy, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
 		htitle += "Energy [keV];Ring;Counts per keV per ring";
 		eE_vs_recoil_dc_recoil_segment = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, 24, -0.5, 23.5 );
-		
+		histlist->Add(eE_vs_recoil_dc_recoil_segment);
+
 		hname = "egE_ejectile_dc_none";
 		htitle = "Electron-gamma matrix without addback, gated on the ejectile with random subtraction;";
 		htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
 		egE_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(egE_ejectile_dc_none);
+
 		hname = "egE_ejectile_dc_ejectile";
 		htitle = "Electron-gamma matrix without addback, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
 		egE_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(egE_ejectile_dc_ejectile);
+
 		hname = "egE_ejectile_dc_recoil";
 		htitle = "Electron-gamma matrix without addback, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
 		htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
 		egE_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(egE_ejectile_dc_recoil);
+
 		hname = "egE_recoil_dc_none";
 		htitle = "Electron-gamma matrix without addback, gated on the recoil with random subtraction;";
 		htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
 		egE_recoil_dc_none = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(egE_recoil_dc_none);
+
 		hname = "egE_recoil_dc_ejectile";
 		htitle = "Electron-gamma matrix without addback, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
 		egE_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(egE_recoil_dc_ejectile);
+
 		hname = "egE_recoil_dc_recoil";
 		htitle = "Electron-gamma matrix without addback, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
 		htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
 		egE_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(egE_recoil_dc_recoil);
+
 		hname = "eaE_ejectile_dc_none";
 		htitle = "Electron-gamma matrix with addback, gated on the ejectile with random subtraction;";
 		htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
 		eaE_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(eaE_ejectile_dc_none);
+
 		hname = "eaE_ejectile_dc_ejectile";
 		htitle = "Electron-gamma matrix with addback, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
 		eaE_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(eaE_ejectile_dc_ejectile);
+
 		hname = "eaE_ejectile_dc_recoil";
 		htitle = "Electron-gamma matrix with addback, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
 		htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
 		eaE_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(eaE_ejectile_dc_recoil);
+
 		hname = "eaE_recoil_dc_none";
 		htitle = "Electron-gamma matrix with addback, gated on the recoil with random subtraction;";
 		htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
 		eaE_recoil_dc_none = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(eaE_recoil_dc_none);
+
 		hname = "eaE_recoil_dc_ejectile";
 		htitle = "Electron-gamma matrix with addback, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
 		htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
 		eaE_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(eaE_recoil_dc_ejectile);
+
 		hname = "eaE_recoil_dc_recoil";
 		htitle = "Electron-gamma matrix with addback, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
 		htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
 		eaE_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(eaE_recoil_dc_recoil);
+
 	} // electrons on
 
 	// Beam dump histograms
@@ -1635,16 +1922,19 @@ void MiniballHistogrammer::MakeHists() {
 		hname = "bdE_singles";
 		htitle = "Beam-dump gamma-ray energy singles;Energy [keV];Counts per 0.5 keV";
 		bdE_singles = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		
+		histlist->Add(bdE_singles);
+
 		hname = "bd_bd_td";
 		htitle = "Beam-dump - Beam-dump time difference;#Deltat [ns];Counts per 10 ns";
 		bd_bd_td = new TH1F( hname.data(), htitle.data(),
 							TBIN, TMIN, TMAX );
-		
+		histlist->Add(bd_bd_td);
+
 		hname = "bdE_bdE";
 		htitle = "Beam-dump gamma-ray coincidence matrix;Energy [keV];Energy [keV];Counts per 0.5 keV";
 		bdE_bdE = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
-		
+		histlist->Add(bdE_bdE);
+
 		bdE_singles_det.resize( set->GetNumberOfBeamDumpDetectors() );
 		for( unsigned int i = 0; i < set->GetNumberOfBeamDumpDetectors(); ++i ){
 			
@@ -1653,7 +1943,8 @@ void MiniballHistogrammer::MakeHists() {
 			htitle += std::to_string(i);
 			htitle += ";Energy [keV];Counts per 0.5 keV";
 			bdE_singles_det[i] = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-			
+			histlist->Add(bdE_singles_det[i]);
+
 		}
 		
 	} // beam dump on
@@ -1668,15 +1959,18 @@ void MiniballHistogrammer::MakeHists() {
 		hname = "ic_dE";
 		htitle = "Ionisation chamber;Energy loss in dE layers (Gas) (arb. units);Counts";
 		ic_dE = new TH1F( hname.data(), htitle.data(), 4096, 0, 10000 );
-		
+		histlist->Add(ic_dE);
+
 		hname = "ic_E";
 		htitle = "Ionisation chamber;Energy loss in rest of the layers (Si) (Gas) (arb. units);Counts";
 		ic_E = new TH1F( hname.data(), htitle.data(), 4096, 0, 10000 );
-		
+		histlist->Add(ic_E);
+
 		hname = "ic_dE_E";
 		htitle = "Ionisation chamber;Energy loss in dE layers (Gas) (arb. units);Energy loss in rest of the layers (Si) (arb. units);Counts";
 		ic_dE_E = new TH2F( hname.data(), htitle.data(), 4096, 0, 10000, 4096, 0, 10000 );
-		
+		histlist->Add(ic_dE_E);
+
 	} // ion-chamber on
 
 	return;
@@ -1689,8 +1983,8 @@ void MiniballHistogrammer::PlotDefaultHists() {
 	if( !hists_ready ) return;
 
 	// Make the canvas
-	c1 = std::make_unique<TCanvas>("c1","Monitor hists");
-	c1->Divide(2,2);
+	c1 = std::make_unique<TCanvas>("Diagnostics","Monitor hists");
+	c1->Divide(2,3);
 
 	// Plot things
 	c1->cd(1);
@@ -1702,6 +1996,12 @@ void MiniballHistogrammer::PlotDefaultHists() {
 	ebis_td_gamma->Draw("hist");
 	c1->cd(4);
 	ebis_td_particle->Draw("hist");
+	c1->cd(5);
+	c1->GetPad(5)->SetLogz();
+	gamma_theta_phi_map->Draw("colz");
+	c1->cd(6);
+	c1->GetPad(6)->SetLogz();
+	particle_xy_map_forward->Draw("colz");
 
 	return;
 
@@ -1738,7 +2038,7 @@ void MiniballHistogrammer::PlotPhysicsHists() {
 	else maxhists = spyhists.size();
 
 	// Make the canvas
-	c2 = std::make_unique<TCanvas>("c2","User hists");
+	c2 = std::make_unique<TCanvas>("Physics","User hists");
 	if( maxhists > 1 && spylayout[0] > 0 && spylayout[1] > 0 )
 		c2->Divide( spylayout[0], spylayout[1] );
 
@@ -1755,7 +2055,7 @@ void MiniballHistogrammer::PlotPhysicsHists() {
 		// Get this histogram of the right type
 		if( spyhists[i][1] == "TH1" || spyhists[i][1] == "TH1F" || spyhists[i][1] == "TH1D" ) {
 
-			ptr_th1 = (TH1F*)gDirectory->Get( spyhists[i][0].data() );
+			ptr_th1 = (TH1F*)output_file->Get( spyhists[i][0].data() );
 			if( ptr_th1 != nullptr )
 				ptr_th1->Draw( spyhists[i][2].data() );
 
@@ -1763,7 +2063,7 @@ void MiniballHistogrammer::PlotPhysicsHists() {
 
 		else if( spyhists[i][1] == "TH2" || spyhists[i][1] == "TH2F" || spyhists[i][1] == "TH2D" ) {
 
-			ptr_th2 = (TH2F*)gDirectory->Get( spyhists[i][0].data() );
+			ptr_th2 = (TH2F*)output_file->Get( spyhists[i][0].data() );
 			if( ptr_th2 != nullptr )
 				ptr_th2->Draw( spyhists[i][2].data() );
 
@@ -1779,50 +2079,18 @@ void MiniballHistogrammer::PlotPhysicsHists() {
 
 
 // Reset histograms in the DataSpy
-void MiniballHistogrammer::ResetHist( TObject *obj ) {
-
-	if( obj == nullptr ) return;
-
-	if( obj->InheritsFrom( "TH2" ) )
-		( (TH2*)obj )->Reset("ICESM");
-	else if( obj->InheritsFrom( "TH1" ) )
-		( (TH1*)obj )->Reset("ICESM");
-
-	return;
-
-}
-
-// Reset histograms in the DataSpy
 void MiniballHistogrammer::ResetHists(){
 
-	TKey *key1, *key2, *key3;
-	TIter keyList1( gDirectory->GetListOfKeys() );
-	while( ( key1 = (TKey*)keyList1() ) ){ // level 1
+	// Loop over the hist list
+	TIter next( histlist->MakeIterator() );
+	while( TObject *obj = next() ) {
 
-		if( key1->ReadObj()->InheritsFrom("TDirectory") ){
+		if( obj->InheritsFrom( "TH2" ) )
+			( (TH2*)obj )->Reset("ICESM");
+		else if( obj->InheritsFrom( "TH1" ) )
+			( (TH1*)obj )->Reset("ICESM");
 
-			TIter keyList2( ( (TDirectory*)key1->ReadObj() )->GetListOfKeys() );
-			while( ( key2 = (TKey*)keyList2() ) ){ // level 2
-
-				if( key2->ReadObj()->InheritsFrom("TDirectory") ){
-
-					TIter keyList3( ( (TDirectory*)key2->ReadObj() )->GetListOfKeys() );
-					while( ( key3 = (TKey*)keyList3() ) ) // level 3
-						ResetHist( key3->ReadObj() );
-
-				}
-
-				else
-					ResetHist( key2->ReadObj() );
-
-			} // level 2
-
-		}
-
-		else
-			ResetHist( key1->ReadObj() );
-
-	} // level 1
+	}
 
 	return;
 
@@ -2543,7 +2811,6 @@ unsigned long MiniballHistogrammer::FillHists() {
 	if( n_entries == 0 ){
 		
 		std::cout << " MiniballHistogrammer: Nothing to do..." << std::endl;
-		output_file->Write( nullptr, TObject::kOverwrite );
 		return n_entries;
 		
 	}
@@ -3268,9 +3535,6 @@ unsigned long MiniballHistogrammer::FillHists() {
 		
 	} // all events
 	
-	//output_file->Write( nullptr, TObject::kOverwrite );
-	//output_file->Purge(2);
-
 	return n_entries;
 	
 }

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -119,111 +119,115 @@ void MiniballHistogrammer::MakeHists() {
 	histlist->Add(particle_particle_td);
 
 	// Gamma-ray singles histograms
-	dirname = "GammaRaySingles";
-	output_file->mkdir( dirname.data() );
-	output_file->cd( dirname.data() );
+	if( react->HistWithoutAddback() ) {
 
-	hname = "gE_singles";
-	htitle = "Gamma-ray energy singles;Energy [keV];Counts per 0.5 keV";
-	gE_singles = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(gE_singles);
+		dirname = "GammaRaySingles";
+		output_file->mkdir( dirname.data() );
+		output_file->cd( dirname.data() );
 
-	if( react->HistByCrystal() ) {
+		hname = "gE_singles";
+		htitle = "Gamma-ray energy singles;Energy [keV];Counts per 0.5 keV";
+		gE_singles = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(gE_singles);
 
-		hname = "gE_singles_vs_crystal";
-		htitle = "Gamma-ray energy singles versus crystal ID;Crystal ID;Energy [keV];Counts per 0.5 keV";
-		gE_singles_vs_crystal = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-		histlist->Add(gE_singles_vs_crystal);
+		if( react->HistByCrystal() ) {
+
+			hname = "gE_singles_vs_crystal";
+			htitle = "Gamma-ray energy singles versus crystal ID;Crystal ID;Energy [keV];Counts per 0.5 keV";
+			gE_singles_vs_crystal = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
+			histlist->Add(gE_singles_vs_crystal);
+
+		}
+
+		hname = "gE_singles_ebis";
+		htitle = "Gamma-ray energy singles EBIS on-off;Energy [keV];Counts per 0.5 keV";
+		gE_singles_ebis = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(gE_singles_ebis);
+
+		hname = "gE_singles_ebis_on";
+		htitle = "Gamma-ray energy singles EBIS on;Energy [keV];Counts per 0.5 keV";
+		gE_singles_ebis_on = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(gE_singles_ebis_on);
+
+		hname = "gE_singles_ebis_off";
+		htitle = "Gamma-ray energy singles EBIS off;Energy [keV];Counts per 0.5 keV";
+		gE_singles_ebis_off = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(gE_singles_ebis_off);
+
+		hname = "gE_singles_dc";
+		htitle = "Gamma-ray energy singles, Doppler corrected for unscattered beam;Energy [keV];Counts per 0.5 keV";
+		gE_singles_dc = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(gE_singles_dc);
+
+		hname = "gE_singles_dc_ebis";
+		htitle = "Gamma-ray energy singles, Doppler corrected for unscattered beam, EBIS on-off;Energy [keV];Counts per 0.5 keV";
+		gE_singles_dc_ebis = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(gE_singles_dc_ebis);
+
+		hname = "aE_singles";
+		htitle = "Gamma-ray energy with addback singles;Energy [keV];Counts per 0.5 keV";
+		aE_singles = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(aE_singles);
+
+		if( react->HistByCrystal() ) {
+
+			hname = "aE_singles_vs_crystal";
+			htitle = "Gamma-ray energy with addback singles versus crystal ID;Crystal ID;Energy [keV];Counts per 0.5 keV";
+			aE_singles_vs_crystal = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
+			histlist->Add(aE_singles_vs_crystal);
+
+		}
+		hname = "aE_singles_ebis";
+		htitle = "Gamma-ray energy with addback singles EBIS on-off;Energy [keV];Counts per 0.5 keV";
+		aE_singles_ebis = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(aE_singles_ebis);
+
+		hname = "aE_singles_ebis_on";
+		htitle = "Gamma-ray energy with addback singles EBIS on;Energy [keV];Counts per 0.5 keV";
+		aE_singles_ebis_on = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(aE_singles_ebis_on);
+
+		hname = "aE_singles_ebis_off";
+		htitle = "Gamma-ray energy with addback singles EBIS off;Energy [keV];Counts per 0.5 keV";
+		aE_singles_ebis_off = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(aE_singles_ebis_off);
+
+		hname = "aE_singles_dc";
+		htitle = "Gamma-ray energy with addback singles, Doppler corrected for unscattered beam;Energy [keV];Counts per 0.5 keV";
+		aE_singles_dc = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(aE_singles_dc);
+
+		hname = "aE_singles_dc_ebis";
+		htitle = "Gamma-ray energy with addback singles, Doppler corrected for unscattered beam, EBIS on-off;Energy [keV];Counts per 0.5 keV";
+		aE_singles_dc_ebis = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(aE_singles_dc_ebis);
+
+		hname = "gamma_xy_map_forward";
+		htitle = "Gamma-ray X-Y hit map (forward: z > 0);y (horizontal) [mm];x (vertical) [mm];Counts";
+		gamma_xy_map_forward = new TH2F( hname.data(), htitle.data(), 201, -201., 201., 201, -201., 201. );
+		histlist->Add(gamma_xy_map_forward);
+
+		hname = "gamma_xy_map_backward";
+		htitle = "Gamma-ray X-Y hit map (backwards: z < 0);y (horizontal) [mm];x (vertical) [mm];Counts";
+		gamma_xy_map_backward = new TH2F( hname.data(), htitle.data(), 201, -201., 201., 201, -201., 201. );
+		histlist->Add(gamma_xy_map_backward);
+
+		hname = "gamma_xz_map_left";
+		htitle = "Gamma-ray X-Z hit map (left: y < 0);z (horizontal) [mm];x (vertical) [mm];Counts";
+		gamma_xz_map_left = new TH2F( hname.data(), htitle.data(), 201, -201., 201., 201, -201., 201. );
+		histlist->Add(gamma_xz_map_left);
+
+		hname = "gamma_xz_map_right";
+		htitle = "Gamma-ray X-Z hit map (right: y > 0);z (horizontal) [mm];x (vertical) [mm];Counts";
+		gamma_xz_map_right = new TH2F( hname.data(), htitle.data(), 201, -201., 201., 201, -201., 201. );
+		histlist->Add(gamma_xz_map_right);
+
+		hname = "gamma_theta_phi_map";
+		htitle = "Gamma-ray #theta-#phi hit map;#theta [degrees];#phi [degrees];Counts";
+		gamma_theta_phi_map = new TH2F( hname.data(), htitle.data(), 180, 0., 180., 360, 0., 360. );
+		histlist->Add(gamma_theta_phi_map);
 
 	}
-
-	hname = "gE_singles_ebis";
-	htitle = "Gamma-ray energy singles EBIS on-off;Energy [keV];Counts per 0.5 keV";
-	gE_singles_ebis = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(gE_singles_ebis);
-
-	hname = "gE_singles_ebis_on";
-	htitle = "Gamma-ray energy singles EBIS on;Energy [keV];Counts per 0.5 keV";
-	gE_singles_ebis_on = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(gE_singles_ebis_on);
-
-	hname = "gE_singles_ebis_off";
-	htitle = "Gamma-ray energy singles EBIS off;Energy [keV];Counts per 0.5 keV";
-	gE_singles_ebis_off = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(gE_singles_ebis_off);
-
-	hname = "gE_singles_dc";
-	htitle = "Gamma-ray energy singles, Doppler corrected for unscattered beam;Energy [keV];Counts per 0.5 keV";
-	gE_singles_dc = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(gE_singles_dc);
-
-	hname = "gE_singles_dc_ebis";
-	htitle = "Gamma-ray energy singles, Doppler corrected for unscattered beam, EBIS on-off;Energy [keV];Counts per 0.5 keV";
-	gE_singles_dc_ebis = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(gE_singles_dc_ebis);
-
-	hname = "aE_singles";
-	htitle = "Gamma-ray energy with addback singles;Energy [keV];Counts per 0.5 keV";
-	aE_singles = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(aE_singles);
-
-	if( react->HistByCrystal() ) {
-
-		hname = "aE_singles_vs_crystal";
-		htitle = "Gamma-ray energy with addback singles versus crystal ID;Crystal ID;Energy [keV];Counts per 0.5 keV";
-		aE_singles_vs_crystal = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-		histlist->Add(aE_singles_vs_crystal);
-
-	}
-	hname = "aE_singles_ebis";
-	htitle = "Gamma-ray energy with addback singles EBIS on-off;Energy [keV];Counts per 0.5 keV";
-	aE_singles_ebis = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(aE_singles_ebis);
-
-	hname = "aE_singles_ebis_on";
-	htitle = "Gamma-ray energy with addback singles EBIS on;Energy [keV];Counts per 0.5 keV";
-	aE_singles_ebis_on = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(aE_singles_ebis_on);
-
-	hname = "aE_singles_ebis_off";
-	htitle = "Gamma-ray energy with addback singles EBIS off;Energy [keV];Counts per 0.5 keV";
-	aE_singles_ebis_off = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(aE_singles_ebis_off);
-
-	hname = "aE_singles_dc";
-	htitle = "Gamma-ray energy with addback singles, Doppler corrected for unscattered beam;Energy [keV];Counts per 0.5 keV";
-	aE_singles_dc = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(aE_singles_dc);
-
-	hname = "aE_singles_dc_ebis";
-	htitle = "Gamma-ray energy with addback singles, Doppler corrected for unscattered beam, EBIS on-off;Energy [keV];Counts per 0.5 keV";
-	aE_singles_dc_ebis = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(aE_singles_dc_ebis);
-
-	hname = "gamma_xy_map_forward";
-	htitle = "Gamma-ray X-Y hit map (forward: z > 0);y (horizontal) [mm];x (vertical) [mm];Counts";
-	gamma_xy_map_forward = new TH2F( hname.data(), htitle.data(), 201, -201., 201., 201, -201., 201. );
-	histlist->Add(gamma_xy_map_forward);
-
-	hname = "gamma_xy_map_backward";
-	htitle = "Gamma-ray X-Y hit map (backwards: z < 0);y (horizontal) [mm];x (vertical) [mm];Counts";
-	gamma_xy_map_backward = new TH2F( hname.data(), htitle.data(), 201, -201., 201., 201, -201., 201. );
-	histlist->Add(gamma_xy_map_backward);
-
-	hname = "gamma_xz_map_left";
-	htitle = "Gamma-ray X-Z hit map (left: y < 0);z (horizontal) [mm];x (vertical) [mm];Counts";
-	gamma_xz_map_left = new TH2F( hname.data(), htitle.data(), 201, -201., 201., 201, -201., 201. );
-	histlist->Add(gamma_xz_map_left);
-
-	hname = "gamma_xz_map_right";
-	htitle = "Gamma-ray X-Z hit map (right: y > 0);z (horizontal) [mm];x (vertical) [mm];Counts";
-	gamma_xz_map_right = new TH2F( hname.data(), htitle.data(), 201, -201., 201., 201, -201., 201. );
-	histlist->Add(gamma_xz_map_right);
-
-	hname = "gamma_theta_phi_map";
-	htitle = "Gamma-ray #theta-#phi hit map;#theta [degrees];#phi [degrees];Counts";
-	gamma_theta_phi_map = new TH2F( hname.data(), htitle.data(), 180, 0., 180., 360, 0., 360. );
-	histlist->Add(gamma_theta_phi_map);
 
 	// Gamma-ray coincidence histograms
 	dirname = "CoincidenceMatrices";
@@ -233,25 +237,33 @@ void MiniballHistogrammer::MakeHists() {
 	// If gamma-gamma histograms are turned on
 	if( react->HistGammaGamma() ) {
 
-		hname = "gE_gE";
-		htitle = "Gamma-ray coincidence matrix;Energy [keV];Energy [keV];Counts per 0.5 keV";
-		gE_gE = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
-		histlist->Add(gE_gE);
+		if( react->HistWithoutAddback() ) {
 
-		hname = "gE_gE_ebis_on";
-		htitle = "Gamma-ray coincidence matrix EBIS on;Energy [keV];Energy [keV];Counts per 0.5 keV";
-		gE_gE_ebis_on = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
-		histlist->Add(gE_gE_ebis_on);
+			hname = "gE_gE";
+			htitle = "Gamma-ray coincidence matrix;Energy [keV];Energy [keV];Counts per 0.5 keV";
+			gE_gE = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
+			histlist->Add(gE_gE);
 
-		hname = "aE_aE";
-		htitle = "Gamma-ray addback coincidence matrix;Energy [keV];Energy [keV];Counts per 0.5 keV";
-		aE_aE = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
-		histlist->Add(aE_aE);
+			hname = "gE_gE_ebis_on";
+			htitle = "Gamma-ray coincidence matrix EBIS on;Energy [keV];Energy [keV];Counts per 0.5 keV";
+			gE_gE_ebis_on = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
+			histlist->Add(gE_gE_ebis_on);
 
-		hname = "aE_aE_ebis_on";
-		htitle = "Gamma-ray addback coincidence matrix EBIS on;Energy [keV];Energy [keV];Counts per 0.5 keV";
-		aE_aE_ebis_on = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
-		histlist->Add(aE_aE_ebis_on);
+		}
+
+		if( react->HistWithAddback() ) {
+
+			hname = "aE_aE";
+			htitle = "Gamma-ray addback coincidence matrix;Energy [keV];Energy [keV];Counts per 0.5 keV";
+			aE_aE = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
+			histlist->Add(aE_aE);
+
+			hname = "aE_aE_ebis_on";
+			htitle = "Gamma-ray addback coincidence matrix EBIS on;Energy [keV];Energy [keV];Counts per 0.5 keV";
+			aE_aE_ebis_on = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
+			histlist->Add(aE_aE_ebis_on);
+
+		}
 
 	} // gamma-gamma on
 
@@ -504,1034 +516,1043 @@ void MiniballHistogrammer::MakeHists() {
 	histlist->Add(particle_theta_phi_map);
 
 	// Gamma-particle coincidences without addback
-	dirname = "GammaRayParticleCoincidences";
-	output_file->mkdir( dirname.data() );
-	output_file->cd( dirname.data() );
-	
-	hname = "gE_prompt";
-	htitle = "Gamma-ray energy in prompt coincide with any particle;Energy [keV];Counts per 0.5 keV";
-	gE_prompt = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(gE_prompt);
+	if( react->HistWithoutAddback() ) {
 
-	hname = "gE_prompt_1p";
-	htitle = "Gamma-ray energy in prompt coincide with just 1 particle;Energy [keV];Counts per 0.5 keV";
-	gE_prompt_1p = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(gE_prompt_1p);
+		dirname = "GammaRayParticleCoincidences";
+		output_file->mkdir( dirname.data() );
+		output_file->cd( dirname.data() );
 
-	hname = "gE_prompt_2p";
-	htitle = "Gamma-ray energy in prompt coincide with 2 particles;Energy [keV];Counts per 0.5 keV";
-	gE_prompt_2p = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(gE_prompt_2p);
+		hname = "gE_prompt";
+		htitle = "Gamma-ray energy in prompt coincide with any particle;Energy [keV];Counts per 0.5 keV";
+		gE_prompt = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(gE_prompt);
 
-	hname = "gE_random";
-	htitle = "Gamma-ray energy in random coincide with any particle;Energy [keV];Counts per 0.5 keV";
-	gE_random = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(gE_random);
+		hname = "gE_prompt_1p";
+		htitle = "Gamma-ray energy in prompt coincide with just 1 particle;Energy [keV];Counts per 0.5 keV";
+		gE_prompt_1p = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(gE_prompt_1p);
 
-	hname = "gE_random_1p";
-	htitle = "Gamma-ray energy in random coincide with just 1 particle;Energy [keV];Counts per 0.5 keV";
-	gE_random_1p = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(gE_random_1p);
+		hname = "gE_prompt_2p";
+		htitle = "Gamma-ray energy in prompt coincide with 2 particles;Energy [keV];Counts per 0.5 keV";
+		gE_prompt_2p = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(gE_prompt_2p);
 
-	hname = "gE_random_2p";
-	htitle = "Gamma-ray energy in random coincide with 2 particles;Energy [keV];Counts per 0.5 keV";
-	gE_random_2p = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(gE_random_2p);
+		hname = "gE_random";
+		htitle = "Gamma-ray energy in random coincide with any particle;Energy [keV];Counts per 0.5 keV";
+		gE_random = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(gE_random);
 
-	hname = "gE_ejectile_dc_none";
-	htitle = "Gamma-ray energy, gated on the ejectile with random subtraction;";
-	htitle += "Energy [keV];Counts per 0.5 keV";
-	gE_ejectile_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(gE_ejectile_dc_none);
+		hname = "gE_random_1p";
+		htitle = "Gamma-ray energy in random coincide with just 1 particle;Energy [keV];Counts per 0.5 keV";
+		gE_random_1p = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(gE_random_1p);
 
-	hname = "gE_ejectile_dc_ejectile";
-	htitle = "Gamma-ray energy, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
-	htitle += "Energy [keV];Counts per 0.5 keV";
-	gE_ejectile_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(gE_ejectile_dc_ejectile);
+		hname = "gE_random_2p";
+		htitle = "Gamma-ray energy in random coincide with 2 particles;Energy [keV];Counts per 0.5 keV";
+		gE_random_2p = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(gE_random_2p);
 
-	hname = "gE_ejectile_dc_recoil";
-	htitle = "Gamma-ray energy, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
-	htitle += "Energy [keV];Counts per 0.5 keV";
-	gE_ejectile_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(gE_ejectile_dc_recoil);
-
-	hname = "gE_recoil_dc_none";
-	htitle = "Gamma-ray energy, gated on the recoil with random subtraction;";
-	htitle += "Energy [keV];Counts per 0.5 keV";
-	gE_recoil_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(gE_recoil_dc_none);
-
-	hname = "gE_recoil_dc_ejectile";
-	htitle = "Gamma-ray energy, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
-	htitle += "Energy [keV];Counts per 0.5 keV";
-	gE_recoil_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(gE_recoil_dc_ejectile);
-
-	hname = "gE_recoil_dc_recoil";
-	htitle = "Gamma-ray energy, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
-	htitle += "Energy [keV];Counts per 0.5 keV";
-	gE_recoil_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(gE_recoil_dc_recoil);
-
-	// 1p and 2p gamma-ray histograms
-	if( react->HistByMultiplicity() ){
-		
-		hname = "gE_1p_ejectile_dc_none";
-		htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only with random subtraction;";
-		htitle += "Energy [keV];Counts per 0.5 keV";
-		gE_1p_ejectile_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		histlist->Add(gE_1p_ejectile_dc_none);
-
-		hname = "gE_1p_ejectile_dc_ejectile";
-		htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "Energy [keV];Counts per 0.5 keV";
-		gE_1p_ejectile_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		histlist->Add(gE_1p_ejectile_dc_ejectile);
-
-		hname = "gE_1p_ejectile_dc_recoil";
-		htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
-		htitle += "Energy [keV];Counts per 0.5 keV";
-		gE_1p_ejectile_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		histlist->Add(gE_1p_ejectile_dc_recoil);
-
-		hname = "gE_1p_recoil_dc_none";
-		htitle = "Gamma-ray energy, gated on the recoil, 1-particle only with random subtraction;";
-		htitle += "Energy [keV];Counts per 0.5 keV";
-		gE_1p_recoil_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		histlist->Add(gE_1p_recoil_dc_none);
-
-		hname = "gE_1p_recoil_dc_ejectile";
-		htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "Energy [keV];Counts per 0.5 keV";
-		gE_1p_recoil_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		histlist->Add(gE_1p_recoil_dc_ejectile);
-
-		hname = "gE_1p_recoil_dc_recoil";
-		htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
-		htitle += "Energy [keV];Counts per 0.5 keV";
-		gE_1p_recoil_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		histlist->Add(gE_1p_recoil_dc_recoil);
-
-		hname = "gE_2p_dc_none";
-		htitle = "Gamma-ray energy, in coincidence with ejectile and recoil with random subtraction;";
-		htitle += "Energy [keV];Counts per 0.5 keV";
-		gE_2p_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		histlist->Add(gE_2p_dc_none);
-
-		hname = "gE_2p_dc_ejectile";
-		htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "Energy [keV];Counts per 0.5 keV";
-		gE_2p_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		histlist->Add(gE_2p_dc_ejectile);
-
-		hname = "gE_2p_dc_recoil";
-		htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
-		htitle += "Energy [keV];Counts per 0.5 keV";
-		gE_2p_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		histlist->Add(gE_2p_dc_recoil);
-
-	}
-	
-	hname = "gE_vs_costheta_ejectile_dc_none";
-	htitle = "Gamma-ray energy versus cos(#theta) of angle between ejectile and gamma-ray, gated on the ejectile;Energy [keV];cos(#theta_p#gamma)";
-	gE_vs_costheta_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
-	histlist->Add(gE_vs_costheta_ejectile_dc_none);
-
-	hname = "gE_vs_costheta2_ejectile_dc_none";
-	htitle = "Gamma-ray energy versus cos(#theta) of angle between recoil and gamma-ray, gated on the ejectile;Energy [keV];cos(#theta_p#gamma)";
-	gE_vs_costheta2_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
-	histlist->Add(gE_vs_costheta2_ejectile_dc_none);
-
-	hname = "gE_vs_costheta_ejectile_dc_ejectile";
-	htitle = "Gamma-ray energy versus cos(#theta) of angle between ejectile and gamma-ray, gated on the ejectile, Doppler corrected for the ejectile;Energy [keV];cos(#theta_p#gamma)";
-	gE_vs_costheta_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
-	histlist->Add(gE_vs_costheta_ejectile_dc_ejectile);
-
-	hname = "gE_vs_costheta_ejectile_dc_recoil";
-	htitle = "Gamma-ray energy versus cos(#theta) of angle between recoil and gamma-ray, gated on the ejectile, Doppler corrected for the recoil;Energy [keV];cos(#theta_p#gamma)";
-	gE_vs_costheta_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
-	histlist->Add(gE_vs_costheta_ejectile_dc_recoil);
-
-	hname = "gE_vs_costheta_recoil_dc_none";
-	htitle = "Gamma-ray energy versus cos(#theta) of angle between recoil and gamma-ray, gated on the recoil, no Doppler correction;Energy [keV];cos(#theta_p#gamma)";
-	gE_vs_costheta_recoil_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
-	histlist->Add(gE_vs_costheta_recoil_dc_none);
-
-	hname = "gE_vs_costheta2_recoil_dc_none";
-	htitle = "Gamma-ray energy versus cos(#theta) of angle between ejectile and gamma-ray, gated on the recoil, no Doppler correction;Energy [keV];cos(#theta_p#gamma)";
-	gE_vs_costheta2_recoil_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
-	histlist->Add(gE_vs_costheta2_recoil_dc_none);
-
-	hname = "gE_vs_costheta_recoil_dc_ejectile";
-	htitle = "Gamma-ray energy versus cos(#theta) of angle between ejectile and gamma-ray, gated on the recoil, Doppler corrected for the ejectile;Energy [keV];cos(#theta_p#gamma)";
-	gE_vs_costheta_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
-	histlist->Add(gE_vs_costheta_recoil_dc_ejectile);
-
-	hname = "gE_vs_costheta_recoil_dc_recoil";
-	htitle = "Gamma-ray energy versus cos(#theta) of angle between recoil and gamma-ray, gated on the recoil, Doppler corrected for the recoil;Energy [keV];cos(#theta_p#gamma)";
-	gE_vs_costheta_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
-	histlist->Add(gE_vs_costheta_recoil_dc_recoil);
-
-	hname = "gE_vs_theta_ejectile_dc_none";
-	htitle = "Gamma-ray energy, gated on the ejectile with random subtraction;";
-	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-	gE_vs_theta_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-	histlist->Add(gE_vs_theta_ejectile_dc_none);
-
-	hname = "gE_vs_theta_ejectile_dc_ejectile";
-	htitle = "Gamma-ray energy, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
-	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-	gE_vs_theta_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-	histlist->Add(gE_vs_theta_ejectile_dc_ejectile);
-
-	hname = "gE_vs_theta_ejectile_dc_recoil";
-	htitle = "Gamma-ray energy, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
-	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-	gE_vs_theta_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-	histlist->Add(gE_vs_theta_ejectile_dc_recoil);
-
-	hname = "gE_vs_theta_recoil_dc_none";
-	htitle = "Gamma-ray energy, gated on the recoil with random subtraction;";
-	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-	gE_vs_theta_recoil_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-	histlist->Add(gE_vs_theta_recoil_dc_none);
-
-	hname = "gE_vs_theta_recoil_dc_ejectile";
-	htitle = "Gamma-ray energy, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
-	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-	gE_vs_theta_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-	histlist->Add(gE_vs_theta_recoil_dc_ejectile);
-
-	hname = "gE_vs_theta_recoil_dc_recoil";
-	htitle = "Gamma-ray energy, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
-	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-	gE_vs_theta_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-	histlist->Add(gE_vs_theta_recoil_dc_recoil);
-
-	// 1p and 2p gamma-ray histograms
-	if( react->HistByMultiplicity() ){
-		
-		hname = "gE_vs_theta_1p_ejectile_dc_none";
-		htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only with random subtraction;";
-		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-		gE_vs_theta_1p_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		histlist->Add(gE_vs_theta_1p_ejectile_dc_none);
-
-		hname = "gE_vs_theta_1p_ejectile_dc_ejectile";
-		htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-		gE_vs_theta_1p_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		histlist->Add(gE_vs_theta_1p_ejectile_dc_ejectile);
-
-		hname = "gE_vs_theta_1p_ejectile_dc_recoil";
-		htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
-		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-		gE_vs_theta_1p_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		histlist->Add(gE_vs_theta_1p_ejectile_dc_recoil);
-
-		hname = "gE_vs_theta_1p_recoil_dc_none";
-		htitle = "Gamma-ray energy, gated on the recoil, 1-particle only with random subtraction;";
-		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-		gE_vs_theta_1p_recoil_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		histlist->Add(gE_vs_theta_1p_recoil_dc_none);
-
-		hname = "gE_vs_theta_1p_recoil_dc_ejectile";
-		htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-		gE_vs_theta_1p_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		histlist->Add(gE_vs_theta_1p_recoil_dc_ejectile);
-
-		hname = "gE_vs_theta_1p_recoil_dc_recoil";
-		htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
-		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-		gE_vs_theta_1p_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		histlist->Add(gE_vs_theta_1p_recoil_dc_recoil);
-
-		hname = "gE_vs_theta_2p_dc_none";
-		htitle = "Gamma-ray energy, in coincidence with ejectile and recoil with random subtraction;";
-		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-		gE_vs_theta_2p_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		histlist->Add(gE_vs_theta_2p_dc_none);
-
-		hname = "gE_vs_theta_2p_dc_ejectile";
-		htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-		gE_vs_theta_2p_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		histlist->Add(gE_vs_theta_2p_dc_ejectile);
-
-		hname = "gE_vs_theta_2p_dc_recoil";
-		htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
-		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-		gE_vs_theta_2p_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		histlist->Add(gE_vs_theta_2p_dc_recoil);
-
-	}
-
-	// Per crystal Doppler-corrected spectra
-	if( react->HistByCrystal() ) {
-		
-		hname = "gE_vs_crystal_ejectile_dc_none";
+		hname = "gE_ejectile_dc_none";
 		htitle = "Gamma-ray energy, gated on the ejectile with random subtraction;";
-		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-		gE_vs_crystal_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-		histlist->Add(gE_vs_crystal_ejectile_dc_none);
+		htitle += "Energy [keV];Counts per 0.5 keV";
+		gE_ejectile_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(gE_ejectile_dc_none);
 
-		hname = "gE_vs_crystal_ejectile_dc_ejectile";
+		hname = "gE_ejectile_dc_ejectile";
 		htitle = "Gamma-ray energy, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-		gE_vs_crystal_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-		histlist->Add(gE_vs_crystal_ejectile_dc_ejectile);
+		htitle += "Energy [keV];Counts per 0.5 keV";
+		gE_ejectile_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(gE_ejectile_dc_ejectile);
 
-		hname = "gE_vs_crystal_ejectile_dc_recoil";
+		hname = "gE_ejectile_dc_recoil";
 		htitle = "Gamma-ray energy, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
-		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-		gE_vs_crystal_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-		histlist->Add(gE_vs_crystal_ejectile_dc_recoil);
+		htitle += "Energy [keV];Counts per 0.5 keV";
+		gE_ejectile_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(gE_ejectile_dc_recoil);
 
-		hname = "gE_vs_crystal_recoil_dc_none";
+		hname = "gE_recoil_dc_none";
 		htitle = "Gamma-ray energy, gated on the recoil with random subtraction;";
-		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-		gE_vs_crystal_recoil_dc_none = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-		histlist->Add(gE_vs_crystal_recoil_dc_none);
+		htitle += "Energy [keV];Counts per 0.5 keV";
+		gE_recoil_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(gE_recoil_dc_none);
 
-		hname = "gE_vs_crystal_recoil_dc_ejectile";
+		hname = "gE_recoil_dc_ejectile";
 		htitle = "Gamma-ray energy, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-		gE_vs_crystal_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-		histlist->Add(gE_vs_crystal_recoil_dc_ejectile);
+		htitle += "Energy [keV];Counts per 0.5 keV";
+		gE_recoil_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(gE_recoil_dc_ejectile);
 
-		hname = "gE_vs_crystal_recoil_dc_recoil";
+		hname = "gE_recoil_dc_recoil";
 		htitle = "Gamma-ray energy, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
-		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-		gE_vs_crystal_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-		histlist->Add(gE_vs_crystal_recoil_dc_recoil);
+		htitle += "Energy [keV];Counts per 0.5 keV";
+		gE_recoil_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(gE_recoil_dc_recoil);
 
 		// 1p and 2p gamma-ray histograms
 		if( react->HistByMultiplicity() ){
-			
-			hname = "gE_vs_crystal_1p_ejectile_dc_none";
+
+			hname = "gE_1p_ejectile_dc_none";
 			htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only with random subtraction;";
-			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-			gE_vs_crystal_1p_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-			histlist->Add(gE_vs_crystal_1p_ejectile_dc_none);
+			htitle += "Energy [keV];Counts per 0.5 keV";
+			gE_1p_ejectile_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+			histlist->Add(gE_1p_ejectile_dc_none);
 
-			hname = "gE_vs_crystal_1p_ejectile_dc_ejectile";
+			hname = "gE_1p_ejectile_dc_ejectile";
 			htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
-			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-			gE_vs_crystal_1p_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-			histlist->Add(gE_vs_crystal_1p_ejectile_dc_ejectile);
+			htitle += "Energy [keV];Counts per 0.5 keV";
+			gE_1p_ejectile_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+			histlist->Add(gE_1p_ejectile_dc_ejectile);
 
-			hname = "gE_vs_crystal_1p_ejectile_dc_recoil";
+			hname = "gE_1p_ejectile_dc_recoil";
 			htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
-			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-			gE_vs_crystal_1p_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-			histlist->Add(gE_vs_crystal_1p_ejectile_dc_recoil);
+			htitle += "Energy [keV];Counts per 0.5 keV";
+			gE_1p_ejectile_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+			histlist->Add(gE_1p_ejectile_dc_recoil);
 
-			hname = "gE_vs_crystal_1p_recoil_dc_none";
+			hname = "gE_1p_recoil_dc_none";
 			htitle = "Gamma-ray energy, gated on the recoil, 1-particle only with random subtraction;";
-			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-			gE_vs_crystal_1p_recoil_dc_none = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-			histlist->Add(gE_vs_crystal_1p_recoil_dc_none);
+			htitle += "Energy [keV];Counts per 0.5 keV";
+			gE_1p_recoil_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+			histlist->Add(gE_1p_recoil_dc_none);
 
-			hname = "gE_vs_crystal_1p_recoil_dc_ejectile";
+			hname = "gE_1p_recoil_dc_ejectile";
 			htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
-			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-			gE_vs_crystal_1p_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-			histlist->Add(gE_vs_crystal_1p_recoil_dc_ejectile);
+			htitle += "Energy [keV];Counts per 0.5 keV";
+			gE_1p_recoil_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+			histlist->Add(gE_1p_recoil_dc_ejectile);
 
-			hname = "gE_vs_crystal_1p_recoil_dc_recoil";
+			hname = "gE_1p_recoil_dc_recoil";
 			htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
-			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-			gE_vs_crystal_1p_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-			histlist->Add(gE_vs_crystal_1p_recoil_dc_recoil);
+			htitle += "Energy [keV];Counts per 0.5 keV";
+			gE_1p_recoil_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+			histlist->Add(gE_1p_recoil_dc_recoil);
 
-			hname = "gE_vs_crystal_2p_dc_none";
+			hname = "gE_2p_dc_none";
 			htitle = "Gamma-ray energy, in coincidence with ejectile and recoil with random subtraction;";
-			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-			gE_vs_crystal_2p_dc_none = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-			histlist->Add(gE_vs_crystal_2p_dc_none);
+			htitle += "Energy [keV];Counts per 0.5 keV";
+			gE_2p_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+			histlist->Add(gE_2p_dc_none);
 
-			hname = "gE_vs_crystal_2p_dc_ejectile";
+			hname = "gE_2p_dc_ejectile";
 			htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
-			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-			gE_vs_crystal_2p_dc_ejectile = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-			histlist->Add(gE_vs_crystal_2p_dc_ejectile);
+			htitle += "Energy [keV];Counts per 0.5 keV";
+			gE_2p_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+			histlist->Add(gE_2p_dc_ejectile);
 
-			hname = "gE_vs_crystal_2p_dc_recoil";
+			hname = "gE_2p_dc_recoil";
 			htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
-			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-			gE_vs_crystal_2p_dc_recoil = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-			histlist->Add(gE_vs_crystal_2p_dc_recoil);
+			htitle += "Energy [keV];Counts per 0.5 keV";
+			gE_2p_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+			histlist->Add(gE_2p_dc_recoil);
 
 		}
-		
-	} // by crystal
-	
-	// T1 impact time
-	if( react->HistByT1() ) {
-		
-		hname = "gE_ejectile_dc_none_t1";
-		htitle = "Gamma-ray energy, gated on the ejectile, with random subtraction;";
-		htitle += "T1 time [ns];Energy [keV];Counts per keV";
-		gE_ejectile_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-		histlist->Add(gE_ejectile_dc_none_t1);
 
-		hname = "gE_ejectile_dc_ejectile_t1";
+		hname = "gE_vs_costheta_ejectile_dc_none";
+		htitle = "Gamma-ray energy versus cos(#theta) of angle between ejectile and gamma-ray, gated on the ejectile;Energy [keV];cos(#theta_p#gamma)";
+		gE_vs_costheta_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+		histlist->Add(gE_vs_costheta_ejectile_dc_none);
+
+		hname = "gE_vs_costheta2_ejectile_dc_none";
+		htitle = "Gamma-ray energy versus cos(#theta) of angle between recoil and gamma-ray, gated on the ejectile;Energy [keV];cos(#theta_p#gamma)";
+		gE_vs_costheta2_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+		histlist->Add(gE_vs_costheta2_ejectile_dc_none);
+
+		hname = "gE_vs_costheta_ejectile_dc_ejectile";
+		htitle = "Gamma-ray energy versus cos(#theta) of angle between ejectile and gamma-ray, gated on the ejectile, Doppler corrected for the ejectile;Energy [keV];cos(#theta_p#gamma)";
+		gE_vs_costheta_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+		histlist->Add(gE_vs_costheta_ejectile_dc_ejectile);
+
+		hname = "gE_vs_costheta_ejectile_dc_recoil";
+		htitle = "Gamma-ray energy versus cos(#theta) of angle between recoil and gamma-ray, gated on the ejectile, Doppler corrected for the recoil;Energy [keV];cos(#theta_p#gamma)";
+		gE_vs_costheta_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+		histlist->Add(gE_vs_costheta_ejectile_dc_recoil);
+
+		hname = "gE_vs_costheta_recoil_dc_none";
+		htitle = "Gamma-ray energy versus cos(#theta) of angle between recoil and gamma-ray, gated on the recoil, no Doppler correction;Energy [keV];cos(#theta_p#gamma)";
+		gE_vs_costheta_recoil_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+		histlist->Add(gE_vs_costheta_recoil_dc_none);
+
+		hname = "gE_vs_costheta2_recoil_dc_none";
+		htitle = "Gamma-ray energy versus cos(#theta) of angle between ejectile and gamma-ray, gated on the recoil, no Doppler correction;Energy [keV];cos(#theta_p#gamma)";
+		gE_vs_costheta2_recoil_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+		histlist->Add(gE_vs_costheta2_recoil_dc_none);
+
+		hname = "gE_vs_costheta_recoil_dc_ejectile";
+		htitle = "Gamma-ray energy versus cos(#theta) of angle between ejectile and gamma-ray, gated on the recoil, Doppler corrected for the ejectile;Energy [keV];cos(#theta_p#gamma)";
+		gE_vs_costheta_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+		histlist->Add(gE_vs_costheta_recoil_dc_ejectile);
+
+		hname = "gE_vs_costheta_recoil_dc_recoil";
+		htitle = "Gamma-ray energy versus cos(#theta) of angle between recoil and gamma-ray, gated on the recoil, Doppler corrected for the recoil;Energy [keV];cos(#theta_p#gamma)";
+		gE_vs_costheta_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+		histlist->Add(gE_vs_costheta_recoil_dc_recoil);
+
+		hname = "gE_vs_theta_ejectile_dc_none";
+		htitle = "Gamma-ray energy, gated on the ejectile with random subtraction;";
+		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+		gE_vs_theta_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+		histlist->Add(gE_vs_theta_ejectile_dc_none);
+
+		hname = "gE_vs_theta_ejectile_dc_ejectile";
 		htitle = "Gamma-ray energy, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "T1 time [ns];Energy [keV];Counts per keV";
-		gE_ejectile_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-		histlist->Add(gE_ejectile_dc_ejectile_t1);
+		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+		gE_vs_theta_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+		histlist->Add(gE_vs_theta_ejectile_dc_ejectile);
 
-		hname = "gE_ejectile_dc_recoil_t1";
+		hname = "gE_vs_theta_ejectile_dc_recoil";
 		htitle = "Gamma-ray energy, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
-		htitle += "T1 time [ns];Energy [keV];Counts per keV";
-		gE_ejectile_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-		histlist->Add(gE_ejectile_dc_recoil_t1);
+		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+		gE_vs_theta_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+		histlist->Add(gE_vs_theta_ejectile_dc_recoil);
 
-		hname = "gE_recoil_dc_none_t1";
-		htitle = "Gamma-ray energy, gated on the recoil, with random subtraction;";
-		htitle += "T1 time [ns];Energy [keV];Counts per keV";
-		gE_recoil_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-		histlist->Add(gE_recoil_dc_none_t1);
+		hname = "gE_vs_theta_recoil_dc_none";
+		htitle = "Gamma-ray energy, gated on the recoil with random subtraction;";
+		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+		gE_vs_theta_recoil_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+		histlist->Add(gE_vs_theta_recoil_dc_none);
 
-		hname = "gE_recoil_dc_ejectile_t1";
+		hname = "gE_vs_theta_recoil_dc_ejectile";
 		htitle = "Gamma-ray energy, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "T1 time [ns];Energy [keV];Counts per keV";
-		gE_recoil_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-		histlist->Add(gE_recoil_dc_ejectile_t1);
+		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+		gE_vs_theta_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+		histlist->Add(gE_vs_theta_recoil_dc_ejectile);
 
-		hname = "gE_recoil_dc_recoil_t1";
+		hname = "gE_vs_theta_recoil_dc_recoil";
 		htitle = "Gamma-ray energy, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
-		htitle += "T1 time [ns];Energy [keV];Counts per eV";
-		gE_recoil_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-		histlist->Add(gE_recoil_dc_recoil_t1);
+		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+		gE_vs_theta_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+		histlist->Add(gE_vs_theta_recoil_dc_recoil);
 
 		// 1p and 2p gamma-ray histograms
 		if( react->HistByMultiplicity() ){
-			
-			hname = "gE_1p_ejectile_dc_none_t1";
-			htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, with random subtraction;";
-			htitle += "T1 time [ns];Energy [keV];Counts per keV";
-			gE_1p_ejectile_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			histlist->Add(gE_1p_ejectile_dc_none_t1);
 
-			hname = "gE_1p_ejectile_dc_ejectile_t1";
+			hname = "gE_vs_theta_1p_ejectile_dc_none";
+			htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only with random subtraction;";
+			htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+			gE_vs_theta_1p_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+			histlist->Add(gE_vs_theta_1p_ejectile_dc_none);
+
+			hname = "gE_vs_theta_1p_ejectile_dc_ejectile";
 			htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
-			htitle += "T1 time [ns];Energy [keV];Counts per keV";
-			gE_1p_ejectile_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			histlist->Add(gE_1p_ejectile_dc_ejectile_t1);
+			htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+			gE_vs_theta_1p_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+			histlist->Add(gE_vs_theta_1p_ejectile_dc_ejectile);
 
-			hname = "gE_1p_ejectile_dc_recoil_t1";
+			hname = "gE_vs_theta_1p_ejectile_dc_recoil";
 			htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
-			htitle += "T1 time [ns];Energy [keV];Counts per keV";
-			gE_1p_ejectile_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			histlist->Add(gE_1p_ejectile_dc_recoil_t1);
+			htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+			gE_vs_theta_1p_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+			histlist->Add(gE_vs_theta_1p_ejectile_dc_recoil);
 
-			hname = "gE_1p_recoil_dc_none_t1";
-			htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, with random subtraction;";
-			htitle += "T1 time [ns];Energy [keV];Counts per keV";
-			gE_1p_recoil_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			histlist->Add(gE_1p_recoil_dc_none_t1);
+			hname = "gE_vs_theta_1p_recoil_dc_none";
+			htitle = "Gamma-ray energy, gated on the recoil, 1-particle only with random subtraction;";
+			htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+			gE_vs_theta_1p_recoil_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+			histlist->Add(gE_vs_theta_1p_recoil_dc_none);
 
-			hname = "gE_1p_recoil_dc_ejectile_t1";
+			hname = "gE_vs_theta_1p_recoil_dc_ejectile";
 			htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
-			htitle += "T1 time [ns];Energy [keV];Counts per keV";
-			gE_1p_recoil_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			histlist->Add(gE_1p_recoil_dc_ejectile_t1);
+			htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+			gE_vs_theta_1p_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+			histlist->Add(gE_vs_theta_1p_recoil_dc_ejectile);
 
-			hname = "gE_1p_recoil_dc_recoil_t1";
+			hname = "gE_vs_theta_1p_recoil_dc_recoil";
 			htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
-			htitle += "T1 time [ns];Energy [keV];Counts per eV";
-			gE_1p_recoil_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			histlist->Add(gE_1p_recoil_dc_recoil_t1);
+			htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+			gE_vs_theta_1p_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+			histlist->Add(gE_vs_theta_1p_recoil_dc_recoil);
 
-			hname = "gE_2p_dc_none_t1";
-			htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil with random subtraction;";
-			htitle += "Energy [keV];Counts per keV";
-			gE_2p_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			histlist->Add(gE_2p_dc_none_t1);
+			hname = "gE_vs_theta_2p_dc_none";
+			htitle = "Gamma-ray energy, in coincidence with ejectile and recoil with random subtraction;";
+			htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+			gE_vs_theta_2p_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+			histlist->Add(gE_vs_theta_2p_dc_none);
 
-			hname = "gE_2p_dc_ejectile_t1";
-			htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
-			htitle += "Energy [keV];Counts per keV";
-			gE_2p_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			histlist->Add(gE_2p_dc_ejectile_t1);
+			hname = "gE_vs_theta_2p_dc_ejectile";
+			htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+			gE_vs_theta_2p_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+			histlist->Add(gE_vs_theta_2p_dc_ejectile);
 
-			hname = "gE_2p_dc_recoil_t1";
+			hname = "gE_vs_theta_2p_dc_recoil";
 			htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
-			htitle += "Energy [keV];Counts per keV";
-			gE_2p_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			histlist->Add(gE_2p_dc_recoil_t1);
+			htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+			gE_vs_theta_2p_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+			histlist->Add(gE_vs_theta_2p_dc_recoil);
 
 		}
-		
-	}
-	// Gamma-gamma hists
-	if( react->HistGammaGamma() ) {
-		
-		hname = "ggE_ejectile_dc_none";
-		htitle = "Gamma-gamma matrix, gated on the ejectile with random subtraction;";
-		htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
-		ggE_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
-		histlist->Add(ggE_ejectile_dc_none);
 
-		hname = "ggE_ejectile_dc_ejectile";
-		htitle = "Gamma-gamma matrix, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
-		ggE_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
-		histlist->Add(ggE_ejectile_dc_ejectile);
+		// Per crystal Doppler-corrected spectra
+		if( react->HistByCrystal() ) {
 
-		hname = "ggE_ejectile_dc_recoil";
-		htitle = "Gamma-gamma matrix, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
-		htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
-		ggE_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
-		histlist->Add(ggE_ejectile_dc_recoil);
-
-		hname = "ggE_recoil_dc_none";
-		htitle = "Gamma-gamma matrix, gated on the recoil with random subtraction;";
-		htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
-		ggE_recoil_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
-		histlist->Add(ggE_recoil_dc_none);
-
-		hname = "ggE_recoil_dc_ejectile";
-		htitle = "Gamma-gamma matrix, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
-		ggE_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
-		histlist->Add(ggE_recoil_dc_ejectile);
-
-		hname = "ggE_recoil_dc_recoil";
-		htitle = "Gamma-gamma matrix, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
-		htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
-		ggE_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
-		histlist->Add(ggE_recoil_dc_recoil);
-
-	}
-	
-	// Gamma-particle coincidences with addback
-	dirname = "GammaRayAddbackParticleCoincidences";
-	output_file->mkdir( dirname.data() );
-	output_file->cd( dirname.data() );
-	
-	hname = "aE_prompt";
-	htitle = "Gamma-ray energy with addback in prompt coincide with any particle;Energy [keV];Counts per 0.5 keV";
-	aE_prompt = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(aE_prompt);
-
-	hname = "aE_prompt_1p";
-	htitle = "Gamma-ray energy with addback in prompt coincide with just 1 particle;Energy [keV];Counts per 0.5 keV";
-	aE_prompt_1p = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(aE_prompt_1p);
-
-	hname = "aE_prompt_2p";
-	htitle = "Gamma-ray energy with addback in prompt coincide with 2 particles;Energy [keV];Counts per 0.5 keV";
-	aE_prompt_2p = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(aE_prompt_2p);
-
-	hname = "aE_random";
-	htitle = "Gamma-ray energy with addback in random coincide with any particle;Energy [keV];Counts per 0.5 keV";
-	aE_random = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(aE_random);
-
-	hname = "aE_random_1p";
-	htitle = "Gamma-ray energy with addback in random coincide with just 1 particle;Energy [keV];Counts per 0.5 keV";
-	aE_random_1p = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(aE_random_1p);
-
-	hname = "aE_random_2p";
-	htitle = "Gamma-ray energy with addback in random coincide with 2 particles;Energy [keV];Counts per 0.5 keV";
-	aE_random_2p = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(aE_random_2p);
-
-	hname = "aE_ejectile_dc_none";
-	htitle = "Gamma-ray energy with addback, gated on the ejectile with random subtraction;";
-	htitle += "Energy [keV];Counts per 0.5 keV";
-	aE_ejectile_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(aE_ejectile_dc_none);
-
-	hname = "aE_ejectile_dc_ejectile";
-	htitle = "Gamma-ray energy with addback, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
-	htitle += "Energy [keV];Counts per 0.5 keV";
-	aE_ejectile_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(aE_ejectile_dc_ejectile);
-
-	hname = "aE_ejectile_dc_recoil";
-	htitle = "Gamma-ray energy with addback, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
-	htitle += "Energy [keV];Counts per 0.5 keV";
-	aE_ejectile_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(aE_ejectile_dc_recoil);
-
-	hname = "aE_recoil_dc_none";
-	htitle = "Gamma-ray energy with addback, gated on the recoil with random subtraction;";
-	htitle += "Energy [keV];Counts per 0.5 keV";
-	aE_recoil_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(aE_recoil_dc_none);
-
-	hname = "aE_recoil_dc_ejectile";
-	htitle = "Gamma-ray energy with addback, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
-	htitle += "Energy [keV];Counts per 0.5 keV";
-	aE_recoil_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(aE_recoil_dc_ejectile);
-
-	hname = "aE_recoil_dc_recoil";
-	htitle = "Gamma-ray energy with addback, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
-	htitle += "Energy [keV];Counts per 0.5 keV";
-	aE_recoil_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-	histlist->Add(aE_recoil_dc_recoil);
-
-	// 1p and 2p gamma-ray histograms
-	if( react->HistByMultiplicity() ){
-		
-		hname = "aE_1p_ejectile_dc_none";
-		htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only with random subtraction;";
-		htitle += "Energy [keV];Counts per 0.5 keV";
-		aE_1p_ejectile_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		histlist->Add(aE_1p_ejectile_dc_none);
-
-		hname = "aE_1p_ejectile_dc_ejectile";
-		htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "Energy [keV];Counts per 0.5 keV";
-		aE_1p_ejectile_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		histlist->Add(aE_1p_ejectile_dc_ejectile);
-
-		hname = "aE_1p_ejectile_dc_recoil";
-		htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
-		htitle += "Energy [keV];Counts per 0.5 keV";
-		aE_1p_ejectile_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		histlist->Add(aE_1p_ejectile_dc_recoil);
-
-		hname = "aE_1p_recoil_dc_none";
-		htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only with random subtraction;";
-		htitle += "Energy [keV];Counts per 0.5 keV";
-		aE_1p_recoil_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		histlist->Add(aE_1p_recoil_dc_none);
-
-		hname = "aE_1p_recoil_dc_ejectile";
-		htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "Energy [keV];Counts per 0.5 keV";
-		aE_1p_recoil_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		histlist->Add(aE_1p_recoil_dc_ejectile);
-
-		hname = "aE_1p_recoil_dc_recoil";
-		htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
-		htitle += "Energy [keV];Counts per 0.5 keV";
-		aE_1p_recoil_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		histlist->Add(aE_1p_recoil_dc_recoil);
-
-		hname = "aE_2p_dc_none";
-		htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil with random subtraction;";
-		htitle += "Energy [keV];Counts per 0.5 keV";
-		aE_2p_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		histlist->Add(aE_2p_dc_none);
-
-		hname = "aE_2p_dc_ejectile";
-		htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "Energy [keV];Counts per 0.5 keV";
-		aE_2p_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		histlist->Add(aE_2p_dc_ejectile);
-
-		hname = "aE_2p_dc_recoil";
-		htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
-		htitle += "Energy [keV];Counts per 0.5 keV";
-		aE_2p_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		histlist->Add(aE_2p_dc_recoil);
-
-	}
-
-	hname = "aE_vs_costheta_ejectile_dc_none";
-	htitle = "Gamma-ray energy with addback versus cos(#theta) of angle between ejectile and gamma-ray, gated on the ejectile;Energy [keV];cos(#theta_p#gamma)";
-	aE_vs_costheta_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
-	histlist->Add(aE_vs_costheta_ejectile_dc_none);
-
-	hname = "aE_vs_costheta2_ejectile_dc_none";
-	htitle = "Gamma-ray energy with addback versus cos(#theta) of angle between recoil and gamma-ray, gated on the ejectile;Energy [keV];cos(#theta_p#gamma)";
-	aE_vs_costheta2_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
-	histlist->Add(aE_vs_costheta2_ejectile_dc_none);
-
-	hname = "aE_vs_costheta_ejectile_dc_ejectile";
-	htitle = "Gamma-ray energy with addback versus cos(#theta) of angle between ejectile and gamma-ray, gated on the ejectile, Doppler corrected for the ejectile;Energy [keV];cos(#theta_p#gamma)";
-	aE_vs_costheta_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
-	histlist->Add(aE_vs_costheta_ejectile_dc_ejectile);
-
-	hname = "aE_vs_costheta_ejectile_dc_recoil";
-	htitle = "Gamma-ray energy with addback versus cos(#theta) of angle between recoil and gamma-ray, gated on the ejectile, Doppler corrected for the recoil;Energy [keV];cos(#theta_p#gamma)";
-	aE_vs_costheta_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
-	histlist->Add(aE_vs_costheta_ejectile_dc_recoil);
-
-	hname = "aE_vs_costheta_recoil_dc_none";
-	htitle = "Gamma-ray energy with addback versus cos(#theta) of angle between recoil and gamma-ray, gated on the recoil, no Doppler correction;Energy [keV];cos(#theta_p#gamma)";
-	aE_vs_costheta_recoil_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
-	histlist->Add(aE_vs_costheta_recoil_dc_none);
-
-	hname = "aE_vs_costheta2_recoil_dc_none";
-	htitle = "Gamma-ray energy with addback versus cos(#theta) of angle between ejectile and gamma-ray, gated on the recoil, no Doppler correction;Energy [keV];cos(#theta_p#gamma)";
-	aE_vs_costheta2_recoil_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
-	histlist->Add(aE_vs_costheta2_recoil_dc_none);
-
-	hname = "aE_vs_costheta_recoil_dc_ejectile";
-	htitle = "Gamma-ray energy with addback versus cos(#theta) of angle between ejectile and gamma-ray, gated on the recoil, Doppler corrected for the ejectile;Energy [keV];cos(#theta_p#gamma)";
-	aE_vs_costheta_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
-	histlist->Add(aE_vs_costheta_recoil_dc_ejectile);
-
-	hname = "aE_vs_costheta_recoil_dc_recoil";
-	htitle = "Gamma-ray energy with addback versus cos(#theta) of angle between recoil and gamma-ray, gated on the recoil, Doppler corrected for the recoil;Energy [keV];cos(#theta_p#gamma)";
-	aE_vs_costheta_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
-	histlist->Add(aE_vs_costheta_recoil_dc_recoil);
-
-	hname = "aE_vs_theta_ejectile_dc_none";
-	htitle = "Gamma-ray energy with addback, gated on the ejectile with random subtraction;";
-	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-	aE_vs_theta_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-	histlist->Add(aE_vs_theta_ejectile_dc_none);
-
-	hname = "aE_vs_theta_ejectile_dc_ejectile";
-	htitle = "Gamma-ray energy with addback, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
-	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-	aE_vs_theta_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-	histlist->Add(aE_vs_theta_ejectile_dc_ejectile);
-
-	hname = "aE_vs_theta_ejectile_dc_recoil";
-	htitle = "Gamma-ray energy with addback, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
-	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-	aE_vs_theta_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-	histlist->Add(aE_vs_theta_ejectile_dc_recoil);
-
-	hname = "aE_vs_theta_recoil_dc_none";
-	htitle = "Gamma-ray energy with addback, gated on the recoil with random subtraction;";
-	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-	aE_vs_theta_recoil_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-	histlist->Add(aE_vs_theta_recoil_dc_none);
-
-	hname = "aE_vs_theta_recoil_dc_ejectile";
-	htitle = "Gamma-ray energy with addback, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
-	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-	aE_vs_theta_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-	histlist->Add(aE_vs_theta_recoil_dc_ejectile);
-
-	hname = "aE_vs_theta_recoil_dc_recoil";
-	htitle = "Gamma-ray energy with addback, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
-	htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-	aE_vs_theta_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-	histlist->Add(aE_vs_theta_recoil_dc_recoil);
-
-	// 1p and 2p gamma-ray histograms
-	if( react->HistByMultiplicity() ){
-		
-		hname = "aE_1p_vs_theta_1p_ejectile_dc_none";
-		htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only with random subtraction;";
-		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-		aE_vs_theta_1p_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		histlist->Add(aE_vs_theta_1p_ejectile_dc_none);
-
-		hname = "aE_vs_theta_1p_ejectile_dc_ejectile";
-		htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-		aE_vs_theta_1p_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		histlist->Add(aE_vs_theta_1p_ejectile_dc_ejectile);
-
-		hname = "aE_vs_theta_1p_ejectile_dc_recoil";
-		htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
-		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-		aE_vs_theta_1p_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		histlist->Add(aE_vs_theta_1p_ejectile_dc_recoil);
-
-		hname = "aE_vs_theta_1p_recoil_dc_none";
-		htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only with random subtraction;";
-		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-		aE_vs_theta_1p_recoil_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		histlist->Add(aE_vs_theta_1p_recoil_dc_none);
-
-		hname = "aE_vs_theta_1p_recoil_dc_ejectile";
-		htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-		aE_vs_theta_1p_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		histlist->Add(aE_vs_theta_1p_recoil_dc_ejectile);
-
-		hname = "aE_vs_theta_1p_recoil_dc_recoil";
-		htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
-		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-		aE_vs_theta_1p_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		histlist->Add(aE_vs_theta_1p_recoil_dc_recoil);
-
-		hname = "aE_vs_theta_2p_dc_none";
-		htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil with random subtraction;";
-		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-		aE_vs_theta_2p_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		histlist->Add(aE_vs_theta_2p_dc_none);
-
-		hname = "aE_vs_theta_2p_dc_ejectile";
-		htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-		aE_vs_theta_2p_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		histlist->Add(aE_vs_theta_2p_dc_ejectile);
-
-		hname = "aE_vs_theta_2p_dc_recoil";
-		htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
-		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
-		aE_vs_theta_2p_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
-		histlist->Add(aE_vs_theta_2p_dc_recoil);
-
-	}
-	
-	// Per crystal Doppler-corrected spectra
-	if( react->HistByCrystal() ) {
-		
-		hname = "aE_vs_crystal_ejectile_dc_none";
-		htitle = "Gamma-ray energy with addback, gated on the ejectile with random subtraction;";
-		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-		aE_vs_crystal_ejectile_dc_none = new TH2F( hname.data(), htitle.data(),
-					set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-		histlist->Add(aE_vs_crystal_ejectile_dc_none);
-
-		hname = "aE_vs_crystal_ejectile_dc_ejectile";
-		htitle = "Gamma-ray energy with addback, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-		aE_vs_crystal_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), 
-													  set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-		histlist->Add(aE_vs_crystal_ejectile_dc_ejectile);
-
-		hname = "aE_vs_crystal_ejectile_dc_recoil";
-		htitle = "Gamma-ray energy with addback, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
-		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-		aE_vs_crystal_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), 
-													set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-		histlist->Add(aE_vs_crystal_ejectile_dc_recoil);
-
-		hname = "aE_vs_crystal_recoil_dc_none";
-		htitle = "Gamma-ray energy with addback, gated on the recoil with random subtraction;";
-		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-		aE_vs_crystal_recoil_dc_none = new TH2F( hname.data(), htitle.data(), 
-												set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-		histlist->Add(aE_vs_crystal_recoil_dc_none);
-
-		hname = "aE_vs_crystal_recoil_dc_ejectile";
-		htitle = "Gamma-ray energy with addback, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-		aE_vs_crystal_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), 
-													set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-		histlist->Add(aE_vs_crystal_recoil_dc_ejectile);
-
-		hname = "aE_vs_crystal_recoil_dc_recoil";
-		htitle = "Gamma-ray energy with addback, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
-		htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-		aE_vs_crystal_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), 
-												  set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-		histlist->Add(aE_vs_crystal_recoil_dc_recoil);
-
-		// 1p and 2p gamma-ray histograms
-		if( react->HistByMultiplicity() ){
-			
-			hname = "aE_vs_crystal_1p_ejectile_dc_none";
-			htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only with random subtraction;";
+			hname = "gE_vs_crystal_ejectile_dc_none";
+			htitle = "Gamma-ray energy, gated on the ejectile with random subtraction;";
 			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-			aE_vs_crystal_1p_ejectile_dc_none = new TH2F( hname.data(), htitle.data(),
-													  set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-			histlist->Add(aE_vs_crystal_1p_ejectile_dc_none);
+			gE_vs_crystal_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
+			histlist->Add(gE_vs_crystal_ejectile_dc_none);
 
-			hname = "aE_vs_crystal_1p_ejectile_dc_ejectile";
-			htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+			hname = "gE_vs_crystal_ejectile_dc_ejectile";
+			htitle = "Gamma-ray energy, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
 			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-			aE_vs_crystal_1p_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(),
-														  set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-			histlist->Add(aE_vs_crystal_1p_ejectile_dc_ejectile);
+			gE_vs_crystal_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
+			histlist->Add(gE_vs_crystal_ejectile_dc_ejectile);
 
-			hname = "aE_vs_crystal_1p_ejectile_dc_recoil";
-			htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+			hname = "gE_vs_crystal_ejectile_dc_recoil";
+			htitle = "Gamma-ray energy, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
 			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-			aE_vs_crystal_1p_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(),
-														set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-			histlist->Add(aE_vs_crystal_1p_ejectile_dc_recoil);
+			gE_vs_crystal_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
+			histlist->Add(gE_vs_crystal_ejectile_dc_recoil);
 
-			hname = "aE_vs_crystal_1p_recoil_dc_none";
-			htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only with random subtraction;";
+			hname = "gE_vs_crystal_recoil_dc_none";
+			htitle = "Gamma-ray energy, gated on the recoil with random subtraction;";
 			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-			aE_vs_crystal_1p_recoil_dc_none = new TH2F( hname.data(), htitle.data(),
-													set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-			histlist->Add(aE_vs_crystal_1p_recoil_dc_none);
+			gE_vs_crystal_recoil_dc_none = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
+			histlist->Add(gE_vs_crystal_recoil_dc_none);
 
-			hname = "aE_vs_crystal_1p_recoil_dc_ejectile";
-			htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+			hname = "gE_vs_crystal_recoil_dc_ejectile";
+			htitle = "Gamma-ray energy, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
 			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-			aE_vs_crystal_1p_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(),
-														set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-			histlist->Add(aE_vs_crystal_1p_recoil_dc_ejectile);
+			gE_vs_crystal_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
+			histlist->Add(gE_vs_crystal_recoil_dc_ejectile);
 
-			hname = "aE_vs_crystal_1p_recoil_dc_recoil";
-			htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+			hname = "gE_vs_crystal_recoil_dc_recoil";
+			htitle = "Gamma-ray energy, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
 			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-			aE_vs_crystal_1p_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(),
-													  set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-			histlist->Add(aE_vs_crystal_1p_recoil_dc_recoil);
+			gE_vs_crystal_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
+			histlist->Add(gE_vs_crystal_recoil_dc_recoil);
 
-			hname = "aE_vs_crystal_2p_dc_none";
-			htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil with random subtraction;";
-			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-			aE_vs_crystal_2p_dc_none = new TH2F( hname.data(), htitle.data(),
-												set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-			histlist->Add(aE_vs_crystal_2p_dc_none);
+			// 1p and 2p gamma-ray histograms
+			if( react->HistByMultiplicity() ){
 
-			hname = "aE_vs_crystal_2p_dc_ejectile";
-			htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
-			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-			aE_vs_crystal_2p_dc_ejectile = new TH2F( hname.data(), htitle.data(),
-													set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-			histlist->Add(aE_vs_crystal_2p_dc_ejectile);
+				hname = "gE_vs_crystal_1p_ejectile_dc_none";
+				htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only with random subtraction;";
+				htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+				gE_vs_crystal_1p_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
+				histlist->Add(gE_vs_crystal_1p_ejectile_dc_none);
 
-			hname = "aE_vs_crystal_2p_dc_recoil";
-			htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
-			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
-			aE_vs_crystal_2p_dc_recoil = new TH2F( hname.data(), htitle.data(),
-												  set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
-			histlist->Add(aE_vs_crystal_2p_dc_recoil);
+				hname = "gE_vs_crystal_1p_ejectile_dc_ejectile";
+				htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+				htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+				gE_vs_crystal_1p_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
+				histlist->Add(gE_vs_crystal_1p_ejectile_dc_ejectile);
 
-		}
-		
-	} // by crystal
-	
-	// T1 impact time
-	if( react->HistByT1() ) {
-		
-		hname = "aE_ejectile_dc_none_t1";
-		htitle = "Gamma-ray energy with addback, gated on the ejectile, with random subtraction;";
-		htitle += "T1 time [ns];Energy [keV];Counts per keV";
-		aE_ejectile_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-		histlist->Add(aE_ejectile_dc_none_t1);
+				hname = "gE_vs_crystal_1p_ejectile_dc_recoil";
+				htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+				htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+				gE_vs_crystal_1p_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
+				histlist->Add(gE_vs_crystal_1p_ejectile_dc_recoil);
 
-		hname = "aE_ejectile_dc_ejectile_t1";
-		htitle = "Gamma-ray energy with addback, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "T1 time [ns];Energy [keV];Counts per keV";
-		aE_ejectile_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-		histlist->Add(aE_ejectile_dc_ejectile_t1);
+				hname = "gE_vs_crystal_1p_recoil_dc_none";
+				htitle = "Gamma-ray energy, gated on the recoil, 1-particle only with random subtraction;";
+				htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+				gE_vs_crystal_1p_recoil_dc_none = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
+				histlist->Add(gE_vs_crystal_1p_recoil_dc_none);
 
-		hname = "aE_ejectile_dc_recoil_t1";
-		htitle = "Gamma-ray energy with addback, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
-		htitle += "T1 time [ns];Energy [keV];Counts per keV";
-		aE_ejectile_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-		histlist->Add(aE_ejectile_dc_recoil_t1);
+				hname = "gE_vs_crystal_1p_recoil_dc_ejectile";
+				htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+				htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+				gE_vs_crystal_1p_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
+				histlist->Add(gE_vs_crystal_1p_recoil_dc_ejectile);
 
-		hname = "aE_recoil_dc_none_t1";
-		htitle = "Gamma-ray energy with addback, gated on the recoil, with random subtraction;";
-		htitle += "T1 time [ns];Energy [keV];Counts per keV";
-		aE_recoil_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-		histlist->Add(aE_recoil_dc_none_t1);
+				hname = "gE_vs_crystal_1p_recoil_dc_recoil";
+				htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+				htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+				gE_vs_crystal_1p_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
+				histlist->Add(gE_vs_crystal_1p_recoil_dc_recoil);
 
-		hname = "aE_recoil_dc_ejectile_t1";
-		htitle = "Gamma-ray energy with addback, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "T1 time [ns];Energy [keV];Counts per keV";
-		aE_recoil_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-		histlist->Add(aE_recoil_dc_ejectile_t1);
+				hname = "gE_vs_crystal_2p_dc_none";
+				htitle = "Gamma-ray energy, in coincidence with ejectile and recoil with random subtraction;";
+				htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+				gE_vs_crystal_2p_dc_none = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
+				histlist->Add(gE_vs_crystal_2p_dc_none);
 
-		hname = "aE_recoil_dc_recoil_t1";
-		htitle = "Gamma-ray energy with addback, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
-		htitle += "T1 time [ns];Energy [keV];Counts per eV";
-		aE_recoil_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-		histlist->Add(aE_recoil_dc_recoil_t1);
+				hname = "gE_vs_crystal_2p_dc_ejectile";
+				htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
+				htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+				gE_vs_crystal_2p_dc_ejectile = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
+				histlist->Add(gE_vs_crystal_2p_dc_ejectile);
 
-		// 1p and 2p gamma-ray histograms
-		if( react->HistByMultiplicity() ){
-			
-			hname = "aE_1p_ejectile_dc_none_t1";
-			htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, with random subtraction;";
+				hname = "gE_vs_crystal_2p_dc_recoil";
+				htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
+				htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+				gE_vs_crystal_2p_dc_recoil = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
+				histlist->Add(gE_vs_crystal_2p_dc_recoil);
+
+			}
+
+		} // by crystal
+
+		// T1 impact time
+		if( react->HistByT1() ) {
+
+			hname = "gE_ejectile_dc_none_t1";
+			htitle = "Gamma-ray energy, gated on the ejectile, with random subtraction;";
 			htitle += "T1 time [ns];Energy [keV];Counts per keV";
-			aE_1p_ejectile_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			histlist->Add(aE_1p_ejectile_dc_none_t1);
+			gE_ejectile_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+			histlist->Add(gE_ejectile_dc_none_t1);
 
-			hname = "aE_1p_ejectile_dc_ejectile_t1";
-			htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+			hname = "gE_ejectile_dc_ejectile_t1";
+			htitle = "Gamma-ray energy, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
 			htitle += "T1 time [ns];Energy [keV];Counts per keV";
-			aE_1p_ejectile_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			histlist->Add(aE_1p_ejectile_dc_ejectile_t1);
+			gE_ejectile_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+			histlist->Add(gE_ejectile_dc_ejectile_t1);
 
-			hname = "aE_1p_ejectile_dc_recoil_t1";
-			htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+			hname = "gE_ejectile_dc_recoil_t1";
+			htitle = "Gamma-ray energy, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
 			htitle += "T1 time [ns];Energy [keV];Counts per keV";
-			aE_1p_ejectile_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			histlist->Add(aE_1p_ejectile_dc_recoil_t1);
+			gE_ejectile_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+			histlist->Add(gE_ejectile_dc_recoil_t1);
 
-			hname = "aE_1p_recoil_dc_none_t1";
-			htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, with random subtraction;";
+			hname = "gE_recoil_dc_none_t1";
+			htitle = "Gamma-ray energy, gated on the recoil, with random subtraction;";
 			htitle += "T1 time [ns];Energy [keV];Counts per keV";
-			aE_1p_recoil_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			histlist->Add(aE_1p_recoil_dc_none_t1);
+			gE_recoil_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+			histlist->Add(gE_recoil_dc_none_t1);
 
-			hname = "aE_1p_recoil_dc_ejectile_t1";
-			htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+			hname = "gE_recoil_dc_ejectile_t1";
+			htitle = "Gamma-ray energy, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
 			htitle += "T1 time [ns];Energy [keV];Counts per keV";
-			aE_1p_recoil_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			histlist->Add(aE_1p_recoil_dc_ejectile_t1);
+			gE_recoil_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+			histlist->Add(gE_recoil_dc_ejectile_t1);
 
-			hname = "aE_1p_recoil_dc_recoil_t1";
-			htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+			hname = "gE_recoil_dc_recoil_t1";
+			htitle = "Gamma-ray energy, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
 			htitle += "T1 time [ns];Energy [keV];Counts per eV";
-			aE_1p_recoil_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			histlist->Add(aE_1p_recoil_dc_recoil_t1);
+			gE_recoil_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+			histlist->Add(gE_recoil_dc_recoil_t1);
 
-			hname = "aE_2p_dc_none_t1";
-			htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, with random subtraction;";
-			htitle += "Energy [keV];Counts per keV";
-			aE_2p_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			histlist->Add(aE_2p_dc_none_t1);
+			// 1p and 2p gamma-ray histograms
+			if( react->HistByMultiplicity() ){
 
-			hname = "aE_2p_dc_ejectile_t1";
-			htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
-			htitle += "Energy [keV];Counts per keV";
-			aE_2p_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			histlist->Add(aE_2p_dc_ejectile_t1);
+				hname = "gE_1p_ejectile_dc_none_t1";
+				htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, with random subtraction;";
+				htitle += "T1 time [ns];Energy [keV];Counts per keV";
+				gE_1p_ejectile_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+				histlist->Add(gE_1p_ejectile_dc_none_t1);
 
-			hname = "aE_2p_dc_recoil_t1";
-			htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
-			htitle += "Energy [keV];Counts per keV";
-			aE_2p_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
-			histlist->Add(aE_2p_dc_recoil_t1);
+				hname = "gE_1p_ejectile_dc_ejectile_t1";
+				htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+				htitle += "T1 time [ns];Energy [keV];Counts per keV";
+				gE_1p_ejectile_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+				histlist->Add(gE_1p_ejectile_dc_ejectile_t1);
+
+				hname = "gE_1p_ejectile_dc_recoil_t1";
+				htitle = "Gamma-ray energy, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+				htitle += "T1 time [ns];Energy [keV];Counts per keV";
+				gE_1p_ejectile_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+				histlist->Add(gE_1p_ejectile_dc_recoil_t1);
+
+				hname = "gE_1p_recoil_dc_none_t1";
+				htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, with random subtraction;";
+				htitle += "T1 time [ns];Energy [keV];Counts per keV";
+				gE_1p_recoil_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+				histlist->Add(gE_1p_recoil_dc_none_t1);
+
+				hname = "gE_1p_recoil_dc_ejectile_t1";
+				htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+				htitle += "T1 time [ns];Energy [keV];Counts per keV";
+				gE_1p_recoil_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+				histlist->Add(gE_1p_recoil_dc_ejectile_t1);
+
+				hname = "gE_1p_recoil_dc_recoil_t1";
+				htitle = "Gamma-ray energy, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+				htitle += "T1 time [ns];Energy [keV];Counts per eV";
+				gE_1p_recoil_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+				histlist->Add(gE_1p_recoil_dc_recoil_t1);
+
+				hname = "gE_2p_dc_none_t1";
+				htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil with random subtraction;";
+				htitle += "Energy [keV];Counts per keV";
+				gE_2p_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+				histlist->Add(gE_2p_dc_none_t1);
+
+				hname = "gE_2p_dc_ejectile_t1";
+				htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
+				htitle += "Energy [keV];Counts per keV";
+				gE_2p_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+				histlist->Add(gE_2p_dc_ejectile_t1);
+
+				hname = "gE_2p_dc_recoil_t1";
+				htitle = "Gamma-ray energy, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
+				htitle += "Energy [keV];Counts per keV";
+				gE_2p_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+				histlist->Add(gE_2p_dc_recoil_t1);
+
+			}
 
 		}
-		
+		// Gamma-gamma hists
+		if( react->HistGammaGamma() ) {
+
+			hname = "ggE_ejectile_dc_none";
+			htitle = "Gamma-gamma matrix, gated on the ejectile with random subtraction;";
+			htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
+			ggE_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
+			histlist->Add(ggE_ejectile_dc_none);
+
+			hname = "ggE_ejectile_dc_ejectile";
+			htitle = "Gamma-gamma matrix, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
+			ggE_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
+			histlist->Add(ggE_ejectile_dc_ejectile);
+
+			hname = "ggE_ejectile_dc_recoil";
+			htitle = "Gamma-gamma matrix, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
+			htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
+			ggE_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
+			histlist->Add(ggE_ejectile_dc_recoil);
+
+			hname = "ggE_recoil_dc_none";
+			htitle = "Gamma-gamma matrix, gated on the recoil with random subtraction;";
+			htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
+			ggE_recoil_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
+			histlist->Add(ggE_recoil_dc_none);
+
+			hname = "ggE_recoil_dc_ejectile";
+			htitle = "Gamma-gamma matrix, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
+			ggE_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
+			histlist->Add(ggE_recoil_dc_ejectile);
+
+			hname = "ggE_recoil_dc_recoil";
+			htitle = "Gamma-gamma matrix, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
+			htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
+			ggE_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
+			histlist->Add(ggE_recoil_dc_recoil);
+
+		}
+
 	}
-	
-	// Gamma-gamma hists
-	if( react->HistGammaGamma() ) {
-		
-		hname = "aaE_ejectile_dc_none";
-		htitle = "Gamma-gamma matrix with addback, gated on the ejectile with random subtraction;";
-		htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
-		aaE_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
-		histlist->Add(aaE_ejectile_dc_none);
 
-		hname = "aaE_ejectile_dc_ejectile";
-		htitle = "Gamma-gamma matrix with addback, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
-		aaE_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
-		histlist->Add(aaE_ejectile_dc_ejectile);
 
-		hname = "aaE_ejectile_dc_recoil";
-		htitle = "Gamma-gamma matrix with addback, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
-		htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
-		aaE_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
-		histlist->Add(aaE_ejectile_dc_recoil);
+	// Gamma-particle coincidences with addback
+	if( react->HistWithAddback() ) {
 
-		hname = "aaE_recoil_dc_none";
-		htitle = "Gamma-gamma matrix with addback, gated on the recoil with random subtraction;";
-		htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
-		aaE_recoil_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
-		histlist->Add(aaE_recoil_dc_none);
+		dirname = "GammaRayAddbackParticleCoincidences";
+		output_file->mkdir( dirname.data() );
+		output_file->cd( dirname.data() );
 
-		hname = "aaE_recoil_dc_ejectile";
-		htitle = "Gamma-gamma matrix with addback, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
-		aaE_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
-		histlist->Add(aaE_recoil_dc_ejectile);
+		hname = "aE_prompt";
+		htitle = "Gamma-ray energy with addback in prompt coincide with any particle;Energy [keV];Counts per 0.5 keV";
+		aE_prompt = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(aE_prompt);
 
-		hname = "aaE_recoil_dc_recoil";
-		htitle = "Gamma-gamma matrix with addback, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
-		htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
-		aaE_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
-		histlist->Add(aaE_recoil_dc_recoil);
+		hname = "aE_prompt_1p";
+		htitle = "Gamma-ray energy with addback in prompt coincide with just 1 particle;Energy [keV];Counts per 0.5 keV";
+		aE_prompt_1p = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(aE_prompt_1p);
+
+		hname = "aE_prompt_2p";
+		htitle = "Gamma-ray energy with addback in prompt coincide with 2 particles;Energy [keV];Counts per 0.5 keV";
+		aE_prompt_2p = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(aE_prompt_2p);
+
+		hname = "aE_random";
+		htitle = "Gamma-ray energy with addback in random coincide with any particle;Energy [keV];Counts per 0.5 keV";
+		aE_random = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(aE_random);
+
+		hname = "aE_random_1p";
+		htitle = "Gamma-ray energy with addback in random coincide with just 1 particle;Energy [keV];Counts per 0.5 keV";
+		aE_random_1p = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(aE_random_1p);
+
+		hname = "aE_random_2p";
+		htitle = "Gamma-ray energy with addback in random coincide with 2 particles;Energy [keV];Counts per 0.5 keV";
+		aE_random_2p = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(aE_random_2p);
+
+		hname = "aE_ejectile_dc_none";
+		htitle = "Gamma-ray energy with addback, gated on the ejectile with random subtraction;";
+		htitle += "Energy [keV];Counts per 0.5 keV";
+		aE_ejectile_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(aE_ejectile_dc_none);
+
+		hname = "aE_ejectile_dc_ejectile";
+		htitle = "Gamma-ray energy with addback, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
+		htitle += "Energy [keV];Counts per 0.5 keV";
+		aE_ejectile_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(aE_ejectile_dc_ejectile);
+
+		hname = "aE_ejectile_dc_recoil";
+		htitle = "Gamma-ray energy with addback, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
+		htitle += "Energy [keV];Counts per 0.5 keV";
+		aE_ejectile_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(aE_ejectile_dc_recoil);
+
+		hname = "aE_recoil_dc_none";
+		htitle = "Gamma-ray energy with addback, gated on the recoil with random subtraction;";
+		htitle += "Energy [keV];Counts per 0.5 keV";
+		aE_recoil_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(aE_recoil_dc_none);
+
+		hname = "aE_recoil_dc_ejectile";
+		htitle = "Gamma-ray energy with addback, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
+		htitle += "Energy [keV];Counts per 0.5 keV";
+		aE_recoil_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(aE_recoil_dc_ejectile);
+
+		hname = "aE_recoil_dc_recoil";
+		htitle = "Gamma-ray energy with addback, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
+		htitle += "Energy [keV];Counts per 0.5 keV";
+		aE_recoil_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(aE_recoil_dc_recoil);
+
+		// 1p and 2p gamma-ray histograms
+		if( react->HistByMultiplicity() ){
+
+			hname = "aE_1p_ejectile_dc_none";
+			htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only with random subtraction;";
+			htitle += "Energy [keV];Counts per 0.5 keV";
+			aE_1p_ejectile_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+			histlist->Add(aE_1p_ejectile_dc_none);
+
+			hname = "aE_1p_ejectile_dc_ejectile";
+			htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Energy [keV];Counts per 0.5 keV";
+			aE_1p_ejectile_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+			histlist->Add(aE_1p_ejectile_dc_ejectile);
+
+			hname = "aE_1p_ejectile_dc_recoil";
+			htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+			htitle += "Energy [keV];Counts per 0.5 keV";
+			aE_1p_ejectile_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+			histlist->Add(aE_1p_ejectile_dc_recoil);
+
+			hname = "aE_1p_recoil_dc_none";
+			htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only with random subtraction;";
+			htitle += "Energy [keV];Counts per 0.5 keV";
+			aE_1p_recoil_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+			histlist->Add(aE_1p_recoil_dc_none);
+
+			hname = "aE_1p_recoil_dc_ejectile";
+			htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Energy [keV];Counts per 0.5 keV";
+			aE_1p_recoil_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+			histlist->Add(aE_1p_recoil_dc_ejectile);
+
+			hname = "aE_1p_recoil_dc_recoil";
+			htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+			htitle += "Energy [keV];Counts per 0.5 keV";
+			aE_1p_recoil_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+			histlist->Add(aE_1p_recoil_dc_recoil);
+
+			hname = "aE_2p_dc_none";
+			htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil with random subtraction;";
+			htitle += "Energy [keV];Counts per 0.5 keV";
+			aE_2p_dc_none = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+			histlist->Add(aE_2p_dc_none);
+
+			hname = "aE_2p_dc_ejectile";
+			htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Energy [keV];Counts per 0.5 keV";
+			aE_2p_dc_ejectile = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+			histlist->Add(aE_2p_dc_ejectile);
+
+			hname = "aE_2p_dc_recoil";
+			htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
+			htitle += "Energy [keV];Counts per 0.5 keV";
+			aE_2p_dc_recoil = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+			histlist->Add(aE_2p_dc_recoil);
+
+		}
+
+		hname = "aE_vs_costheta_ejectile_dc_none";
+		htitle = "Gamma-ray energy with addback versus cos(#theta) of angle between ejectile and gamma-ray, gated on the ejectile;Energy [keV];cos(#theta_p#gamma)";
+		aE_vs_costheta_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+		histlist->Add(aE_vs_costheta_ejectile_dc_none);
+
+		hname = "aE_vs_costheta2_ejectile_dc_none";
+		htitle = "Gamma-ray energy with addback versus cos(#theta) of angle between recoil and gamma-ray, gated on the ejectile;Energy [keV];cos(#theta_p#gamma)";
+		aE_vs_costheta2_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+		histlist->Add(aE_vs_costheta2_ejectile_dc_none);
+
+		hname = "aE_vs_costheta_ejectile_dc_ejectile";
+		htitle = "Gamma-ray energy with addback versus cos(#theta) of angle between ejectile and gamma-ray, gated on the ejectile, Doppler corrected for the ejectile;Energy [keV];cos(#theta_p#gamma)";
+		aE_vs_costheta_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+		histlist->Add(aE_vs_costheta_ejectile_dc_ejectile);
+
+		hname = "aE_vs_costheta_ejectile_dc_recoil";
+		htitle = "Gamma-ray energy with addback versus cos(#theta) of angle between recoil and gamma-ray, gated on the ejectile, Doppler corrected for the recoil;Energy [keV];cos(#theta_p#gamma)";
+		aE_vs_costheta_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+		histlist->Add(aE_vs_costheta_ejectile_dc_recoil);
+
+		hname = "aE_vs_costheta_recoil_dc_none";
+		htitle = "Gamma-ray energy with addback versus cos(#theta) of angle between recoil and gamma-ray, gated on the recoil, no Doppler correction;Energy [keV];cos(#theta_p#gamma)";
+		aE_vs_costheta_recoil_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+		histlist->Add(aE_vs_costheta_recoil_dc_none);
+
+		hname = "aE_vs_costheta2_recoil_dc_none";
+		htitle = "Gamma-ray energy with addback versus cos(#theta) of angle between ejectile and gamma-ray, gated on the recoil, no Doppler correction;Energy [keV];cos(#theta_p#gamma)";
+		aE_vs_costheta2_recoil_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+		histlist->Add(aE_vs_costheta2_recoil_dc_none);
+
+		hname = "aE_vs_costheta_recoil_dc_ejectile";
+		htitle = "Gamma-ray energy with addback versus cos(#theta) of angle between ejectile and gamma-ray, gated on the recoil, Doppler corrected for the ejectile;Energy [keV];cos(#theta_p#gamma)";
+		aE_vs_costheta_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+		histlist->Add(aE_vs_costheta_recoil_dc_ejectile);
+
+		hname = "aE_vs_costheta_recoil_dc_recoil";
+		htitle = "Gamma-ray energy with addback versus cos(#theta) of angle between recoil and gamma-ray, gated on the recoil, Doppler corrected for the recoil;Energy [keV];cos(#theta_p#gamma)";
+		aE_vs_costheta_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, 100, -1.0, 1.0 );
+		histlist->Add(aE_vs_costheta_recoil_dc_recoil);
+
+		hname = "aE_vs_theta_ejectile_dc_none";
+		htitle = "Gamma-ray energy with addback, gated on the ejectile with random subtraction;";
+		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+		aE_vs_theta_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+		histlist->Add(aE_vs_theta_ejectile_dc_none);
+
+		hname = "aE_vs_theta_ejectile_dc_ejectile";
+		htitle = "Gamma-ray energy with addback, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
+		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+		aE_vs_theta_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+		histlist->Add(aE_vs_theta_ejectile_dc_ejectile);
+
+		hname = "aE_vs_theta_ejectile_dc_recoil";
+		htitle = "Gamma-ray energy with addback, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
+		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+		aE_vs_theta_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+		histlist->Add(aE_vs_theta_ejectile_dc_recoil);
+
+		hname = "aE_vs_theta_recoil_dc_none";
+		htitle = "Gamma-ray energy with addback, gated on the recoil with random subtraction;";
+		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+		aE_vs_theta_recoil_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+		histlist->Add(aE_vs_theta_recoil_dc_none);
+
+		hname = "aE_vs_theta_recoil_dc_ejectile";
+		htitle = "Gamma-ray energy with addback, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
+		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+		aE_vs_theta_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+		histlist->Add(aE_vs_theta_recoil_dc_ejectile);
+
+		hname = "aE_vs_theta_recoil_dc_recoil";
+		htitle = "Gamma-ray energy with addback, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
+		htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+		aE_vs_theta_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+		histlist->Add(aE_vs_theta_recoil_dc_recoil);
+
+		// 1p and 2p gamma-ray histograms
+		if( react->HistByMultiplicity() ){
+
+			hname = "aE_1p_vs_theta_1p_ejectile_dc_none";
+			htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only with random subtraction;";
+			htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+			aE_vs_theta_1p_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+			histlist->Add(aE_vs_theta_1p_ejectile_dc_none);
+
+			hname = "aE_vs_theta_1p_ejectile_dc_ejectile";
+			htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+			aE_vs_theta_1p_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+			histlist->Add(aE_vs_theta_1p_ejectile_dc_ejectile);
+
+			hname = "aE_vs_theta_1p_ejectile_dc_recoil";
+			htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+			htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+			aE_vs_theta_1p_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+			histlist->Add(aE_vs_theta_1p_ejectile_dc_recoil);
+
+			hname = "aE_vs_theta_1p_recoil_dc_none";
+			htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only with random subtraction;";
+			htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+			aE_vs_theta_1p_recoil_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+			histlist->Add(aE_vs_theta_1p_recoil_dc_none);
+
+			hname = "aE_vs_theta_1p_recoil_dc_ejectile";
+			htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+			aE_vs_theta_1p_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+			histlist->Add(aE_vs_theta_1p_recoil_dc_ejectile);
+
+			hname = "aE_vs_theta_1p_recoil_dc_recoil";
+			htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+			htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+			aE_vs_theta_1p_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+			histlist->Add(aE_vs_theta_1p_recoil_dc_recoil);
+
+			hname = "aE_vs_theta_2p_dc_none";
+			htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil with random subtraction;";
+			htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+			aE_vs_theta_2p_dc_none = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+			histlist->Add(aE_vs_theta_2p_dc_none);
+
+			hname = "aE_vs_theta_2p_dc_ejectile";
+			htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+			aE_vs_theta_2p_dc_ejectile = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+			histlist->Add(aE_vs_theta_2p_dc_ejectile);
+
+			hname = "aE_vs_theta_2p_dc_recoil";
+			htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
+			htitle += "Theta [deg];Energy [keV];Counts per 0.5 keV per strip";
+			aE_vs_theta_2p_dc_recoil = new TH2F( hname.data(), htitle.data(), react->GetNumberOfParticleThetas(), react->GetParticleThetas().data(), GBIN, GMIN, GMAX );
+			histlist->Add(aE_vs_theta_2p_dc_recoil);
+
+		}
+
+		// Per crystal Doppler-corrected spectra
+		if( react->HistByCrystal() ) {
+
+			hname = "aE_vs_crystal_ejectile_dc_none";
+			htitle = "Gamma-ray energy with addback, gated on the ejectile with random subtraction;";
+			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+			aE_vs_crystal_ejectile_dc_none = new TH2F( hname.data(), htitle.data(),
+													  set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
+			histlist->Add(aE_vs_crystal_ejectile_dc_none);
+
+			hname = "aE_vs_crystal_ejectile_dc_ejectile";
+			htitle = "Gamma-ray energy with addback, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+			aE_vs_crystal_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(),
+														  set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
+			histlist->Add(aE_vs_crystal_ejectile_dc_ejectile);
+
+			hname = "aE_vs_crystal_ejectile_dc_recoil";
+			htitle = "Gamma-ray energy with addback, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
+			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+			aE_vs_crystal_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(),
+														set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
+			histlist->Add(aE_vs_crystal_ejectile_dc_recoil);
+
+			hname = "aE_vs_crystal_recoil_dc_none";
+			htitle = "Gamma-ray energy with addback, gated on the recoil with random subtraction;";
+			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+			aE_vs_crystal_recoil_dc_none = new TH2F( hname.data(), htitle.data(),
+													set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
+			histlist->Add(aE_vs_crystal_recoil_dc_none);
+
+			hname = "aE_vs_crystal_recoil_dc_ejectile";
+			htitle = "Gamma-ray energy with addback, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+			aE_vs_crystal_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(),
+														set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
+			histlist->Add(aE_vs_crystal_recoil_dc_ejectile);
+
+			hname = "aE_vs_crystal_recoil_dc_recoil";
+			htitle = "Gamma-ray energy with addback, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
+			htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+			aE_vs_crystal_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(),
+													  set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
+			histlist->Add(aE_vs_crystal_recoil_dc_recoil);
+
+			// 1p and 2p gamma-ray histograms
+			if( react->HistByMultiplicity() ){
+
+				hname = "aE_vs_crystal_1p_ejectile_dc_none";
+				htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only with random subtraction;";
+				htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+				aE_vs_crystal_1p_ejectile_dc_none = new TH2F( hname.data(), htitle.data(),
+															 set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
+				histlist->Add(aE_vs_crystal_1p_ejectile_dc_none);
+
+				hname = "aE_vs_crystal_1p_ejectile_dc_ejectile";
+				htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+				htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+				aE_vs_crystal_1p_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(),
+																 set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
+				histlist->Add(aE_vs_crystal_1p_ejectile_dc_ejectile);
+
+				hname = "aE_vs_crystal_1p_ejectile_dc_recoil";
+				htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+				htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+				aE_vs_crystal_1p_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(),
+															   set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
+				histlist->Add(aE_vs_crystal_1p_ejectile_dc_recoil);
+
+				hname = "aE_vs_crystal_1p_recoil_dc_none";
+				htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only with random subtraction;";
+				htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+				aE_vs_crystal_1p_recoil_dc_none = new TH2F( hname.data(), htitle.data(),
+														   set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
+				histlist->Add(aE_vs_crystal_1p_recoil_dc_none);
+
+				hname = "aE_vs_crystal_1p_recoil_dc_ejectile";
+				htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+				htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+				aE_vs_crystal_1p_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(),
+															   set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
+				histlist->Add(aE_vs_crystal_1p_recoil_dc_ejectile);
+
+				hname = "aE_vs_crystal_1p_recoil_dc_recoil";
+				htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+				htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+				aE_vs_crystal_1p_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(),
+															 set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
+				histlist->Add(aE_vs_crystal_1p_recoil_dc_recoil);
+
+				hname = "aE_vs_crystal_2p_dc_none";
+				htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil with random subtraction;";
+				htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+				aE_vs_crystal_2p_dc_none = new TH2F( hname.data(), htitle.data(),
+													set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
+				histlist->Add(aE_vs_crystal_2p_dc_none);
+
+				hname = "aE_vs_crystal_2p_dc_ejectile";
+				htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
+				htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+				aE_vs_crystal_2p_dc_ejectile = new TH2F( hname.data(), htitle.data(),
+														set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
+				histlist->Add(aE_vs_crystal_2p_dc_ejectile);
+
+				hname = "aE_vs_crystal_2p_dc_recoil";
+				htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
+				htitle += "Crystal ID;Energy [keV];Counts per 0.5 keV per strip";
+				aE_vs_crystal_2p_dc_recoil = new TH2F( hname.data(), htitle.data(),
+													  set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals(), -0.5, set->GetNumberOfMiniballClusters() * set->GetNumberOfMiniballCrystals() - 0.5, GBIN, GMIN, GMAX );
+				histlist->Add(aE_vs_crystal_2p_dc_recoil);
+
+			}
+
+		} // by crystal
+
+		// T1 impact time
+		if( react->HistByT1() ) {
+
+			hname = "aE_ejectile_dc_none_t1";
+			htitle = "Gamma-ray energy with addback, gated on the ejectile, with random subtraction;";
+			htitle += "T1 time [ns];Energy [keV];Counts per keV";
+			aE_ejectile_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+			histlist->Add(aE_ejectile_dc_none_t1);
+
+			hname = "aE_ejectile_dc_ejectile_t1";
+			htitle = "Gamma-ray energy with addback, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "T1 time [ns];Energy [keV];Counts per keV";
+			aE_ejectile_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+			histlist->Add(aE_ejectile_dc_ejectile_t1);
+
+			hname = "aE_ejectile_dc_recoil_t1";
+			htitle = "Gamma-ray energy with addback, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
+			htitle += "T1 time [ns];Energy [keV];Counts per keV";
+			aE_ejectile_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+			histlist->Add(aE_ejectile_dc_recoil_t1);
+
+			hname = "aE_recoil_dc_none_t1";
+			htitle = "Gamma-ray energy with addback, gated on the recoil, with random subtraction;";
+			htitle += "T1 time [ns];Energy [keV];Counts per keV";
+			aE_recoil_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+			histlist->Add(aE_recoil_dc_none_t1);
+
+			hname = "aE_recoil_dc_ejectile_t1";
+			htitle = "Gamma-ray energy with addback, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "T1 time [ns];Energy [keV];Counts per keV";
+			aE_recoil_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+			histlist->Add(aE_recoil_dc_ejectile_t1);
+
+			hname = "aE_recoil_dc_recoil_t1";
+			htitle = "Gamma-ray energy with addback, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
+			htitle += "T1 time [ns];Energy [keV];Counts per eV";
+			aE_recoil_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+			histlist->Add(aE_recoil_dc_recoil_t1);
+
+			// 1p and 2p gamma-ray histograms
+			if( react->HistByMultiplicity() ){
+
+				hname = "aE_1p_ejectile_dc_none_t1";
+				htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, with random subtraction;";
+				htitle += "T1 time [ns];Energy [keV];Counts per keV";
+				aE_1p_ejectile_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+				histlist->Add(aE_1p_ejectile_dc_none_t1);
+
+				hname = "aE_1p_ejectile_dc_ejectile_t1";
+				htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+				htitle += "T1 time [ns];Energy [keV];Counts per keV";
+				aE_1p_ejectile_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+				histlist->Add(aE_1p_ejectile_dc_ejectile_t1);
+
+				hname = "aE_1p_ejectile_dc_recoil_t1";
+				htitle = "Gamma-ray energy with addback, gated on the ejectile, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+				htitle += "T1 time [ns];Energy [keV];Counts per keV";
+				aE_1p_ejectile_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+				histlist->Add(aE_1p_ejectile_dc_recoil_t1);
+
+				hname = "aE_1p_recoil_dc_none_t1";
+				htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, with random subtraction;";
+				htitle += "T1 time [ns];Energy [keV];Counts per keV";
+				aE_1p_recoil_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+				histlist->Add(aE_1p_recoil_dc_none_t1);
+
+				hname = "aE_1p_recoil_dc_ejectile_t1";
+				htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the ejectile with random subtraction;";
+				htitle += "T1 time [ns];Energy [keV];Counts per keV";
+				aE_1p_recoil_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+				histlist->Add(aE_1p_recoil_dc_ejectile_t1);
+
+				hname = "aE_1p_recoil_dc_recoil_t1";
+				htitle = "Gamma-ray energy with addback, gated on the recoil, 1-particle only, Doppler corrected for the recoil with random subtraction;";
+				htitle += "T1 time [ns];Energy [keV];Counts per eV";
+				aE_1p_recoil_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+				histlist->Add(aE_1p_recoil_dc_recoil_t1);
+
+				hname = "aE_2p_dc_none_t1";
+				htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, with random subtraction;";
+				htitle += "Energy [keV];Counts per keV";
+				aE_2p_dc_none_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+				histlist->Add(aE_2p_dc_none_t1);
+
+				hname = "aE_2p_dc_ejectile_t1";
+				htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the ejectile with random subtraction;";
+				htitle += "Energy [keV];Counts per keV";
+				aE_2p_dc_ejectile_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+				histlist->Add(aE_2p_dc_ejectile_t1);
+
+				hname = "aE_2p_dc_recoil_t1";
+				htitle = "Gamma-ray energy with addback, in coincidence with ejectile and recoil, Doppler corrected for the recoil with random subtraction;";
+				htitle += "Energy [keV];Counts per keV";
+				aE_2p_dc_recoil_t1 = new TH2F( hname.data(), htitle.data(), T1BIN, T1MIN, T1MAX, GBIN, GMIN, GMAX );
+				histlist->Add(aE_2p_dc_recoil_t1);
+
+			}
+
+		}
+
+		// Gamma-gamma hists
+		if( react->HistGammaGamma() ) {
+
+			hname = "aaE_ejectile_dc_none";
+			htitle = "Gamma-gamma matrix with addback, gated on the ejectile with random subtraction;";
+			htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
+			aaE_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
+			histlist->Add(aaE_ejectile_dc_none);
+
+			hname = "aaE_ejectile_dc_ejectile";
+			htitle = "Gamma-gamma matrix with addback, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
+			aaE_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
+			histlist->Add(aaE_ejectile_dc_ejectile);
+
+			hname = "aaE_ejectile_dc_recoil";
+			htitle = "Gamma-gamma matrix with addback, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
+			htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
+			aaE_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
+			histlist->Add(aaE_ejectile_dc_recoil);
+
+			hname = "aaE_recoil_dc_none";
+			htitle = "Gamma-gamma matrix with addback, gated on the recoil with random subtraction;";
+			htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
+			aaE_recoil_dc_none = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
+			histlist->Add(aaE_recoil_dc_none);
+
+			hname = "aaE_recoil_dc_ejectile";
+			htitle = "Gamma-gamma matrix with addback, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
+			aaE_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
+			histlist->Add(aaE_recoil_dc_ejectile);
+
+			hname = "aaE_recoil_dc_recoil";
+			htitle = "Gamma-gamma matrix with addback, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
+			htitle += "Gamma-ray Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
+			aaE_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), GBIN, GMIN, GMAX, GBIN, GMIN, GMAX );
+			histlist->Add(aaE_recoil_dc_recoil);
+
+		}
 
 	}
-	
+
 	// Segment phi determination
-	if( react->HistSegmentPhi() ) {
-	
+	if( react->HistSegmentPhi() && react->HistWithoutAddback() ) {
+
 		dirname = "SegmentPhiDetermination";
 		output_file->mkdir( dirname.data() );
 		output_file->cd( dirname.data() );
@@ -1838,78 +1859,86 @@ void MiniballHistogrammer::MakeHists() {
 		eE_vs_recoil_dc_recoil_segment = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, 24, -0.5, 23.5 );
 		histlist->Add(eE_vs_recoil_dc_recoil_segment);
 
-		hname = "egE_ejectile_dc_none";
-		htitle = "Electron-gamma matrix without addback, gated on the ejectile with random subtraction;";
-		htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
-		egE_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
-		histlist->Add(egE_ejectile_dc_none);
+		if( react->HistWithoutAddback() ) {
 
-		hname = "egE_ejectile_dc_ejectile";
-		htitle = "Electron-gamma matrix without addback, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
-		egE_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
-		histlist->Add(egE_ejectile_dc_ejectile);
+			hname = "egE_ejectile_dc_none";
+			htitle = "Electron-gamma matrix without addback, gated on the ejectile with random subtraction;";
+			htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
+			egE_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
+			histlist->Add(egE_ejectile_dc_none);
 
-		hname = "egE_ejectile_dc_recoil";
-		htitle = "Electron-gamma matrix without addback, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
-		htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
-		egE_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
-		histlist->Add(egE_ejectile_dc_recoil);
+			hname = "egE_ejectile_dc_ejectile";
+			htitle = "Electron-gamma matrix without addback, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
+			egE_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
+			histlist->Add(egE_ejectile_dc_ejectile);
 
-		hname = "egE_recoil_dc_none";
-		htitle = "Electron-gamma matrix without addback, gated on the recoil with random subtraction;";
-		htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
-		egE_recoil_dc_none = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
-		histlist->Add(egE_recoil_dc_none);
+			hname = "egE_ejectile_dc_recoil";
+			htitle = "Electron-gamma matrix without addback, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
+			htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
+			egE_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
+			histlist->Add(egE_ejectile_dc_recoil);
 
-		hname = "egE_recoil_dc_ejectile";
-		htitle = "Electron-gamma matrix without addback, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
-		egE_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
-		histlist->Add(egE_recoil_dc_ejectile);
+			hname = "egE_recoil_dc_none";
+			htitle = "Electron-gamma matrix without addback, gated on the recoil with random subtraction;";
+			htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
+			egE_recoil_dc_none = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
+			histlist->Add(egE_recoil_dc_none);
 
-		hname = "egE_recoil_dc_recoil";
-		htitle = "Electron-gamma matrix without addback, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
-		htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
-		egE_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
-		histlist->Add(egE_recoil_dc_recoil);
+			hname = "egE_recoil_dc_ejectile";
+			htitle = "Electron-gamma matrix without addback, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
+			egE_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
+			histlist->Add(egE_recoil_dc_ejectile);
 
-		hname = "eaE_ejectile_dc_none";
-		htitle = "Electron-gamma matrix with addback, gated on the ejectile with random subtraction;";
-		htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
-		eaE_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
-		histlist->Add(eaE_ejectile_dc_none);
+			hname = "egE_recoil_dc_recoil";
+			htitle = "Electron-gamma matrix without addback, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
+			htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
+			egE_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
+			histlist->Add(egE_recoil_dc_recoil);
 
-		hname = "eaE_ejectile_dc_ejectile";
-		htitle = "Electron-gamma matrix with addback, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
-		eaE_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
-		histlist->Add(eaE_ejectile_dc_ejectile);
+		}
 
-		hname = "eaE_ejectile_dc_recoil";
-		htitle = "Electron-gamma matrix with addback, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
-		htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
-		eaE_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
-		histlist->Add(eaE_ejectile_dc_recoil);
+		if( react->HistWithAddback() ) {
 
-		hname = "eaE_recoil_dc_none";
-		htitle = "Electron-gamma matrix with addback, gated on the recoil with random subtraction;";
-		htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
-		eaE_recoil_dc_none = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
-		histlist->Add(eaE_recoil_dc_none);
+			hname = "eaE_ejectile_dc_none";
+			htitle = "Electron-gamma matrix with addback, gated on the ejectile with random subtraction;";
+			htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
+			eaE_ejectile_dc_none = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
+			histlist->Add(eaE_ejectile_dc_none);
 
-		hname = "eaE_recoil_dc_ejectile";
-		htitle = "Electron-gamma matrix with addback, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
-		htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
-		eaE_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
-		histlist->Add(eaE_recoil_dc_ejectile);
+			hname = "eaE_ejectile_dc_ejectile";
+			htitle = "Electron-gamma matrix with addback, gated on the ejectile, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
+			eaE_ejectile_dc_ejectile = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
+			histlist->Add(eaE_ejectile_dc_ejectile);
 
-		hname = "eaE_recoil_dc_recoil";
-		htitle = "Electron-gamma matrix with addback, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
-		htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
-		eaE_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
-		histlist->Add(eaE_recoil_dc_recoil);
+			hname = "eaE_ejectile_dc_recoil";
+			htitle = "Electron-gamma matrix with addback, gated on the ejectile, Doppler corrected for the recoil with random subtraction;";
+			htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
+			eaE_ejectile_dc_recoil = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
+			histlist->Add(eaE_ejectile_dc_recoil);
 
+			hname = "eaE_recoil_dc_none";
+			htitle = "Electron-gamma matrix with addback, gated on the recoil with random subtraction;";
+			htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
+			eaE_recoil_dc_none = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
+			histlist->Add(eaE_recoil_dc_none);
+
+			hname = "eaE_recoil_dc_ejectile";
+			htitle = "Electron-gamma matrix with addback, gated on the recoil, Doppler corrected for the ejectile with random subtraction;";
+			htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
+			eaE_recoil_dc_ejectile = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
+			histlist->Add(eaE_recoil_dc_ejectile);
+
+			hname = "eaE_recoil_dc_recoil";
+			htitle = "Electron-gamma matrix with addback, gated on the recoil, Doppler corrected for the recoil with random subtraction;";
+			htitle += "Electron Energy [keV];Gamma-ray Energy [keV];Counts per 0.5 keV";
+			eaE_recoil_dc_recoil = new TH2F( hname.data(), htitle.data(), EBIN, EMIN, EMAX, GBIN, GMIN, GMAX );
+			histlist->Add(eaE_recoil_dc_recoil);
+
+		}
+		
 	} // electrons on
 
 	// Beam dump histograms
@@ -3128,177 +3157,185 @@ unsigned long MiniballHistogrammer::FillHists() {
 		// ------------------------------------------ //
 		// Loop over gamma-ray events without addback //
 		// ------------------------------------------ //
-		for( unsigned int j = 0; j < read_evts->GetGammaRayMultiplicity(); ++j ){
-						
-			// Get gamma-ray event
-			gamma_evt = read_evts->GetGammaRayEvt(j);
-			
-			// Singles
-			int cry = gamma_evt->GetCrystal() + set->GetNumberOfMiniballCrystals() * gamma_evt->GetCluster();
-			gE_singles->Fill( gamma_evt->GetEnergy() );
-			if( react->HistByCrystal() )
-				gE_singles_vs_crystal->Fill( cry, gamma_evt->GetEnergy() );
+		if( react->HistWithoutAddback() ) {
 
-			// Singles - Doppler corrected
-			gE_singles_dc->Fill( react->DopplerCorrection( gamma_evt, react->GetBeam()->GetBeta(), 0, 0 ) );
-			
-			// EBIS time
-			ebis_td_gamma->Fill( (double)gamma_evt->GetTime() - (double)read_evts->GetEBIS() );
-			
-			// Check for events in the EBIS on-beam window
-			if( OnBeam( gamma_evt ) ){
-				
-				gE_singles_ebis->Fill( gamma_evt->GetEnergy() );
-				gE_singles_ebis_on->Fill( gamma_evt->GetEnergy() );
-				gE_singles_dc_ebis->Fill( react->DopplerCorrection( gamma_evt, react->GetBeam()->GetBeta(), 0, 0 ) );
+			for( unsigned int j = 0; j < read_evts->GetGammaRayMultiplicity(); ++j ){
 
-			} // ebis on
-			
-			else if( OffBeam( gamma_evt ) ){
-				
-				gE_singles_ebis->Fill( gamma_evt->GetEnergy(), -1.0 * react->GetEBISFillRatio() );
-				gE_singles_ebis_off->Fill( gamma_evt->GetEnergy() );
-				gE_singles_dc_ebis->Fill( react->DopplerCorrection( gamma_evt, react->GetBeam()->GetBeta(), 0, 0 ), -1.0 * react->GetEBISFillRatio() );
-
-			} // ebis off
-			
-			// Gamma-ray X-Y hit map
-			if( react->GetGammaZ( gamma_evt ) > 0 )
-				gamma_xy_map_forward->Fill( react->GetGammaY( gamma_evt ), react->GetGammaX( gamma_evt ) );
-			else
-				gamma_xy_map_backward->Fill( react->GetGammaY( gamma_evt ), react->GetGammaX( gamma_evt ) );
-
-			// Gamma-ray X-Z hit map
-			if( react->GetGammaY( gamma_evt ) > 0 )
-				gamma_xz_map_right->Fill( react->GetGammaZ( gamma_evt ), react->GetGammaX( gamma_evt ) );
-			else
-				gamma_xz_map_left->Fill( react->GetGammaZ( gamma_evt ), react->GetGammaX( gamma_evt ) );
-
-			// Gamma-ray theta-phi map
-			double theta = react->GetGammaTheta( gamma_evt );
-			double phi = react->GetGammaPhi( gamma_evt );
-			if( theta < 0 ) theta += TMath::Pi();
-			if( phi < 0 ) phi += TMath::TwoPi();
-			gamma_theta_phi_map->Fill( theta*TMath::RadToDeg(), phi*TMath::RadToDeg() );
-			
-			// Particle-gamma coincidence spectra
-			FillParticleGammaHists( gamma_evt );
-
-			// Loop over other gamma events
-			for( unsigned int k = j+1; k < read_evts->GetGammaRayMultiplicity(); ++k ){
-				
 				// Get gamma-ray event
-				gamma_evt2 = read_evts->GetGammaRayEvt(k);
-				
-				// Time differences - symmetrise
-				gamma_gamma_td->Fill( (double)gamma_evt->GetTime() - (double)gamma_evt2->GetTime() );
-				gamma_gamma_td->Fill( (double)gamma_evt2->GetTime() - (double)gamma_evt->GetTime() );
-				
-				// Particle-gamma-gamma coincidence spectra
-				if( react->HistGammaGamma() ) {
-					
-					// Check for prompt gamma-gamma coincidences
-					if( PromptCoincidence( gamma_evt, gamma_evt2 ) ) {
-						
-						// Fill and symmetrise
-						gE_gE->Fill( gamma_evt->GetEnergy(), gamma_evt2->GetEnergy() );
-						gE_gE->Fill( gamma_evt2->GetEnergy(), gamma_evt->GetEnergy() );
-						
-						// Apply EBIS condition
-						if( OnBeam( gamma_evt ) && OnBeam( gamma_evt2 ) ) {
-							
+				gamma_evt = read_evts->GetGammaRayEvt(j);
+
+				// Singles
+				int cry = gamma_evt->GetCrystal() + set->GetNumberOfMiniballCrystals() * gamma_evt->GetCluster();
+				gE_singles->Fill( gamma_evt->GetEnergy() );
+				if( react->HistByCrystal() )
+					gE_singles_vs_crystal->Fill( cry, gamma_evt->GetEnergy() );
+
+				// Singles - Doppler corrected
+				gE_singles_dc->Fill( react->DopplerCorrection( gamma_evt, react->GetBeam()->GetBeta(), 0, 0 ) );
+
+				// EBIS time
+				ebis_td_gamma->Fill( (double)gamma_evt->GetTime() - (double)read_evts->GetEBIS() );
+
+				// Check for events in the EBIS on-beam window
+				if( OnBeam( gamma_evt ) ){
+
+					gE_singles_ebis->Fill( gamma_evt->GetEnergy() );
+					gE_singles_ebis_on->Fill( gamma_evt->GetEnergy() );
+					gE_singles_dc_ebis->Fill( react->DopplerCorrection( gamma_evt, react->GetBeam()->GetBeta(), 0, 0 ) );
+
+				} // ebis on
+
+				else if( OffBeam( gamma_evt ) ){
+
+					gE_singles_ebis->Fill( gamma_evt->GetEnergy(), -1.0 * react->GetEBISFillRatio() );
+					gE_singles_ebis_off->Fill( gamma_evt->GetEnergy() );
+					gE_singles_dc_ebis->Fill( react->DopplerCorrection( gamma_evt, react->GetBeam()->GetBeta(), 0, 0 ), -1.0 * react->GetEBISFillRatio() );
+
+				} // ebis off
+
+				// Gamma-ray X-Y hit map
+				if( react->GetGammaZ( gamma_evt ) > 0 )
+					gamma_xy_map_forward->Fill( react->GetGammaY( gamma_evt ), react->GetGammaX( gamma_evt ) );
+				else
+					gamma_xy_map_backward->Fill( react->GetGammaY( gamma_evt ), react->GetGammaX( gamma_evt ) );
+
+				// Gamma-ray X-Z hit map
+				if( react->GetGammaY( gamma_evt ) > 0 )
+					gamma_xz_map_right->Fill( react->GetGammaZ( gamma_evt ), react->GetGammaX( gamma_evt ) );
+				else
+					gamma_xz_map_left->Fill( react->GetGammaZ( gamma_evt ), react->GetGammaX( gamma_evt ) );
+
+				// Gamma-ray theta-phi map
+				double theta = react->GetGammaTheta( gamma_evt );
+				double phi = react->GetGammaPhi( gamma_evt );
+				if( theta < 0 ) theta += TMath::Pi();
+				if( phi < 0 ) phi += TMath::TwoPi();
+				gamma_theta_phi_map->Fill( theta*TMath::RadToDeg(), phi*TMath::RadToDeg() );
+
+				// Particle-gamma coincidence spectra
+				FillParticleGammaHists( gamma_evt );
+
+				// Loop over other gamma events
+				for( unsigned int k = j+1; k < read_evts->GetGammaRayMultiplicity(); ++k ){
+
+					// Get gamma-ray event
+					gamma_evt2 = read_evts->GetGammaRayEvt(k);
+
+					// Time differences - symmetrise
+					gamma_gamma_td->Fill( (double)gamma_evt->GetTime() - (double)gamma_evt2->GetTime() );
+					gamma_gamma_td->Fill( (double)gamma_evt2->GetTime() - (double)gamma_evt->GetTime() );
+
+					// Particle-gamma-gamma coincidence spectra
+					if( react->HistGammaGamma() ) {
+
+						// Check for prompt gamma-gamma coincidences
+						if( PromptCoincidence( gamma_evt, gamma_evt2 ) ) {
+
 							// Fill and symmetrise
-							gE_gE_ebis_on->Fill( gamma_evt->GetEnergy(), gamma_evt2->GetEnergy() );
-							gE_gE_ebis_on->Fill( gamma_evt2->GetEnergy(), gamma_evt->GetEnergy() );
-							
-						} // On Beam
-						
-						FillParticleGammaGammaHists( gamma_evt, gamma_evt2 );
-						FillParticleGammaGammaHists( gamma_evt2, gamma_evt );
-						
-					} // if prompt
-					
-				} // gamma-gamma user option on
-				
-			} // k: second gamma-ray
-			
-		} // j: gamma ray
-		
-		
+							gE_gE->Fill( gamma_evt->GetEnergy(), gamma_evt2->GetEnergy() );
+							gE_gE->Fill( gamma_evt2->GetEnergy(), gamma_evt->GetEnergy() );
+
+							// Apply EBIS condition
+							if( OnBeam( gamma_evt ) && OnBeam( gamma_evt2 ) ) {
+
+								// Fill and symmetrise
+								gE_gE_ebis_on->Fill( gamma_evt->GetEnergy(), gamma_evt2->GetEnergy() );
+								gE_gE_ebis_on->Fill( gamma_evt2->GetEnergy(), gamma_evt->GetEnergy() );
+
+							} // On Beam
+
+							FillParticleGammaGammaHists( gamma_evt, gamma_evt2 );
+							FillParticleGammaGammaHists( gamma_evt2, gamma_evt );
+
+						} // if prompt
+
+					} // gamma-gamma user option on
+
+				} // k: second gamma-ray
+
+			} // j: gamma ray
+
+		} // user requests histograms without addback
+
+
 		// --------------------------------------- //
 		// Loop over gamma-ray events with addback //
 		// --------------------------------------- //
-		for( unsigned int j = 0; j < read_evts->GetGammaRayAddbackMultiplicity(); ++j ){
-			
-			// Get gamma-ray event
-			gamma_ab_evt = read_evts->GetGammaRayAddbackEvt(j);
-			
-			// Singles
-			int cry = gamma_ab_evt->GetCrystal() + set->GetNumberOfMiniballCrystals() * gamma_ab_evt->GetCluster();
-			aE_singles->Fill( gamma_ab_evt->GetEnergy() );
-			if( react->HistByCrystal() )
-				aE_singles_vs_crystal->Fill( cry, gamma_ab_evt->GetEnergy() );
+		if( react->HistWithAddback() ) {
 
-			// Singles - Doppler corrected
-			aE_singles_dc->Fill( react->DopplerCorrection( gamma_ab_evt, react->GetBeam()->GetBeta(), 0, 0 ) );
-			
-			// Check for events in the EBIS on-beam window
-			if( OnBeam( gamma_ab_evt ) ){
-				
-				aE_singles_ebis->Fill( gamma_ab_evt->GetEnergy() );
-				aE_singles_ebis_on->Fill( gamma_ab_evt->GetEnergy() );
-				aE_singles_dc_ebis->Fill( react->DopplerCorrection( gamma_ab_evt, react->GetBeam()->GetBeta(), 0, 0 ) );
+			for( unsigned int j = 0; j < read_evts->GetGammaRayAddbackMultiplicity(); ++j ){
 
-			} // ebis on
-			
-			else if( OffBeam( gamma_ab_evt ) ){
-				
-				aE_singles_ebis->Fill( gamma_ab_evt->GetEnergy(), -1.0 * react->GetEBISFillRatio() );
-				aE_singles_ebis_off->Fill( gamma_ab_evt->GetEnergy() );
-				aE_singles_dc_ebis->Fill( react->DopplerCorrection( gamma_ab_evt, react->GetBeam()->GetBeta(), 0, 0 ), -1.0 * react->GetEBISFillRatio() );
+				// Get gamma-ray event
+				gamma_ab_evt = read_evts->GetGammaRayAddbackEvt(j);
 
-			} // ebis off
-			
-			// Particle-gamma coincidence spectra
-			FillParticleGammaHists( gamma_ab_evt );
-			
-			// If gamma-gamma histograms are turned on
-			if( react->HistGammaGamma() ) {
-				
-				// Loop over other gamma events
-				for( unsigned int k = j+1; k < read_evts->GetGammaRayAddbackMultiplicity(); ++k ){
-					
-					// Get gamma-ray event
-					gamma_ab_evt2 = read_evts->GetGammaRayAddbackEvt(k);
-					
-					// Check for prompt gamma-gamma coincidences
-					if( PromptCoincidence( gamma_ab_evt, gamma_ab_evt2 ) ) {
-						
-						// Fill and symmetrise
-						aE_aE->Fill( gamma_ab_evt->GetEnergy(), gamma_ab_evt2->GetEnergy() );
-						aE_aE->Fill( gamma_ab_evt2->GetEnergy(), gamma_ab_evt->GetEnergy() );
-						
-						// Apply EBIS condition
-						if( OnBeam( gamma_ab_evt ) && OnBeam( gamma_ab_evt2 ) ) {
-							
+				// Singles
+				int cry = gamma_ab_evt->GetCrystal() + set->GetNumberOfMiniballCrystals() * gamma_ab_evt->GetCluster();
+				aE_singles->Fill( gamma_ab_evt->GetEnergy() );
+				if( react->HistByCrystal() )
+					aE_singles_vs_crystal->Fill( cry, gamma_ab_evt->GetEnergy() );
+
+				// Singles - Doppler corrected
+				aE_singles_dc->Fill( react->DopplerCorrection( gamma_ab_evt, react->GetBeam()->GetBeta(), 0, 0 ) );
+
+				// Check for events in the EBIS on-beam window
+				if( OnBeam( gamma_ab_evt ) ){
+
+					aE_singles_ebis->Fill( gamma_ab_evt->GetEnergy() );
+					aE_singles_ebis_on->Fill( gamma_ab_evt->GetEnergy() );
+					aE_singles_dc_ebis->Fill( react->DopplerCorrection( gamma_ab_evt, react->GetBeam()->GetBeta(), 0, 0 ) );
+
+				} // ebis on
+
+				else if( OffBeam( gamma_ab_evt ) ){
+
+					aE_singles_ebis->Fill( gamma_ab_evt->GetEnergy(), -1.0 * react->GetEBISFillRatio() );
+					aE_singles_ebis_off->Fill( gamma_ab_evt->GetEnergy() );
+					aE_singles_dc_ebis->Fill( react->DopplerCorrection( gamma_ab_evt, react->GetBeam()->GetBeta(), 0, 0 ), -1.0 * react->GetEBISFillRatio() );
+
+				} // ebis off
+
+				// Particle-gamma coincidence spectra
+				FillParticleGammaHists( gamma_ab_evt );
+
+				// If gamma-gamma histograms are turned on
+				if( react->HistGammaGamma() ) {
+
+					// Loop over other gamma events
+					for( unsigned int k = j+1; k < read_evts->GetGammaRayAddbackMultiplicity(); ++k ){
+
+						// Get gamma-ray event
+						gamma_ab_evt2 = read_evts->GetGammaRayAddbackEvt(k);
+
+						// Check for prompt gamma-gamma coincidences
+						if( PromptCoincidence( gamma_ab_evt, gamma_ab_evt2 ) ) {
+
 							// Fill and symmetrise
-							aE_aE_ebis_on->Fill( gamma_ab_evt->GetEnergy(), gamma_ab_evt2->GetEnergy() );
-							aE_aE_ebis_on->Fill( gamma_ab_evt2->GetEnergy(), gamma_ab_evt->GetEnergy() );
-							
-						} // On Beam
-						
-						// Particle-gamma-gamma coincidence spectra
-						FillParticleGammaGammaHists( gamma_ab_evt, gamma_ab_evt2 );
-						FillParticleGammaGammaHists( gamma_ab_evt2, gamma_ab_evt );
-						
-					} // if prompt
-					
-				} // k: second gamma-ray
-				
-			} // gamma-gamma user option on
-			
-		} // j: gamma ray
-		
+							aE_aE->Fill( gamma_ab_evt->GetEnergy(), gamma_ab_evt2->GetEnergy() );
+							aE_aE->Fill( gamma_ab_evt2->GetEnergy(), gamma_ab_evt->GetEnergy() );
+
+							// Apply EBIS condition
+							if( OnBeam( gamma_ab_evt ) && OnBeam( gamma_ab_evt2 ) ) {
+
+								// Fill and symmetrise
+								aE_aE_ebis_on->Fill( gamma_ab_evt->GetEnergy(), gamma_ab_evt2->GetEnergy() );
+								aE_aE_ebis_on->Fill( gamma_ab_evt2->GetEnergy(), gamma_ab_evt->GetEnergy() );
+
+							} // On Beam
+
+							// Particle-gamma-gamma coincidence spectra
+							FillParticleGammaGammaHists( gamma_ab_evt, gamma_ab_evt2 );
+							FillParticleGammaGammaHists( gamma_ab_evt2, gamma_ab_evt );
+
+						} // if prompt
+
+					} // k: second gamma-ray
+
+				} // gamma-gamma user option on
+
+			} // j: gamma ray
+
+		} // user requests histograms with addback
+
 
 		// ---------------------------------- //
 		// Loop over electron events in SPEDE //
@@ -3368,44 +3405,49 @@ unsigned long MiniballHistogrammer::FillHists() {
 				} // k: second electron
 				
 				// Loop over gamma events
-				for( unsigned int k = 0; k < read_evts->GetGammaRayMultiplicity(); ++k ){
-					
-					// Get gamma-ray event
-					gamma_evt = read_evts->GetGammaRayEvt(k);
-					
-					// Time differences
-					gamma_electron_td->Fill( (double)spede_evt->GetTime() - (double)gamma_evt->GetTime() );
-					gamma_electron_td->Fill( (double)gamma_evt->GetTime() - (double)spede_evt->GetTime() );
-					
-					// If electron-gamma histograms are turned on
-					if( react->HistElectronGamma() ) {
-						
-						// Check for prompt gamma-electron coincidences
-						if( PromptCoincidence( gamma_evt, spede_evt ) ) {
-							
-							// Fill
-							gE_eE->Fill( gamma_evt->GetEnergy(), spede_evt->GetEnergy() );
-							
-							// Apply EBIS condition
-							if( OnBeam( gamma_evt ) && OnBeam( spede_evt ) ) {
-								
+				// If electron-gamma and gamma without addback histograms are turned on
+				if( react->HistElectronGamma() && react->HistWithoutAddback() ) {
+
+					for( unsigned int k = 0; k < read_evts->GetGammaRayMultiplicity(); ++k ){
+
+						// Get gamma-ray event
+						gamma_evt = read_evts->GetGammaRayEvt(k);
+
+						// Time differences
+						gamma_electron_td->Fill( (double)spede_evt->GetTime() - (double)gamma_evt->GetTime() );
+						gamma_electron_td->Fill( (double)gamma_evt->GetTime() - (double)spede_evt->GetTime() );
+
+						// If electron-gamma histograms are turned on
+						if( react->HistElectronGamma() ) {
+
+							// Check for prompt gamma-electron coincidences
+							if( PromptCoincidence( gamma_evt, spede_evt ) ) {
+
 								// Fill
-								gE_eE_ebis_on->Fill( gamma_evt->GetEnergy(), spede_evt->GetEnergy() );
-								
-							} // On Beam
-							
-							// Particle-electron-gamma coincidence spectra
-							FillParticleElectronGammaHists( spede_evt, gamma_evt );
-							
-						} // if prompt
-						
-					} // electron-gamma user option
-					
-				} // k: gamma without addback
-				
-				// If electron-gamma histograms are turned on
-				if( react->HistElectronGamma() ) {
-					
+								gE_eE->Fill( gamma_evt->GetEnergy(), spede_evt->GetEnergy() );
+
+								// Apply EBIS condition
+								if( OnBeam( gamma_evt ) && OnBeam( spede_evt ) ) {
+
+									// Fill
+									gE_eE_ebis_on->Fill( gamma_evt->GetEnergy(), spede_evt->GetEnergy() );
+
+								} // On Beam
+
+								// Particle-electron-gamma coincidence spectra
+								FillParticleElectronGammaHists( spede_evt, gamma_evt );
+
+							} // if prompt
+
+						} // electron-gamma user option
+
+					} // k: gamma without addback
+
+				} // // electron-gamma user option
+
+				// If electron-gamma and addback histograms are turned on
+				if( react->HistElectronGamma() && react->HistWithAddback() ) {
+
 					// Loop over gamma addback events
 					for( unsigned int k = 0; k < read_evts->GetGammaRayAddbackMultiplicity(); ++k ){
 						

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -1743,6 +1743,9 @@ void MiniballHistogrammer::PlotPhysicsHists() {
 
 	}
 
+	// Write once
+	output_file->Write();
+
 	return;
 
 }
@@ -1757,8 +1760,6 @@ void MiniballHistogrammer::ResetHist( TObject *obj ) {
 		( (TH1*)obj )->Reset("ICESM");
 	else if( obj->InheritsFrom( "TH2" ) )
 		( (TH2*)obj )->Reset("ICESM");
-	else if( obj->InheritsFrom( "TProfile" ) )
-		( (TProfile*)obj )->Reset("ICESM");
 
 	return;
 
@@ -1771,12 +1772,12 @@ void MiniballHistogrammer::ResetHists(){
 	TIter keyList1( output_file->GetListOfKeys() );
 	while( ( key1 = (TKey*)keyList1() ) ){ // level 1
 
-		if( key1->InheritsFrom( "TDirectory" ) ){
+		if( key1->ReadObj()->InheritsFrom("TDirectory") ){
 
 			TIter keyList2( ( (TDirectory*)key1->ReadObj() )->GetListOfKeys() );
 			while( ( key2 = (TKey*)keyList2() ) ){ // level 2
 
-				if( key1->InheritsFrom( "TDirectory" ) ){
+				if( key1->ReadObj()->InheritsFrom("TDirectory") ){
 
 					TIter keyList3( ( (TDirectory*)key2->ReadObj() )->GetListOfKeys() );
 					while( ( key3 = (TKey*)keyList3() ) ) // level 3

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -1687,7 +1687,16 @@ void MiniballHistogrammer::MakeHists() {
 	
 }
 
-void MiniballHistogrammer::PlotPhysicsHists( std::vector<std::vector<std::string>> hists, short layout[2] ) {
+void MiniballHistogrammer::SetSpyHists( std::vector<std::vector<std::string>> hists, short layout[2] ) {
+
+	// Copy the input hists and layouts
+	spyhists = hists;
+	spylayout[0] = layout[0];
+	spylayout[1] = layout[1];
+
+}
+
+void MiniballHistogrammer::PlotPhysicsHists() {
 
 	// Escape if we haven't built the hists to avoid a seg fault
 	if( !hists_ready ){
@@ -1698,20 +1707,20 @@ void MiniballHistogrammer::PlotPhysicsHists( std::vector<std::vector<std::string
 	}
 
 	// Get appropriate layout and number of hists
-	unsigned short maxhists = layout[0] * layout[1];
+	unsigned short maxhists = spylayout[0] * spylayout[1];
 	if( maxhists == 0 ) maxhists = 1;
-	if( hists.size() > maxhists ) {
+	if( spyhists.size() > maxhists ) {
 
 		std::cout << "Too many histograms for layout size. Plotting the first ";
 		std::cout << maxhists << " histograms in the list." << std::endl;
 
 	}
-	else maxhists = hists.size();
+	else maxhists = spyhists.size();
 
 	// Clear and divide canvas
 	cspy->Clear("D");
-	if( maxhists > 1 && layout[0] > 0 && layout[1] > 0 )
-		cspy->Divide( layout[0], layout[1] );
+	if( maxhists > 1 && spylayout[0] > 0 && spylayout[1] > 0 )
+		cspy->Divide( spylayout[0], spylayout[1] );
 
 	// ASIC time difference histograms
 	for( unsigned int i = 0; i < maxhists; i++ ){
@@ -1720,17 +1729,17 @@ void MiniballHistogrammer::PlotPhysicsHists( std::vector<std::vector<std::string
 		cspy->cd(i+1);
 
 		// Get this histogram of the right type
-		if( hists[i][0] == "TH1" )
-			static_cast<TH1*>( output_file->Get( hists[i][1].data() ) )->Draw( hists[i][2].data() );
+		if( spyhists[i][1] == "TH1" )
+			static_cast<TH1*>( output_file->Get( spyhists[i][0].data() ) )->Draw( spyhists[i][2].data() );
 
-		else if( hists[i][0] == "TH2" )
-			static_cast<TH1*>( output_file->Get( hists[i][1].data() ) )->Draw( hists[i][2].data() );
+		else if( spyhists[i][1] == "TH2" )
+			static_cast<TH1*>( output_file->Get( spyhists[i][0].data() ) )->Draw( spyhists[i][2].data() );
 
-		else if( hists[i][0] == "TProfile" )
-			static_cast<TProfile*>( output_file->Get( hists[i][1].data() ) )->Draw( hists[i][2].data() );
+		else if( spyhists[i][1] == "TProfile" )
+			static_cast<TProfile*>( output_file->Get( spyhists[i][0].data() ) )->Draw( spyhists[i][2].data() );
 
 		else
-			std::cout << "Type " << hists[i][0] << " not currently supported" << std::endl;
+			std::cout << "Type " << spyhists[i][1] << " not currently supported" << std::endl;
 
 	}
 

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -1700,7 +1700,7 @@ void MiniballHistogrammer::PlotDefaultHists() {
 	c1->cd(1);
 	gE_singles->Draw("hist");
 	c1->cd(2);
-	c1->GetPad(2)->SetLogz()
+	c1->GetPad(2)->SetLogz();
 	pE_theta->Draw("colz");
 	c1->cd(3);
 	ebis_td_particle->Draw();

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -1684,7 +1684,7 @@ void MiniballHistogrammer::MakeHists() {
 	hists_ready = true;
 
 	// Write hists once at the start
-	//output_file->Write();
+	output_file->Write();
 
 	return;
 	
@@ -1779,9 +1779,6 @@ void MiniballHistogrammer::PlotPhysicsHists() {
 		else std::cout << "Type " << spyhists[i][1] << " not currently supported" << std::endl;
 
 	}
-
-	// Write once
-	//output_file->Write();
 
 	return;
 

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -1747,7 +1747,7 @@ void MiniballHistogrammer::PlotPhysicsHists() {
 	// Make the canvas
 	c2 = std::make_unique<TCanvas>("c2","User hists");
 	if( maxhists > 1 && spylayout[0] > 0 && spylayout[1] > 0 )
-		cspy->Divide( spylayout[0], spylayout[1] );
+		c2->Divide( spylayout[0], spylayout[1] );
 
 	// ASIC time difference histograms
 	for( unsigned int i = 0; i < maxhists; i++ ){

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -2018,6 +2018,10 @@ void MiniballHistogrammer::PlotDefaultHists() {
 	// Check that we're ready
 	if( !hists_ready ) return;
 
+	// Because we have the spy, we turn off the error tracking
+	// on the histograms so that the default draw option is "hist"
+	TH1::SetDefaultSumw2(kFALSE);
+
 	// Make the canvas
 	c1 = std::make_unique<TCanvas>("Diagnostics","Monitor hists");
 	c1->Divide(2,3);

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -1683,6 +1683,9 @@ void MiniballHistogrammer::MakeHists() {
 	// flag to denote that hists are ready (used for spy)
 	hists_ready = true;
 
+	// Write hists once at the start
+	output_file->Write();
+
 	return;
 	
 }
@@ -1754,13 +1757,13 @@ void MiniballHistogrammer::PlotPhysicsHists() {
 
 		// Get this histogram of the right type
 		if( spyhists[i][1] == "TH1" )
-			static_cast<TH1*>( output_file->Get( spyhists[i][0].data() ) )->Draw( spyhists[i][2].data() );
+			static_cast<TH1*>( gDirectory->Get( spyhists[i][0].data() ) )->Draw( spyhists[i][2].data() );
 
 		else if( spyhists[i][1] == "TH2" )
-			static_cast<TH1*>( output_file->Get( spyhists[i][0].data() ) )->Draw( spyhists[i][2].data() );
+			static_cast<TH1*>( gDirectory->Get( spyhists[i][0].data() ) )->Draw( spyhists[i][2].data() );
 
 		else if( spyhists[i][1] == "TProfile" )
-			static_cast<TProfile*>( output_file->Get( spyhists[i][0].data() ) )->Draw( spyhists[i][2].data() );
+			static_cast<TProfile*>( gDirectory->Get( spyhists[i][0].data() ) )->Draw( spyhists[i][2].data() );
 
 		else
 			std::cout << "Type " << spyhists[i][1] << " not currently supported" << std::endl;

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -164,44 +164,6 @@ void MiniballHistogrammer::MakeHists() {
 		gE_singles_dc_ebis = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
 		histlist->Add(gE_singles_dc_ebis);
 
-		hname = "aE_singles";
-		htitle = "Gamma-ray energy with addback singles;Energy [keV];Counts per 0.5 keV";
-		aE_singles = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		histlist->Add(aE_singles);
-
-		if( react->HistByCrystal() ) {
-
-			hname = "aE_singles_vs_crystal";
-			htitle = "Gamma-ray energy with addback singles versus crystal ID;Crystal ID;Energy [keV];Counts per 0.5 keV";
-			aE_singles_vs_crystal = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
-			histlist->Add(aE_singles_vs_crystal);
-
-		}
-		hname = "aE_singles_ebis";
-		htitle = "Gamma-ray energy with addback singles EBIS on-off;Energy [keV];Counts per 0.5 keV";
-		aE_singles_ebis = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		histlist->Add(aE_singles_ebis);
-
-		hname = "aE_singles_ebis_on";
-		htitle = "Gamma-ray energy with addback singles EBIS on;Energy [keV];Counts per 0.5 keV";
-		aE_singles_ebis_on = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		histlist->Add(aE_singles_ebis_on);
-
-		hname = "aE_singles_ebis_off";
-		htitle = "Gamma-ray energy with addback singles EBIS off;Energy [keV];Counts per 0.5 keV";
-		aE_singles_ebis_off = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		histlist->Add(aE_singles_ebis_off);
-
-		hname = "aE_singles_dc";
-		htitle = "Gamma-ray energy with addback singles, Doppler corrected for unscattered beam;Energy [keV];Counts per 0.5 keV";
-		aE_singles_dc = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		histlist->Add(aE_singles_dc);
-
-		hname = "aE_singles_dc_ebis";
-		htitle = "Gamma-ray energy with addback singles, Doppler corrected for unscattered beam, EBIS on-off;Energy [keV];Counts per 0.5 keV";
-		aE_singles_dc_ebis = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
-		histlist->Add(aE_singles_dc_ebis);
-
 		hname = "gamma_xy_map_forward";
 		htitle = "Gamma-ray X-Y hit map (forward: z > 0);y (horizontal) [mm];x (vertical) [mm];Counts";
 		gamma_xy_map_forward = new TH2F( hname.data(), htitle.data(), 201, -201., 201., 201, -201., 201. );
@@ -228,6 +190,51 @@ void MiniballHistogrammer::MakeHists() {
 		histlist->Add(gamma_theta_phi_map);
 
 	}
+
+	// Gamma-ray addback singles histograms
+	if( react->HistWithAddback() ) {
+
+		hname = "aE_singles";
+		htitle = "Gamma-ray energy with addback singles;Energy [keV];Counts per 0.5 keV";
+		aE_singles = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(aE_singles);
+
+		if( react->HistByCrystal() ) {
+
+			hname = "aE_singles_vs_crystal";
+			htitle = "Gamma-ray energy with addback singles versus crystal ID;Crystal ID;Energy [keV];Counts per 0.5 keV";
+			aE_singles_vs_crystal = new TH2F( hname.data(), htitle.data(), ncry, -0.5, ncry-0.5, GBIN, GMIN, GMAX );
+			histlist->Add(aE_singles_vs_crystal);
+
+		}
+
+		hname = "aE_singles_ebis";
+		htitle = "Gamma-ray energy with addback singles EBIS on-off;Energy [keV];Counts per 0.5 keV";
+		aE_singles_ebis = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(aE_singles_ebis);
+
+		hname = "aE_singles_ebis_on";
+		htitle = "Gamma-ray energy with addback singles EBIS on;Energy [keV];Counts per 0.5 keV";
+		aE_singles_ebis_on = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(aE_singles_ebis_on);
+
+		hname = "aE_singles_ebis_off";
+		htitle = "Gamma-ray energy with addback singles EBIS off;Energy [keV];Counts per 0.5 keV";
+		aE_singles_ebis_off = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(aE_singles_ebis_off);
+
+		hname = "aE_singles_dc";
+		htitle = "Gamma-ray energy with addback singles, Doppler corrected for unscattered beam;Energy [keV];Counts per 0.5 keV";
+		aE_singles_dc = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(aE_singles_dc);
+
+		hname = "aE_singles_dc_ebis";
+		htitle = "Gamma-ray energy with addback singles, Doppler corrected for unscattered beam, EBIS on-off;Energy [keV];Counts per 0.5 keV";
+		aE_singles_dc_ebis = new TH1F( hname.data(), htitle.data(), GBIN, GMIN, GMAX );
+		histlist->Add(aE_singles_dc_ebis);
+
+	}
+
 
 	// Gamma-ray coincidence histograms
 	dirname = "CoincidenceMatrices";
@@ -2129,8 +2136,10 @@ void MiniballHistogrammer::ResetHists(){
 	TIter next( histlist->MakeIterator() );
 	while( TObject *obj = next() ) {
 
-		if( obj->InheritsFrom( "TH2" ) )
+		if( obj->InheritsFrom( "TH2" ) ) {
 			( (TH2*)obj )->Reset("ICESM");
+			( (TH2*)obj )->GetZaxis()->UnZoom();
+		}
 		else if( obj->InheritsFrom( "TH1" ) )
 			( (TH1*)obj )->Reset("ICESM");
 

--- a/src/Histogrammer.cc
+++ b/src/Histogrammer.cc
@@ -1684,7 +1684,7 @@ void MiniballHistogrammer::MakeHists() {
 	hists_ready = true;
 
 	// Write hists once at the start
-	output_file->Write();
+	//output_file->Write();
 
 	return;
 	
@@ -1749,24 +1749,34 @@ void MiniballHistogrammer::PlotPhysicsHists() {
 	if( maxhists > 1 && spylayout[0] > 0 && spylayout[1] > 0 )
 		c2->Divide( spylayout[0], spylayout[1] );
 
-	// ASIC time difference histograms
+	// User defined histograms
+	std::vector<std::unique_ptr<TH1F>>> ptr_th1;
+	std::vector<std::unique_ptr<TH2F>>> ptr_th2;
 	for( unsigned int i = 0; i < maxhists; i++ ){
 
 		// Go to corresponding canvas
 		c2->cd(i+1);
 
+		std::cout << spyhists[i][0] << "\t" <<  spyhists[i][1] << "\t" <<  spyhists[i][2] << std::endl;
+
 		// Get this histogram of the right type
-		if( spyhists[i][1] == "TH1" )
-			static_cast<TH1*>( gDirectory->Get( spyhists[i][0].data() ) )->Draw( spyhists[i][2].data() );
+		if( spyhists[i][1] == "TH1" || spyhists[i][1] == "TH1F" || spyhists[i][1] == "TH1D" ) {
 
-		else if( spyhists[i][1] == "TH2" )
-			static_cast<TH1*>( gDirectory->Get( spyhists[i][0].data() ) )->Draw( spyhists[i][2].data() );
+			ptr_th1.push_back( static_cast<TH1*>( gDirectory->Get( spyhists[i][0].data() ) ) );
+			if( ptr_th1.back().get() != nullptr )
+				ptr_th1.back()->Draw( spyhists[i][2].data() );
 
-		else if( spyhists[i][1] == "TProfile" )
-			static_cast<TProfile*>( gDirectory->Get( spyhists[i][0].data() ) )->Draw( spyhists[i][2].data() );
+		}
 
-		else
-			std::cout << "Type " << spyhists[i][1] << " not currently supported" << std::endl;
+		else if( spyhists[i][1] == "TH2" || spyhists[i][1] == "TH2F" || spyhists[i][1] == "TH2D" ) {
+
+			ptr_th2.push_back( static_cast<TH2*>( gDirectory->Get( spyhists[i][0].data() ) ) );
+			if( ptr_th2.back().get() != nullptr )
+				ptr_th2.back()->Draw( spyhists[i][2].data() );
+
+		}
+
+		else std::cout << "Type " << spyhists[i][1] << " not currently supported" << std::endl;
 
 	}
 
@@ -1783,10 +1793,10 @@ void MiniballHistogrammer::ResetHist( TObject *obj ) {
 
 	if( obj == nullptr ) return;
 
-	if( obj->InheritsFrom( "TH1" ) )
-		( (TH1*)obj )->Reset("ICESM");
-	else if( obj->InheritsFrom( "TH2" ) )
+	if( obj->InheritsFrom( "TH2" ) )
 		( (TH2*)obj )->Reset("ICESM");
+	else if( obj->InheritsFrom( "TH1" ) )
+		( (TH1*)obj )->Reset("ICESM");
 
 	return;
 
@@ -1796,7 +1806,7 @@ void MiniballHistogrammer::ResetHist( TObject *obj ) {
 void MiniballHistogrammer::ResetHists(){
 
 	TKey *key1, *key2, *key3;
-	TIter keyList1( output_file->GetListOfKeys() );
+	TIter keyList1( gDirectory->GetListOfKeys() );
 	while( ( key1 = (TKey*)keyList1() ) ){ // level 1
 
 		if( key1->ReadObj()->InheritsFrom("TDirectory") ){

--- a/src/Reaction.cc
+++ b/src/Reaction.cc
@@ -202,6 +202,8 @@ void MiniballReaction::ReadReaction() {
 	events_particle_cdpad_veto  = config->GetValue( "Events.CdPadVeto", false );			// only do histogramming for particles without CD-Pad coincidences (Pad as veto)
 
 	// Histogram options
+	hist_wo_addback = config->GetValue( "Histograms.WithoutAddback", true );	// turn on histograms for gamma-rays without addback
+	hist_w_addback = config->GetValue( "Histograms.WithAddback", false );	// turn on histograms for gamma-rays with addback
 	hist_segment_phi = config->GetValue( "Histograms.SegmentPhi", false );	// turn on histograms for segment phi
 	hist_by_crystal = config->GetValue( "Histograms.ByCrystal", false );	// turn on histograms for gamma-gamma
 	hist_by_pmult = config->GetValue( "Histograms.ByMultiplicity", false );	// turn on particle-gamma(-electron) spectra by multiplicity, i.e. 1p and 2p spectra

--- a/src/Reaction.cc
+++ b/src/Reaction.cc
@@ -373,7 +373,7 @@ void MiniballReaction::ReadReaction() {
 
 	if( degrader_thickness > 0 ) {
 
-		std::cout << "A " << degrader_material << " of " << degrader_thickness;
+		std::cout << "A " << degrader_material << " degrader of " << degrader_thickness;
 		std::cout << " mg/cm2 has been included. Doppler correction will be performed";
 		if( doppler_mode == 0 || doppler_mode == 1 || doppler_mode == 5 )
 			std::cout << " BEFORE the degrader";


### PR DESCRIPTION
Changes to the DataSpy mainly, but also added a switch to the reaction file to only plot histograms with and/or without addback. This reduces the memory pressure and speeds up sorting in case people online only want to look at one of these. Especially useful in the spy. 

It also introduces some Canvases for the spy and the ability for users to decide which histograms to plot with an input file given with the -spyhists option. 

Other minor bug fixes too. 