### PR TITLE
Add detector lookup functions to the Settings class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,10 @@ bin/*
 lib/*
 
 # Plots
+srim/*.png
 srim/*.pdf
+scripts/*.png
+scripts/*.pdf
 
 # Test data
 test/*

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@
 .PHONY: clean all
 
 PWD			:= $(shell pwd)
-BIN_DIR     := ./bin
-SRC_DIR     := ./src
-LIB_DIR     := ./lib
-INC_DIR     := ./include
-UTIL_DIR    := ./utils
+BIN_DIR     := $(PWD)/bin
+SRC_DIR     := $(PWD)/src
+LIB_DIR     := $(PWD)/lib
+INC_DIR     := $(PWD)/include
+UTIL_DIR    := $(PWD)/utils
 AME_FILE	:= \"$(PWD)/data/mass_1.mas20\"
 SRIM_DIR	:= \"$(PWD)/srim/\"
 CUR_DIR		:= \"$(PWD)/\"

--- a/include/Settings.hh
+++ b/include/Settings.hh
@@ -201,6 +201,7 @@ public:
 					  const std::vector<std::vector<std::vector<int>>> &vector );
 	int GetMiniballID( unsigned int sfp, unsigned int board, unsigned int ch,
 					  const std::vector<std::vector<std::vector<int>>> &vector );
+	std::vector<int> GetMiniballDAQ( unsigned int clu, unsigned int cry, unsigned int seg );
 	inline int GetMiniballCluster( unsigned int dgf, unsigned int ch ){
 		return GetMiniballID( dgf, ch, mb_cluster );
 	};
@@ -219,6 +220,22 @@ public:
 	inline int GetMiniballSegment( unsigned int sfp, unsigned int board, unsigned int ch ){
 		return GetMiniballID( sfp, board, ch, mb_segment );
 	};
+	inline int GetMiniballSFP( unsigned int clu, unsigned int cry, unsigned int seg ){
+		return GetMiniballDAQ( clu, cry, seg ).at(0);
+	};
+	inline int GetMiniballBoard( unsigned int clu, unsigned int cry, unsigned int seg ){
+		std::vector<int> daqinfo = GetMiniballDAQ( clu, cry, seg );
+		if( daqinfo.at(0) >= 0 ) return daqinfo.at(1);
+		else return -1;
+	};
+	inline int GetMiniballDGF( unsigned int clu, unsigned int cry, unsigned int seg ){
+		std::vector<int> daqinfo = GetMiniballDAQ( clu, cry, seg );
+		if( daqinfo.at(0) < 0 ) return daqinfo.at(1);
+		else return -1;
+	};
+	inline int GetMiniballChannel( unsigned int clu, unsigned int cry, unsigned int seg ){
+		return GetMiniballDAQ( clu, cry, seg ).at(2);
+	};
 	bool IsMiniballSegmentVetoed( unsigned int clu, unsigned int cry, unsigned int seg );
 	inline double GetMiniballCrystalHitWindow(){ return mb_hit_window; };
 	inline double GetMiniballAddbackHitWindow(){ return ab_hit_window; };
@@ -236,6 +253,7 @@ public:
 				const std::vector<std::vector<std::vector<int>>> &vector );
 	int GetCDID( unsigned int sfp, unsigned int board, unsigned int ch,
 				const std::vector<std::vector<std::vector<int>>> &vector );
+	std::vector<int> GetCDDAQ( unsigned int det, unsigned int sec, unsigned int side, unsigned int strip );
 	inline int GetCDDetector( unsigned int adc, unsigned int ch ){
 		return GetCDID( adc, ch, cd_det );
 	};
@@ -260,6 +278,22 @@ public:
 	inline int GetCDStrip( unsigned int sfp, unsigned int board, unsigned int ch ){
 		return GetCDID( sfp, board, ch, cd_strip );
 	};
+	inline int GetCDSFP( unsigned int det, unsigned int sec, unsigned int side, unsigned int strip ){
+		return GetCDDAQ( det, sec, side, strip ).at(0);
+	};
+	inline int GetCDBoard(  unsigned int det, unsigned int sec, unsigned int side, unsigned int strip ){
+		std::vector<int> daqinfo = GetCDDAQ( det, sec, side, strip );
+		if( daqinfo.at(0) >= 0 ) return daqinfo.at(1);
+		else return -1;
+	};
+	inline int GetCDADC( unsigned int det, unsigned int sec, unsigned int side, unsigned int strip ){
+		std::vector<int> daqinfo = GetCDDAQ( det, sec, side, strip );
+		if( daqinfo.at(0) < 0 ) return daqinfo.at(1);
+		else return -1;
+	};
+	inline int GetCDChannel( unsigned int det, unsigned int sec, unsigned int side, unsigned int strip ){
+		return GetCDDAQ( det, sec, side, strip ).at(2);
+	};
 	inline double GetCDHitWindow(){ return cd_hit_window; };
 	inline double GetCDCalibratorMaxEnergy(){ return cd_calibrator_max_energy; };
 	
@@ -271,6 +305,23 @@ public:
 	int GetPadDetector( unsigned int sfp, unsigned int board, unsigned int ch );
 	int GetPadSector( unsigned int adc, unsigned int ch );
 	int GetPadSector( unsigned int sfp, unsigned int board, unsigned int ch );
+	std::vector<int> GetPadDAQ( unsigned int det, unsigned int sec );
+	inline int GetPadSFP( unsigned int det, unsigned int sec ){
+		return GetPadDAQ( det, sec ).at(0);
+	};
+	inline int GetPadBoard(  unsigned int det, unsigned int sec ){
+		std::vector<int> daqinfo = GetPadDAQ( det, sec );
+		if( daqinfo.at(0) >= 0 ) return daqinfo.at(1);
+		else return -1;
+	};
+	inline int GetPadADC( unsigned int det, unsigned int sec ){
+		std::vector<int> daqinfo = GetPadDAQ( det, sec );
+		if( daqinfo.at(0) < 0 ) return daqinfo.at(1);
+		else return -1;
+	};
+	inline int GetPadChannel( unsigned int det, unsigned int sec ){
+		return GetPadDAQ( det, sec ).at(2);
+	};
 	inline double GetPadHitWindow(){ return pad_hit_window; };
 	
 	
@@ -280,12 +331,41 @@ public:
 	bool IsBeamDump( unsigned int sfp, unsigned int board, unsigned int ch );
 	int GetBeamDumpDetector( unsigned int dgf, unsigned int ch );
 	int GetBeamDumpDetector( unsigned int sfp, unsigned int board, unsigned int ch );
+	std::vector<int> GetBeamDumpDAQ( unsigned int det );
+	inline int GetBeamDumpSFP( unsigned int det ){
+		return GetBeamDumpDAQ( det ).at(0);
+	};
+	inline int GetBeamDumpBoard(  unsigned int det ){
+		std::vector<int> daqinfo = GetBeamDumpDAQ( det );
+		if( daqinfo.at(0) >= 0 ) return daqinfo.at(1);
+		else return -1;
+	};
+	inline int GetBeamDumpDGF( unsigned int det ){
+		std::vector<int> daqinfo = GetBeamDumpDAQ( det );
+		if( daqinfo.at(0) < 0 ) return daqinfo.at(1);
+		else return -1;
+	};
+	inline int GetBeamDumpChannel( unsigned int det ){
+		return GetBeamDumpDAQ( det ).at(2);
+	};
 
 	
 	// SPEDE detector
 	inline unsigned int GetNumberOfSpedeSegments(){ return n_spede_seg; };
 	bool IsSpede( unsigned int sfp, unsigned int board, unsigned int ch );
 	int GetSpedeSegment( unsigned int sfp, unsigned int board, unsigned int ch );
+	std::vector<int> GetSpedeDAQ( unsigned int seg );
+	inline int GetSpedeSFP( unsigned int seg ){
+		return GetSpedeDAQ( seg ).at(0);
+	};
+	inline int GetSpedeBoard(  unsigned int seg ){
+		std::vector<int> daqinfo = GetSpedeDAQ( seg );
+		if( daqinfo.at(0) >= 0 ) return daqinfo.at(1);
+		else return -1;
+	};
+	inline int GetSpedeChannel( unsigned int seg ){
+		return GetSpedeDAQ( seg ).at(2);
+	};
 
 	
 	// IonChamber
@@ -294,6 +374,23 @@ public:
 	bool IsIonChamber( unsigned int sfp, unsigned int board, unsigned int ch );
 	int GetIonChamberLayer( unsigned int adc, unsigned int ch );
 	int GetIonChamberLayer( unsigned int sfp, unsigned int board, unsigned int ch );
+	std::vector<int> GetIonChamberDAQ( unsigned int layer );
+	inline int GetIonChamberSFP( unsigned int layer ){
+		return GetIonChamberDAQ( layer ).at(0);
+	};
+	inline int GetIonChamberBoard(  unsigned int layer ){
+		std::vector<int> daqinfo = GetIonChamberDAQ( layer );
+		if( daqinfo.at(0) >= 0 ) return daqinfo.at(1);
+		else return -1;
+	};
+	inline int GetIonChamberADC( unsigned int layer ){
+		std::vector<int> daqinfo = GetIonChamberDAQ( layer );
+		if( daqinfo.at(0) < 0 ) return daqinfo.at(1);
+		else return -1;
+	};
+	inline int GetIonChamberChannel( unsigned int layer ){
+		return GetIonChamberDAQ( layer ).at(2);
+	};
 	inline double GetIonChamberHitWindow(){ return ic_hit_window; };
 	
 	

--- a/mb_sort.cc
+++ b/mb_sort.cc
@@ -1,3 +1,17 @@
+// ============================================================================================= //
+/*! \mainpage The Miniball Sort Code
+ * **Author**: Liam Gaffney [(liam.gaffney@liverpool.ac.uk)](mailto:liam.gaffney@liverpool.ac.uk), University of Liverpool
+ *
+ * See the [GitHub page](https://github.com/Miniball/MiniballSort) for installation
+ * instructions, to submit bug reports, and to understand the sorting philosophy. The documentation
+ * here focuses on the purpose of different variables and functions. N.B. it's not complete, but
+ * should become more complete over time.
+ *
+ * For information on how to use the code and what the variables mean in the different input files,
+ * see the [wiki pages on GitHub](https://github.com/Miniball/MiniballSort/wiki).
+ */
+// ============================================================================================= //
+
 // My code include.
 #include "mb_sort.hh"
 

--- a/scripts/calculate_alpha_energies.cc
+++ b/scripts/calculate_alpha_energies.cc
@@ -4,8 +4,8 @@
 // Written by Liam Gaffney (liam.gaffney@liverpool.ac.uk) - 18/07/2025
 //
 // To run you need to do the following in ROOT:
-// root [0]: .L show_miniball_positions.cc
-// root [1]: show_miniball_positions( "reaction.dat", "settings.dat" )
+// root [0]: .L calculate_alpha_energies.cc
+// root [1]: calculate_alpha_energies( "reaction.dat", "settings.dat" )
 // where the settings and reaction files match those from your experiment
 
 R__LOAD_LIBRARY(libmb_sort.so)

--- a/scripts/simulate_alpha_spectrum_pad.cc
+++ b/scripts/simulate_alpha_spectrum_pad.cc
@@ -1,0 +1,130 @@
+// This code will take a reaction file and calculate the energies of
+// the quadruple alpha source for each ring of the CD.
+//
+// Written by Liam Gaffney (liam.gaffney@liverpool.ac.uk) - 18/07/2025
+//
+// To run you need to do the following in ROOT:
+// root [0]: .L calculate_alpha_energies.cc
+// root [1]: calculate_alpha_energies( "reaction.dat", "settings.dat" )
+// where the settings and reaction files match those from your experiment
+
+#include "../include/Settings.hh"
+#include "../include/Calibration.hh"
+#include "../include/Reaction.hh"
+#include "TRandom3.h"
+#include "TF1.h"
+#include "TH1.h"
+#include <vector>
+
+R__LOAD_LIBRARY(libmb_sort.so)
+
+// List of alpha energies
+std::vector<double> AlphaEnergy;
+
+double single_alpha( double *x, double *par ){
+
+	double gaus = TMath::Exp( -0.5 * TMath::Power( ( x[0]-par[1] ) / par[2], 2.0 ) );
+	gaus *= par[0] / ( TMath::Sqrt( TMath::TwoPi() ) * par[2] );
+	return gaus;
+
+}
+
+double spectrum_fit( double *x, double *par ){
+
+	double total = 0;
+	for( unsigned int i = 0; i < AlphaEnergy.size(); i++ )
+		total += single_alpha( x, &par[i*3] );
+
+	return total;
+
+}
+
+void simulate_alpha_spectrum_pad( std::string reactionfile = "default", std::string settingsfile = "default" ) {
+
+	// Settings file - needed for reaction file
+	std::shared_ptr<MiniballSettings> myset = std::make_shared<MiniballSettings>( settingsfile );
+	
+	// Reaction file
+	std::shared_ptr<MiniballReaction> myreact = std::make_shared<MiniballReaction>( reactionfile, myset );
+
+	// Define the alpha energies
+	AlphaEnergy.push_back( 3182.69 );	// % 148Gd
+	AlphaEnergy.push_back( 5148.31 );	// % 239Pu
+	AlphaEnergy.push_back( 5478.62 );	// % 241Am
+	AlphaEnergy.push_back( 5795.04 );	// % 244Cm
+
+	// Get distance and dead layers
+	double cd_dist = myreact->GetCDDistance(0);
+	double pad_dist = cd_dist + 10.0; // mm
+	double cd_dead = myreact->GetCDDeadLayer(0);
+	//double cd_dist = 28.5; // manual hack [mm] (doesn't work yet, see below)
+	//double cd_dead = 0.0007; // manual hack [mm] (doesn't work, see below)
+	//myreact->SetCDDistance( 0, cd_dist ); // not yet implemented in MiniballSort
+	//myreact->SetCDDeadLayer( 0, cd_dead ); // not yet implemented in MiniballSort
+
+	// Get the stopping powers
+	std::unique_ptr<TGraph> g = std::make_unique<TGraph>();
+	myreact->ReadStoppingPowers( "4He", "Si", g );
+
+	// Make a histogram
+	TH1F *hpad = new TH1F( "hpad", "alphas in pad including energy loss", 14000, 0, 7000 );
+
+	// Calculate PAD angles
+	double low_theta = TMath::ATan( 9.0 / pad_dist );
+	double upp_theta = TMath::ATan( 41.0 / pad_dist );
+
+	// Randomise over theta between 0˚ and 90˚, assuming symmetry in phi
+	double Npoints = 1e6;
+	double eres = 10.0; // keV detector resolutions
+	TRandom3 rand;
+	for( unsigned int i = 0; i < Npoints; i++ ){
+
+		// Get theta and check it's in the pad range
+		double theta = TMath::ACos( 1.0 - rand.Rndm() );
+		if( theta < low_theta || theta > upp_theta ) continue;
+
+		// Effective thickness
+		double thick = cd_dead / TMath::Abs( TMath::Cos( theta ) );
+
+		// Loop over alpha energies and get energy for each
+		for( unsigned int j = 0; j < AlphaEnergy.size(); j++ ){
+
+			// Calculate energy loss
+			double eloss = myreact->GetEnergyLoss( AlphaEnergy[j], thick, g );
+			double edet = AlphaEnergy[j] - eloss;
+
+			// Add some Gaussian broadening
+			hpad->Fill( rand.Gaus( edet, eres ) );
+
+		} // j
+
+	} // i
+
+	// Make a canvas and draw histogram
+	TCanvas *c1 = new TCanvas();
+	hpad->Draw("hist");
+
+	// Define the fit
+	TF1 *fitalphas = new TF1( "fitalphas", spectrum_fit, 0, 7000, 3*AlphaEnergy.size() );
+	for( unsigned int j = 0; j < AlphaEnergy.size(); j++ ) {
+		fitalphas->SetParameter( 3*j+0, Npoints );
+		fitalphas->SetParameter( 3*j+1, AlphaEnergy[j] );
+		fitalphas->SetParameter( 3*j+2, eres );
+	}
+
+	// Fit the histogram
+	hpad->Fit( fitalphas, "WLR" );
+	fitalphas->SetNpx(1e5);
+	fitalphas->Draw("same L");
+
+	// Print the results
+	std::cout << "Alpha Energy (keV)\tDetected Energy (keV)" << std::endl;
+	for( unsigned int j = 0; j < AlphaEnergy.size(); j++ )
+		std::cout << AlphaEnergy[j] << "\t" << fitalphas->GetParameter(j*3+1) << std::endl;
+
+	c1->Print("pad_spectrum.pdf");
+
+	return;
+	
+}
+

--- a/src/Settings.cc
+++ b/src/Settings.cc
@@ -1002,22 +1002,84 @@ int MiniballSettings::GetMiniballID( unsigned int dgf, unsigned int ch,
 }
 
 int MiniballSettings::GetMiniballID( unsigned int sfp, unsigned int board, unsigned int ch,
-							 const std::vector<std::vector<std::vector<int>>> &vector ) {
-	
+									const std::vector<std::vector<std::vector<int>>> &vector ) {
+
 	/// Return the Miniball ID by the FEBEX SFP, Board number and Channel number
 	if( sfp < n_febex_sfp && board < n_febex_board && ch < n_febex_ch )
 		return vector[sfp][board][ch];
-	
+
 	else {
-		
+
 		std::cerr << "Bad Miniball event: sfp = " << sfp;
 		std::cerr << ", board = " << board;
 		std::cerr << ", channel = " << ch << std::endl;
 		return 0;
-		
+
 	}
-	
+
 }
+
+std::vector<int> MiniballSettings::GetMiniballDAQ( unsigned int clu, unsigned int cry, unsigned int seg ) {
+
+	/// Return the DAQ information, given the Miniball cluster, crystal and segment.
+	/// \param[in] clu Cluster number from 0-7
+	/// \param[in] cry Crystal number from 0-2
+	/// \param[in] seg Segment number from 0-6, core is 0 and outer segments are 1-6
+	/// \return a vector containing the FEBEX SFP, Board and Channel numbers unless it is the
+	/// old Marabou DAQ, which returns -1 for the SFP, then the DGF module and channel numbers.
+
+	std::vector<int> daqinfo(3,-1);
+
+	// Loop over all FEBEX SFPs, boards and channels to find a match
+	for( unsigned int i = 0; i < GetNumberOfFebexSfps(); ++i ) {
+
+		for( unsigned int j = 0; j < GetNumberOfFebexBoards(); ++j ) {
+
+			for( unsigned int k = 0; k < GetNumberOfFebexChannels(); ++k ) {
+
+				// test for complete match
+				if( GetMiniballCluster(i,j,k) == (int)clu &&
+				   GetMiniballCrystal(i,j,k) == (int)cry &&
+				   GetMiniballSegment(i,j,k) == (int)seg ) {
+
+					daqinfo[0] = i;
+					daqinfo[1] = j;
+					daqinfo[2] = k;
+					return daqinfo;
+
+				} // test
+
+			} // k - channel
+
+		} // j - board
+
+	} // i - sfp
+
+	// Loop over all DGF modules and channels to find a match
+	// only here if we didn't find a match in FEBEX
+	for( unsigned int i = 0; i < GetNumberOfDgfModules(); ++i ) {
+
+		for( unsigned int j = 0; j < GetNumberOfDgfChannels(); ++j ) {
+
+			// test for complete match
+			if( GetMiniballCluster(i,j) == (int)clu &&
+			   GetMiniballCrystal(i,j) == (int)cry &&
+			   GetMiniballSegment(i,j) == (int)seg ) {
+
+				daqinfo[0] = -1;
+				daqinfo[1] = i;
+				daqinfo[2] = j;
+				return daqinfo;
+
+			} // test
+
+		} // j - channel
+
+	} // i - module
+
+	return daqinfo;
+
+};
 
 
 bool MiniballSettings::IsCD( unsigned int adc, unsigned int ch ) {
@@ -1095,6 +1157,72 @@ int MiniballSettings::GetCDID( unsigned int sfp, unsigned int board, unsigned in
 	}
 	
 }
+
+std::vector<int> MiniballSettings::GetCDDAQ( unsigned int det, unsigned int sec, unsigned int side, unsigned int strip ) {
+
+	/// Return the DAQ information, given the CD detector, sector, side and strip
+	/// \param[in] det CD detector number (0: downstream, 1: upstream)
+	/// \param[in] sec sector number 0-3 for quadrants
+	/// \param[in] side the side of the silicon (0: p-side, 1: n-side)
+	/// \param[in] strip the strip ID (e.g. 0-15: p-side, 0-23: n-side)
+	/// \return a vector containing the FEBEX SFP, Board and Channel numbers unless it is the
+	/// old Marabou DAQ, which returns -1 for the SFP, then the ADC module and channel numbers.
+
+	std::vector<int> daqinfo(3,-1);
+
+	// Loop over all FEBEX SFPs, boards and channels to find a match
+	for( unsigned int i = 0; i < GetNumberOfFebexSfps(); ++i ) {
+
+		for( unsigned int j = 0; j < GetNumberOfFebexBoards(); ++j ) {
+
+			for( unsigned int k = 0; k < GetNumberOfFebexChannels(); ++k ) {
+
+				// test for complete match
+				if( GetCDDetector(i,j,k) == (int)det &&
+				   GetCDSector(i,j,k) == (int)sec &&
+				   GetCDSide(i,j,k) == (int)side &&
+				   GetCDStrip(i,j,k) == (int)strip ) {
+
+					daqinfo[0] = i;
+					daqinfo[1] = j;
+					daqinfo[2] = k;
+					return daqinfo;
+
+				} // test
+
+			} // k - channel
+
+		} // j - board
+
+	} // i - sfp
+
+	// Loop over all ADC modules and channels to find a match
+	// only here if we didn't find a match in FEBEX
+	for( unsigned int i = 0; i < GetNumberOfAdcModules(); ++i ) {
+
+		for( unsigned int j = 0; j < GetMaximumNumberOfAdcChannels(); ++j ) {
+
+			// test for complete match
+			if( GetCDDetector(i,j) == (int)det &&
+			   GetCDSector(i,j) == (int)sec &&
+			   GetCDSide(i,j) == (int)side &&
+			   GetCDStrip(i,j) == (int)strip ) {
+
+				daqinfo[0] = -1;
+				daqinfo[1] = i;
+				daqinfo[2] = j;
+				return daqinfo;
+
+			} // test
+
+		} // j - channel
+
+	} // i - module
+
+	return daqinfo;
+
+};
+
 
 bool MiniballSettings::IsPad( unsigned int adc, unsigned int ch ) {
 	
@@ -1203,6 +1331,66 @@ int MiniballSettings::GetPadSector( unsigned int sfp, unsigned int board, unsign
 	
 }
 
+std::vector<int> MiniballSettings::GetPadDAQ( unsigned int det, unsigned int sec ) {
+
+	/// Return the DAQ information, given the Pad detector and sector
+	/// \param[in] det Pad detector number (0: downstream, 1: upstream)
+	/// \param[in] sec sector number 0-3 for quadrants
+	/// \return a vector containing the FEBEX SFP, Board and Channel numbers unless it is the
+	/// old Marabou DAQ, which returns -1 for the SFP, then the ADC module and channel numbers.
+
+	std::vector<int> daqinfo(3,-1);
+
+	// Loop over all FEBEX SFPs, boards and channels to find a match
+	for( unsigned int i = 0; i < GetNumberOfFebexSfps(); ++i ) {
+
+		for( unsigned int j = 0; j < GetNumberOfFebexBoards(); ++j ) {
+
+			for( unsigned int k = 0; k < GetNumberOfFebexChannels(); ++k ) {
+
+				// test for complete match
+				if( GetPadDetector(i,j,k) == (int)det &&
+				   GetPadSector(i,j,k) == (int)sec ) {
+
+					daqinfo[0] = i;
+					daqinfo[1] = j;
+					daqinfo[2] = k;
+					return daqinfo;
+
+				} // test
+
+			} // k - channel
+
+		} // j - board
+
+	} // i - sfp
+
+	// Loop over all ADC modules and channels to find a match
+	// only here if we didn't find a match in FEBEX
+	for( unsigned int i = 0; i < GetNumberOfAdcModules(); ++i ) {
+
+		for( unsigned int j = 0; j < GetMaximumNumberOfAdcChannels(); ++j ) {
+
+			// test for complete match
+			if( GetPadDetector(i,j) == (int)det &&
+			   GetPadSector(i,j) == (int)sec ) {
+
+				daqinfo[0] = -1;
+				daqinfo[1] = i;
+				daqinfo[2] = j;
+				return daqinfo;
+
+			} // test
+
+		} // j - channel
+
+	} // i - module
+
+	return daqinfo;
+
+};
+
+
 bool MiniballSettings::IsBeamDump( unsigned int dgf, unsigned int ch ) {
 	
 	/// Return true if this is a beam dump event
@@ -1252,6 +1440,63 @@ int MiniballSettings::GetBeamDumpDetector( unsigned int sfp, unsigned int board,
 	
 }
 
+std::vector<int> MiniballSettings::GetBeamDumpDAQ( unsigned int det ) {
+
+	/// Return the DAQ information, given the beam dump detector
+	/// \param[in] det Beam dump detector number
+	/// \return a vector containing the FEBEX SFP, Board and Channel numbers unless it is the
+	/// old Marabou DAQ, which returns -1 for the SFP, then the ADC module and channel numbers.
+
+	std::vector<int> daqinfo(3,-1);
+
+	// Loop over all FEBEX SFPs, boards and channels to find a match
+	for( unsigned int i = 0; i < GetNumberOfFebexSfps(); ++i ) {
+
+		for( unsigned int j = 0; j < GetNumberOfFebexBoards(); ++j ) {
+
+			for( unsigned int k = 0; k < GetNumberOfFebexChannels(); ++k ) {
+
+				// test for complete match
+				if( GetBeamDumpDetector(i,j,k) == (int)det ) {
+
+					daqinfo[0] = i;
+					daqinfo[1] = j;
+					daqinfo[2] = k;
+					return daqinfo;
+
+				} // test
+
+			} // k - channel
+
+		} // j - board
+
+	} // i - sfp
+
+	// Loop over all DGF modules and channels to find a match
+	// only here if we didn't find a match in FEBEX
+	for( unsigned int i = 0; i < GetNumberOfDgfModules(); ++i ) {
+
+		for( unsigned int j = 0; j < GetNumberOfDgfChannels(); ++j ) {
+
+			// test for complete match
+			if( GetBeamDumpDetector(i,j) == (int)det ) {
+
+				daqinfo[0] = -1;
+				daqinfo[1] = i;
+				daqinfo[2] = j;
+				return daqinfo;
+
+			} // test
+
+		} // j - channel
+
+	} // i - module
+
+	return daqinfo;
+
+};
+
+
 bool MiniballSettings::IsSpede( unsigned int sfp, unsigned int board, unsigned int ch ) {
 	
 	/// Return true if this is a SPEDE event
@@ -1276,6 +1521,46 @@ int MiniballSettings::GetSpedeSegment( unsigned int sfp, unsigned int board, uns
 	}
 	
 }
+
+std::vector<int> MiniballSettings::GetSpedeDAQ( unsigned int seg ) {
+
+	/// Return the DAQ information, given the Spede segment
+	/// \param[in] seg Spede segment number
+	/// \return a vector containing the FEBEX SFP, Board and Channel numbers unless it is the
+	/// old Marabou DAQ, which returns -1 for the SFP, then the ADC module and channel numbers.
+
+	std::vector<int> daqinfo(3,-1);
+
+	// Loop over all FEBEX SFPs, boards and channels to find a match
+	for( unsigned int i = 0; i < GetNumberOfFebexSfps(); ++i ) {
+
+		for( unsigned int j = 0; j < GetNumberOfFebexBoards(); ++j ) {
+
+			for( unsigned int k = 0; k < GetNumberOfFebexChannels(); ++k ) {
+
+				// test for complete match
+				if( GetSpedeSegment(i,j,k) == (int)seg ) {
+
+					daqinfo[0] = i;
+					daqinfo[1] = j;
+					daqinfo[2] = k;
+					return daqinfo;
+
+				} // test
+
+			} // k - channel
+
+		} // j - board
+
+	} // i - sfp
+
+	// SPEDE never worked with the old Marabou DAQ, so we don't search
+	// through the DGFs or ADCs to look for the mapping.
+
+	return daqinfo;
+
+};
+
 
 bool MiniballSettings::IsIonChamber( unsigned int adc, unsigned int ch ) {
 	
@@ -1325,6 +1610,63 @@ int MiniballSettings::GetIonChamberLayer( unsigned int sfp, unsigned int board, 
 	}
 	
 }
+
+std::vector<int> MiniballSettings::GetIonChamberDAQ( unsigned int layer ) {
+
+	/// Return the DAQ information, given the ionisation chamber layer ID
+	/// \param[in] layer ID of the ionisation chamber layer (0: Silicon - delta E, 1: Gas - E rest)
+	/// \return a vector containing the FEBEX SFP, Board and Channel numbers unless it is the
+	/// old Marabou DAQ, which returns -1 for the SFP, then the ADC module and channel numbers.
+
+	std::vector<int> daqinfo(3,-1);
+
+	// Loop over all FEBEX SFPs, boards and channels to find a match
+	for( unsigned int i = 0; i < GetNumberOfFebexSfps(); ++i ) {
+
+		for( unsigned int j = 0; j < GetNumberOfFebexBoards(); ++j ) {
+
+			for( unsigned int k = 0; k < GetNumberOfFebexChannels(); ++k ) {
+
+				// test for complete match
+				if( GetIonChamberLayer(i,j) == (int)layer ) {
+
+					daqinfo[0] = i;
+					daqinfo[1] = j;
+					daqinfo[2] = k;
+					return daqinfo;
+
+				} // test
+
+			} // k - channel
+
+		} // j - board
+
+	} // i - sfp
+
+	// Loop over all ADC modules and channels to find a match
+	// only here if we didn't find a match in FEBEX
+	for( unsigned int i = 0; i < GetNumberOfAdcModules(); ++i ) {
+
+		for( unsigned int j = 0; j < GetMaximumNumberOfAdcChannels(); ++j ) {
+
+			// test for complete match
+			if( GetIonChamberLayer(i,j) == (int)layer ) {
+
+				daqinfo[0] = -1;
+				daqinfo[1] = i;
+				daqinfo[2] = j;
+				return daqinfo;
+
+			} // test
+
+		} // j - channel
+
+	} // i - module
+
+	return daqinfo;
+
+};
+
 
 bool MiniballSettings::IsPulser( unsigned int sfp, unsigned int board, unsigned int ch ) {
 	


### PR DESCRIPTION
Add lookup functions to the Settings class to find the corresponding DAQ channels for a given detector element. Each detector has it's own Get<detector>DAQ function, which returns a vector of length 3. The first element is the SFP ID for the FEBEX DAQ, and if this is -1 it means that it might be found in the DGFs or ADCs instead for the case of the old DAQ. The second and third elements are the board/module and channel numbers, respectively.