### PR TITLE
Fix warnings

### DIFF
--- a/src/CDCalibrator.cc
+++ b/src/CDCalibrator.cc
@@ -503,9 +503,9 @@ void MiniballCDCalibrator::CalibrateNsides() {
 					cal_base = "adc_";
 					if( !FindCDChannels( i, j, 1, k, fmod, fch ) )
 					   continue;
-					   modchstr = std::to_string(fmod) + "_" + std::to_string(fch);
+					modchstr = std::to_string(fmod) + "_" + std::to_string(fch);
 
-					   } // old DAQ
+				} // old DAQ
 
 				else {
 					

--- a/src/MedConverter.cc
+++ b/src/MedConverter.cc
@@ -105,12 +105,6 @@ void MiniballMedConverter::ProcessMesytecAdcData() {
 		// If format is fine, we have the word count in here
 		int wc = (header & MESYTEC_MADC_WORD_COUNT);
 
-		// Is module number ok? If not, get next item
-		if( mod < 0 ) {
-			i += wc * 2; // skip rest of event (2 shorts per word)
-			continue;
-		}
-
 		// check number of Channels (MESYTEC_MADC_NBOFCHAN=32 + 1 word End of Event + 1 extended timestamp)
 		// -> skip TOTAL subevent if wrong number of Channels
 		if( wc <= 0 || wc > (int)set->GetNumberOfMesytecAdcChannels() + 2 ) {
@@ -564,7 +558,6 @@ void MiniballMedConverter::ProcessDgfData() {
 		// beam dump module has format 'COMP3_LM_BUFFORMAT'
 		// determine corrected module number
 		mod = set->GetDgfModuleNumber( mod );
-		if( mod < 0 ) return;
 
 		// Work out what type of DGF event we have
 		int DgfType = mbs_sevt->GetSubEventType() - XIA_EVENT;

--- a/src/MidasConverter.cc
+++ b/src/MidasConverter.cc
@@ -712,7 +712,7 @@ void MiniballMidasConverter::FinishFebexData( long nblock ){
 
 }
 
-void MiniballMidasConverter::ProcessInfoData( long nblock ){
+void MiniballMidasConverter::ProcessInfoData( long /* nblock */ ){
 
 	// Module number from MIDAS
 	my_sfp_id	= (word_0 >> 28) & 0x0003; // bits 28:29

--- a/src/MiniballAngleFitter.cc
+++ b/src/MiniballAngleFitter.cc
@@ -120,8 +120,8 @@ void MiniballAngleFunction::FitSegmentEnergies( TFile *infile ){
 	std::string hname, folder = "/miniball/cluster_", base = "mb_en_core_seg_";
 	
 	// Histogram objects
-	TH1D *h1;
-	TH2D *h2;
+	TH1D *h1 = nullptr;
+	TH2D *h2 = nullptr;
 	
 	// Open the pdf file for peak fits
 	auto c1 = std::make_unique<TCanvas>();
@@ -186,8 +186,8 @@ void MiniballAngleFunction::FitSegmentEnergies( TFile *infile ){
 	c1->Print("peak_fits.pdf)");
 
 	// Clean up
-	delete h1;
-	delete h2;
+	if (h1) delete h1;
+	if (h2) delete h2;
 
 	gErrorIgnoreLevel = kInfo;
 

--- a/src/Reaction.cc
+++ b/src/Reaction.cc
@@ -285,7 +285,7 @@ void MiniballReaction::ReadReaction() {
 	cd_dist.resize( set->GetNumberOfCDDetectors() );
 	cd_offset.resize( set->GetNumberOfCDDetectors() );
 	dead_layer.resize( set->GetNumberOfCDDetectors() );
-	double d_tmp;
+	double d_tmp = 0;
 	for( unsigned int i = 0; i < set->GetNumberOfCDDetectors(); ++i ) {
 
 		if( i == 0 ) d_tmp = 32.0; // standard CD
@@ -1040,7 +1040,7 @@ void MiniballReaction::CalculateRecoil(){
 
 }
 
-void MiniballReaction::TransferProduct( std::shared_ptr<ParticleEvt> p, bool kinflag ){
+void MiniballReaction::TransferProduct( std::shared_ptr<ParticleEvt> p, bool /* kinflag */ ){
 
 	/// Set the ejectile particle and calculate the centre of mass angle too
 	/// @param kinflag kinematics flag such that true is the backwards solution (i.e. CoM > 90 deg)
@@ -1103,9 +1103,9 @@ void MiniballReaction::TransferProduct( std::shared_ptr<ParticleEvt> p, bool kin
 	// Lets check E4_CoM also with lorentz transfrom
 	//double E4_CoM = Recoil.GetEnergyTotCM(); This is only calculated from projectile = target -> bad
 	double E4_CoM = GetGammaCoM()*(Recoil.GetEnergyTot() - GetBetaCoM() * p4x);
-	double p4x_CoM = GetGammaCoM()*(p4x - GetBetaCoM() * Recoil.GetEnergyTot());
-	double p4y_CoM = p4y;
-	double theta4_CoM = TMath::ATan2(p4y_CoM, p4x_CoM);
+//	double p4x_CoM = GetGammaCoM()*(p4x - GetBetaCoM() * Recoil.GetEnergyTot());
+//	double p4y_CoM = p4y;
+//	double theta4_CoM = TMath::ATan2(p4y_CoM, p4x_CoM);
 
 	Ejectile.SetEnergyCoM(E3_CoM - Ejectile.GetMass() ); // Energy of the ejectile in CoM frame
 	Ejectile.SetThetaCoM(theta3_CoM); // theta of ejectile in CoM frame in radians


### PR DESCRIPTION
A few warnings that were annoying me:
- in one place an unsigned variable is tested if it is < 0
- in two places there's an unused parameter to a function, which has a name
- in one place there's a couple of pointers which don't have a default initialisation and then have delete applied to them
- in one place there's some dodgy indentation