### PR TITLE
User defined energy range for CDCalibrator

### DIFF
--- a/include/Settings.hh
+++ b/include/Settings.hh
@@ -261,6 +261,7 @@ public:
 		return GetCDID( sfp, board, ch, cd_strip );
 	};
 	inline double GetCDHitWindow(){ return cd_hit_window; };
+	inline double GetCDCalibratorMaxEnergy(){ return cd_calibrator_max_energy; };
 	
 	
 	// Pad detector
@@ -358,6 +359,9 @@ private:
 	unsigned int n_cd_side;			///< number of sides, it's always 2, i.e. p-side and n-side
 	unsigned int n_cd_pstrip;		///< number of p-side strips
 	unsigned int n_cd_nstrip;		///< number of n-side strips
+
+	// CD calibration settings
+	double cd_calibrator_max_energy;	///< Max energy to fill spectra to calibrate CD strips with CD calibrator; default is 2000e3 keV
 
 	// CD electronics mapping
 	std::vector<std::vector<std::vector<std::vector<unsigned int>>>> cd_sfp;	///< A list of SFP numbers for each CD detector, sector, side and strip

--- a/settings.dat
+++ b/settings.dat
@@ -282,7 +282,7 @@
 #NumberOfCDStrips.P: 16			# number of p-side strips = 16
 #NumberOfCDStrips.N: 12			# number of n-side strips = 12 with Edinburgh/RAL preamps
 
-#CDCalibratorMaxEn: 2000e3		# max energy for CD calibrator spectra in keV; default is 2000e3 keV
+#CDCalibrator.MaxEnergy: 2000e3		# max energy for CD calibrator spectra in keV; default is 2000e3 keV
 
 #CD_0_0_0.P.Sfp: 1				# Forward CD, Sector 0, P-Strip 0
 #CD_0_0_0.P.Board: 0			#

--- a/settings.dat
+++ b/settings.dat
@@ -282,6 +282,8 @@
 #NumberOfCDStrips.P: 16			# number of p-side strips = 16
 #NumberOfCDStrips.N: 12			# number of n-side strips = 12 with Edinburgh/RAL preamps
 
+#CDCalibratorMaxEn: 2000e3		# max energy for CD calibrator spectra in keV; default is 2000e3 keV
+
 #CD_0_0_0.P.Sfp: 1				# Forward CD, Sector 0, P-Strip 0
 #CD_0_0_0.P.Board: 0			#
 #CD_0_0_0.P.Channel: 0			#

--- a/src/CDCalibrator.cc
+++ b/src/CDCalibrator.cc
@@ -147,6 +147,20 @@ void MiniballCDCalibrator::Initialise(){
 }
 
 
+int nextPowerOf2(unsigned int n) {
+    if (n == 0) return 1;
+
+    n--;
+    n |= n >> 1;
+    n |= n >> 2;
+    n |= n >> 4;
+    n |= n >> 8;
+    n |= n >> 16;
+
+    return n + 1;
+}
+
+
 void MiniballCDCalibrator::MakeHists(){
 
 	std::string hname, htitle;
@@ -160,7 +174,11 @@ void MiniballCDCalibrator::MakeHists(){
 	cd_nQ_pQ.resize( set->GetNumberOfCDDetectors() );
 
 	// Get sizes and scales
-	double maxQ = 1073741824;
+	double maxEn = set->GetCDCalibratorMaxEnergy();
+	// read FEBEX gain and offset for reference p strip in first quadrant (febex_1_0_ptag) to get an idea of raw charge range
+	double maxRawEn = ( maxEn - cal->FebexOffset(1,0,ptag) ) / cal->FebexGain(1,0,ptag);
+	// round that value to the next power of two
+	int maxQ = nextPowerOf2(std::round(maxRawEn));
 	unsigned int Qbins = 8192;
 
 	if( set->GetNumberOfCaenAdcModules() > 0 ) {
@@ -198,7 +216,7 @@ void MiniballCDCalibrator::MakeHists(){
 				htitle += ", nid " + std::to_string(ntag);
 				htitle += ";n-side energy (keV);p-side energy (keV);Counts";
 				cd_nen_pen[i][j][k] = new TH2F( hname.data(), htitle.data(),
-											   4000, 0, 2000e3, 4000, 0, 2000e3 );
+											   4000, 0, maxEn, 4000, 0, maxEn );
 				histlist->Add(cd_nen_pen[i][j][k]);
 
 				hname  = "cd_" + std::to_string(i) + "_" + std::to_string(j);
@@ -225,7 +243,7 @@ void MiniballCDCalibrator::MakeHists(){
 				htitle += ", nid " + std::to_string(k);
 				htitle += ";p-side energy (keV);n-side energy (keV);Counts";
 				cd_pen_nen[i][j][k] = new TH2F( hname.data(), htitle.data(),
-											   4000, 0, 2000e3, 4000, 0, 2000e3 );
+											   4000, 0, maxEn, 4000, 0, maxEn );
 				histlist->Add(cd_pen_nen[i][j][k]);
 
 				hname  = "cd_" + std::to_string(i) + "_" + std::to_string(j);
@@ -235,7 +253,7 @@ void MiniballCDCalibrator::MakeHists(){
 				htitle += ", nid " + std::to_string(k);
 				htitle += ";p-side energy (keV);n-side raw charge (ADC units);Counts";
 				cd_pen_nQ[i][j][k] = new TH2F( hname.data(), htitle.data(),
-											  4000, 0, 2000e3, Qbins, 0, maxQ );
+											  4000, 0, maxEn, Qbins, 0, maxQ );
 				histlist->Add(cd_pen_nQ[i][j][k]);
 
 			} // k

--- a/src/Settings.cc
+++ b/src/Settings.cc
@@ -272,7 +272,7 @@ void MiniballSettings::ReadSettings() {
 	bufferpart_reject	= config->GetValue( "BufferPartRejection", false );
 
 	// CD calibrator settings
-	cd_calibrator_max_energy = config->GetValue( "CDCalibratorMaxEn", 2000e3 );
+	cd_calibrator_max_energy = config->GetValue( "CDCalibrator.MaxEnergy", 2000e3 );
 	
 	// Electronics mapping
 	// Will depend on whether we have FEBEX or DGF/ADC combo

--- a/src/Settings.cc
+++ b/src/Settings.cc
@@ -271,6 +271,8 @@ void MiniballSettings::ReadSettings() {
 	bufferfull_reject	= config->GetValue( "BufferFullRejection", false );
 	bufferpart_reject	= config->GetValue( "BufferPartRejection", false );
 
+	// CD calibrator settings
+	cd_calibrator_max_energy = config->GetValue( "CDCalibratorMaxEn", 2000e3 );
 	
 	// Electronics mapping
 	// Will depend on whether we have FEBEX or DGF/ADC combo


### PR DESCRIPTION
Added variable to settings file so that user can define relevant energy range to use in CDCalibrator routine. If this is ok, I will modify accordingly the wiki part that lists the settings file variables.